### PR TITLE
Add an `enumerate` combinator

### DIFF
--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,0 +1,65 @@
+use super::{ParallelIterator, ParallelIteratorState, ParallelLen};
+
+pub struct Enumerate<M> {
+    base: M,
+}
+
+impl<M> Enumerate<M> {
+    pub fn new(base: M) -> Enumerate<M> {
+        Enumerate { base: base }
+    }
+}
+
+impl<M> ParallelIterator for Enumerate<M>
+    where M: ParallelIterator,
+{
+    type Item = (usize, M::Item);
+    type Shared = EnumerateShared<M>;
+    type State = EnumerateState<M>;
+
+    fn state(self) -> (Self::Shared, Self::State) {
+        let (base_shared, base_state) = self.base.state();
+        (EnumerateShared { base: base_shared },
+         EnumerateState { base: base_state, offset: 0 })
+    }
+}
+
+pub struct EnumerateState<M>
+    where M: ParallelIterator
+{
+    base: M::State,
+    offset: usize,
+}
+
+pub struct EnumerateShared<M>
+    where M: ParallelIterator
+{
+    base: M::Shared,
+}
+
+impl<M> ParallelIteratorState for EnumerateState<M>
+    where M: ParallelIterator,
+{
+    type Item = (usize, M::Item);
+    type Shared = EnumerateShared<M>;
+
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
+        self.base.len(&shared.base)
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (EnumerateState { base: left, offset: self.offset },
+         EnumerateState { base: right, offset: self.offset + index })
+    }
+
+    fn for_each<F>(self, shared: &Self::Shared, mut op: F)
+        where F: FnMut(Self::Item)
+    {
+        let mut count = self.offset;
+        self.base.for_each(&shared.base, |item| {
+            op((count, item));
+            count += 1;
+        });
+    }
+}

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -4,6 +4,7 @@ use std::ops::Fn;
 use self::reduce::{SumOp, MulOp, MinOp, MaxOp, ReduceWithOp};
 
 mod collect;
+mod enumerate;
 mod len;
 mod reduce;
 mod slice;
@@ -14,6 +15,7 @@ mod weight;
 mod test;
 
 pub use self::collect::collect_into;
+pub use self::enumerate::Enumerate;
 pub use self::len::ParallelLen;
 pub use self::len::THRESHOLD;
 pub use self::map::Map;
@@ -45,6 +47,13 @@ pub trait ParallelIterator {
         where Self: Sized
     {
         Weight::new(self, scale)
+    }
+
+    /// Yields an index along with each item.
+    fn enumerate(self) -> Enumerate<Self>
+        where Self: Sized
+    {
+        Enumerate::new(self)
     }
 
     /// Applies `map_op` to each item of his iterator, producing a new

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -66,3 +66,15 @@ pub fn check_weight() {
 
     assert_eq!(len1.cost * 2.0, len2.cost);
 }
+
+#[test]
+pub fn check_enumerate() {
+    let a: Vec<usize> = (0..1024).rev().collect();
+
+    let mut b = vec![];
+    a.into_par_iter()
+     .enumerate()
+     .map(|(i, &x)| i + x)
+     .collect_into(&mut b);
+    assert!(b.iter().all(|&x| x == a.len() - 1));
+}


### PR DESCRIPTION
Returns the index into the original sequence along with each item.
Works like `Iterator::enumerate()`, but of course with threaded jobs it
won't be visited in any guaranteed order.  It has to assume that the
size of each split is known exactly though, so this wouldn't work after
a filtering function, for instance.