### PR TITLE
add a `weight` combinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Rayon is a data-parallelism library for Rust. It is extremely
 lightweight and makes it easy to convert a sequential computation into
-a parallel one. It also guarantees data-race freedom.
+a parallel one. It also guarantees data-race freedom. (You may also
+enjoy [this blog post][blog] about Rayon, which gives more background
+and details about how it works .)
 
 Using rayon is very simple. There is one method you need to know
 about, `join`. `join` simply takes two closures and potentially runs
@@ -29,6 +31,28 @@ CPUs are already busy with other work, Rayon will instead opt to run
 them sequentially. The call to `join` is designed to have very low
 overhead in that case, so that you can safely call it even with very
 small workloads (as in the example above).
+
+### Parallel Iterators
+
+Rayon also supports an experimental API called "parallel iterators".
+These let you write iterator-like chains that execute in parallel.
+For example, to compute the sum of the squares of a sequence of
+integers, one might write:
+
+```rust
+fn sum_of_squares(input: &[i32]) -> i32 {
+    input.into_par_iter()
+         .map(|&i| i * i)
+         .sum()
+}
+```
+
+For more examples, see
+[the tests](https://github.com/nikomatsakis/rayon/blob/master/src/par_iter/test.rs)
+in
+[the `par_iter` module](https://github.com/nikomatsakis/rayon/blob/master/src/par_iter/mod.rs)
+(sorry, documentation is fairly lacking at this stage; rayon is still
+fairly experimental).
 
 ### Safety
 
@@ -273,4 +297,6 @@ fn search(path: &Path, cost_so_far: usize, best_cost: &Arc<AtomicUsize>) {
 
 Now in this case, we really WANT to see results from other threads
 interjected into our execution!
+
+[blog]: http://smallcultfollowing.com/babysteps/blog/2015/12/18/rayon-data-parallelism-in-rust/
 

--- a/src/par_iter/collect.rs
+++ b/src/par_iter/collect.rs
@@ -10,7 +10,7 @@ pub fn collect_into<PAR_ITER,T>(pi: PAR_ITER, v: &mut Vec<T>)
           T: Send,
 {
     let (shared, mut state) = pi.state();
-    let len = state.len();
+    let len = state.len(&shared);
 
     v.truncate(0); // clear any old data
     v.reserve(len.maximal_len); // reserve enough space

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -61,8 +61,8 @@ impl<M, MAP_OP, R> ParallelIteratorState for MapState<M, MAP_OP>
     type Item = R;
     type Shared = MapShared<M, MAP_OP>;
 
-    fn len(&mut self) -> ParallelLen {
-        self.base.len()
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
+        self.base.len(&shared.base)
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -36,54 +36,103 @@ pub trait ParallelIterator {
 
     fn state(self) -> (Self::Shared, Self::State);
 
+    /// Indicates the relative "weight" of producing each item in this
+    /// parallel iterator. 1.0 indicates something very cheap, like
+    /// copying a value out of an array, or computing `x + 1`. Tuning
+    /// this value can affect how many subtasks are created and can
+    /// improve performance.
     fn weight(self, scale: f64) -> Weight<Self>
         where Self: Sized
     {
         Weight::new(self, scale)
     }
 
+    /// Applies `map_op` to each item of his iterator, producing a new
+    /// iterator with the results.
     fn map<MAP_OP,R>(self, map_op: MAP_OP) -> Map<Self, MAP_OP>
         where MAP_OP: Fn(Self::Item) -> R, Self: Sized
     {
         Map::new(self, map_op)
     }
 
+    /// Collects the results of the iterator into the specified
+    /// vector. The vector is always truncated before execution
+    /// begins. If possible, reusing the vector across calls can lead
+    /// to better performance since it reuses the same backing buffer.
     fn collect_into(self, target: &mut Vec<Self::Item>)
         where Self: Sized
     {
         collect_into(self, target);
     }
 
+    /// Reduces the items in the iterator into one item using `op`.
+    /// See also `sum`, `mul`, `min`, etc, which are slightly more
+    /// efficient. Returns `None` if the iterator is empty.
+    ///
+    /// Note: unlike in a sequential iterator, the order in which `op`
+    /// will be applied to reduce the result is not specified. So `op`
+    /// should be commutative and associative or else the results will
+    /// be non-deterministic.
     fn reduce_with<OP>(self, op: OP) -> Option<Self::Item>
         where Self: Sized, OP: Fn(Self::Item, Self::Item) -> Self::Item + Sync,
     {
         reduce(self.map(Some), &ReduceWithOp::new(op))
     }
 
+    /// Sums up the items in the iterator.
+    ///
+    /// Note that the order in items will be reduced is not specified,
+    /// so if the `+` operator is not truly commutative and
+    /// associative (as is the case for floating point numbers), then
+    /// the results are not fully deterministic.
     fn sum(self) -> Self::Item
         where Self: Sized, SumOp: ReduceOp<Self::Item>
     {
         reduce(self, SUM)
     }
 
+    /// Multiplies all the items in the iterator.
+    ///
+    /// Note that the order in items will be reduced is not specified,
+    /// so if the `*` operator is not truly commutative and
+    /// associative (as is the case for floating point numbers), then
+    /// the results are not fully deterministic.
     fn mul(self) -> Self::Item
         where Self: Sized, MulOp: ReduceOp<Self::Item>
     {
         reduce(self, MUL)
     }
 
+    /// Computes the minimum of all the items in the iterator.
+    ///
+    /// Note that the order in items will be reduced is not specified,
+    /// so if the `Ord` impl is not truly commutative and associative
+    /// (as is the case for floating point numbers), then the results
+    /// are not deterministic.
     fn min(self) -> Self::Item
         where Self: Sized, MinOp: ReduceOp<Self::Item>
     {
         reduce(self, MIN)
     }
 
+    /// Computes the maximum of all the items in the iterator.
+    ///
+    /// Note that the order in items will be reduced is not specified,
+    /// so if the `Ord` impl is not truly commutative and associative
+    /// (as is the case for floating point numbers), then the results
+    /// are not deterministic.
     fn max(self) -> Self::Item
         where Self: Sized, MaxOp: ReduceOp<Self::Item>
     {
         reduce(self, MAX)
     }
 
+    /// Reduces the items using the given "reduce operator". You may
+    /// prefer `reduce_with` for a simpler interface.
+    ///
+    /// Note that the order in items will be reduced is not specified,
+    /// so if the `reduce_op` impl is not truly commutative and
+    /// associative, then the results are not deterministic.
     fn reduce<REDUCE_OP>(self, reduce_op: &REDUCE_OP) -> Self::Item
         where Self: Sized, REDUCE_OP: ReduceOp<Self::Item>
     {

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -15,11 +15,15 @@ use super::{ParallelIterator, ParallelIteratorState, ParallelLen, THRESHOLD};
 /// specified. For example, the input `[ 0 1 2 ]` might be reduced in a
 /// sequential fashion:
 ///
-///     reduce(reduce(reduce(S, 0), 1), 2)
+/// ```ignore
+/// reduce(reduce(reduce(S, 0), 1), 2)
+/// ```
 ///
 /// or it might be reduced in a tree-like way:
 ///
-///     reduce(reduce(0, 1), reduce(S, 2))
+/// ```ignore
+/// reduce(reduce(0, 1), reduce(S, 2))
+/// ```
 ///
 /// etc.
 pub trait ReduceOp<T>: Sync {

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -2,6 +2,26 @@ use api::join;
 use std;
 use super::{ParallelIterator, ParallelIteratorState, ParallelLen, THRESHOLD};
 
+/// Specifies a "reduce operator". This is the combination of a start
+/// value and a reduce function. The reduce function takes two items
+/// and computes a reduced version. The start value `S` is a kind of
+/// "zero" or "identity" value that may be intermingled as needed;
+/// idealy, `reduce(S, X)` for any item `X` yields `X`.
+///
+/// Example: to sum up the values, use a `start_value` of `0` and a
+/// reduce function of `reduce(a, b) = a + b`.
+///
+/// The order in which the reduce function will be applied is not
+/// specified. For example, the input `[ 0 1 2 ]` might be reduced in a
+/// sequential fashion:
+///
+///     reduce(reduce(reduce(S, 0), 1), 2)
+///
+/// or it might be reduced in a tree-like way:
+///
+///     reduce(reduce(0, 1), reduce(S, 2))
+///
+/// etc.
 pub trait ReduceOp<T>: Sync {
     fn start_value(&self) -> T;
     fn reduce(&self, value1: T, value2: T) -> T;

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -14,7 +14,7 @@ pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: &REDUCE_OP) -> T
           T: Send,
 {
     let (shared, mut state) = pi.state();
-    let len = state.len();
+    let len = state.len(&shared);
     reduce_helper(state, &shared, len, reduce_op)
 }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -27,7 +27,7 @@ impl<'map, T: Sync> ParallelIteratorState for SliceIter<'map, T> {
     type Item = &'map T;
     type Shared = ();
 
-    fn len(&mut self) -> ParallelLen {
+    fn len(&mut self, _shared: &Self::Shared) -> ParallelLen {
         ParallelLen {
             maximal_len: self.slice.len(),
             cost: self.slice.len() as f64,

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -34,3 +34,16 @@ pub fn map_reduce_with() {
               .fold(0, |a,b| a+b);
     assert_eq!(r1.unwrap(), r2);
 }
+
+#[test]
+pub fn map_reduce_weighted() {
+    let a: Vec<i32> = (0..1024).collect();
+    let r1 = a.into_par_iter()
+              .map(|&i| i + 1)
+              .weight(2.0)
+              .reduce_with(|i, j| i + j);
+    let r2 = a.iter()
+              .map(|&i| i + 1)
+              .fold(0, |a,b| a+b);
+    assert_eq!(r1.unwrap(), r2);
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -47,3 +47,22 @@ pub fn map_reduce_weighted() {
               .fold(0, |a,b| a+b);
     assert_eq!(r1.unwrap(), r2);
 }
+
+#[test]
+pub fn check_weight() {
+    let a: Vec<i32> = (0..1024).collect();
+
+    let len1 = {
+        let (shared, mut state) = a.into_par_iter().state();
+        state.len(&shared)
+    };
+
+    let len2 = {
+        let (shared, mut state) = a.into_par_iter()
+                               .weight(2.0)
+                               .state();
+        state.len(&shared)
+    };
+
+    assert_eq!(len1.cost * 2.0, len2.cost);
+}

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,0 +1,63 @@
+use super::{ParallelIterator, ParallelIteratorState, ParallelLen};
+
+pub struct Weight<M> {
+    base: M,
+    weight: f64,
+}
+
+impl<M> Weight<M> {
+    pub fn new(base: M, weight: f64) -> Weight<M> {
+        Weight { base: base, weight: weight }
+    }
+}
+
+impl<M> ParallelIterator for Weight<M>
+    where M: ParallelIterator,
+{
+    type Item = M::Item;
+    type Shared = WeightShared<M>;
+    type State = WeightState<M>;
+
+    fn state(self) -> (Self::Shared, Self::State) {
+        let (base_shared, base_state) = self.base.state();
+        (WeightShared { base: base_shared, weight: self.weight },
+         WeightState { base: base_state })
+    }
+}
+
+pub struct WeightState<M>
+    where M: ParallelIterator
+{
+    base: M::State,
+}
+
+pub struct WeightShared<M>
+    where M: ParallelIterator
+{
+    base: M::Shared,
+    weight: f64,
+}
+
+impl<M> ParallelIteratorState for WeightState<M>
+    where M: ParallelIterator,
+{
+    type Item = M::Item;
+    type Shared = WeightShared<M>;
+
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
+        let mut l = self.base.len(&shared.base);
+        l.cost *= shared.weight;
+        l
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (WeightState { base: left }, WeightState { base: right })
+    }
+
+    fn for_each<F>(self, shared: &Self::Shared, op: F)
+        where F: FnMut(Self::Item)
+    {
+        self.base.for_each(&shared.base, op)
+    }
+}


### PR DESCRIPTION
This adds a method `weight` that can be used to specify the relative weight of an operation. 1.0 means "very cheap". As expressed in the thread on #7, I would like to find a more elegant solution to this problem, but this seems like a simple thing to add for now.

Fixes #7.
