### PR TITLE
Par iter and par iter mut

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ integers, please see the [notes on atomicity](#atomicity).
 **WARNING:** Rayon is still in **experimental** status. It is probably
 not very robust and not (yet) suitable for production applications.
 In particular, the handling of panics is known to be terrible.  See
-nikomatsakis/rayon#10 for more details.
+[nikomatsakis/rayon#10](https://github.com/nikomatsakis/rayon/issues/10)
+for more details.
 
 ### Parallel Iterators
 

--- a/src/par_iter/collect.rs
+++ b/src/par_iter/collect.rs
@@ -1,5 +1,7 @@
 use api::join;
-use super::{ParallelIterator, ParallelIteratorState, ParallelLen, THRESHOLD};
+use super::ParallelIterator;
+use super::len::{ParallelLen, THRESHOLD};
+use super::state::ParallelIteratorState;
 use std::isize;
 use std::mem;
 use std::ptr;

--- a/src/par_iter/collect.rs
+++ b/src/par_iter/collect.rs
@@ -28,7 +28,7 @@ pub fn collect_into<PAR_ITER,T>(pi: PAR_ITER, v: &mut Vec<T>)
     }
 }
 
-unsafe fn collect_into_helper<STATE,T>(state: STATE,
+unsafe fn collect_into_helper<STATE,T>(mut state: STATE,
                                        shared: &STATE::Shared,
                                        len: ParallelLen,
                                        target: CollectTarget<T>)
@@ -42,10 +42,10 @@ unsafe fn collect_into_helper<STATE,T>(state: STATE,
              || collect_into_helper(right, shared, len.right_cost(mid), right_target));
     } else {
         let mut p = DropInitialized::new(target.as_mut_ptr());
-        state.for_each(shared, |item| {
+        while let Some(item) = state.next(shared) {
             ptr::write(p.next, item);
             p.bump();
-        });
+        }
         mem::forget(p); // fully initialized, so don't run the destructor
     }
 }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -55,13 +55,12 @@ unsafe impl<M> ParallelIteratorState for EnumerateState<M>
          EnumerateState { base: right, offset: self.offset + index })
     }
 
-    fn for_each<F>(self, shared: &Self::Shared, mut op: F)
-        where F: FnMut(Self::Item)
-    {
-        let mut count = self.offset;
-        self.base.for_each(&shared.base, |item| {
-            op((count, item));
-            count += 1;
-        });
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
+        self.base.next(&shared.base)
+                 .map(|base| {
+                     let index = self.offset;
+                     self.offset += 1;
+                     (index, base)
+                 })
     }
 }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,4 +1,6 @@
-use super::{ParallelIterator, ParallelIteratorState, ParallelLen};
+use super::ParallelIterator;
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
 
 pub struct Enumerate<M> {
     base: M,

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -1,0 +1,34 @@
+use api::join;
+use super::ParallelIterator;
+use super::len::{ParallelLen, THRESHOLD};
+use super::state::ParallelIteratorState;
+
+pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
+    where PAR_ITER: ParallelIterator<Item=T>,
+          PAR_ITER::State: Send,
+          OP: Fn(T) + Sync,
+          T: Send,
+{
+    let (shared, mut state) = pi.state();
+    let len = state.len(&shared);
+    for_each_helper(state, &shared, len, op)
+}
+
+fn for_each_helper<STATE,OP,T>(state: STATE,
+                               shared: &STATE::Shared,
+                               len: ParallelLen,
+                               op: &OP)
+    where STATE: ParallelIteratorState<Item=T> + Send,
+          OP: Fn(T) + Sync,
+          T: Send,
+{
+    if len.cost > THRESHOLD && len.maximal_len > 1 {
+        let mid = len.maximal_len / 2;
+        let (left, right) = state.split_at(mid);
+        join(|| for_each_helper(left, shared, len.left_cost(mid), op),
+             || for_each_helper(right, shared, len.right_cost(mid), op));
+    } else {
+        state.for_each(shared, |item| op(item));
+    }
+}
+

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -14,7 +14,7 @@ pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
     for_each_helper(state, &shared, len, op)
 }
 
-fn for_each_helper<STATE,OP,T>(state: STATE,
+fn for_each_helper<STATE,OP,T>(mut state: STATE,
                                shared: &STATE::Shared,
                                len: ParallelLen,
                                op: &OP)
@@ -28,7 +28,9 @@ fn for_each_helper<STATE,OP,T>(state: STATE,
         join(|| for_each_helper(left, shared, len.left_cost(mid), op),
              || for_each_helper(right, shared, len.right_cost(mid), op));
     } else {
-        state.for_each(shared, |item| op(item));
+        while let Some(item) = state.next(shared) {
+            op(item);
+        }
     }
 }
 

--- a/src/par_iter/len.rs
+++ b/src/par_iter/len.rs
@@ -32,4 +32,5 @@ impl ParallelLen {
 }
 
 // The threshold cost where it is worth falling back to sequential.
+// This may be tweaked over time!
 pub const THRESHOLD: f64 = 10. * 1024.0;

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -1,4 +1,6 @@
-use super::{ParallelIterator, ParallelIteratorState, ParallelLen};
+use super::ParallelIterator;
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
 use std::marker::PhantomData;
 
 pub struct Map<M, MAP_OP> {

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -72,11 +72,8 @@ unsafe impl<M, MAP_OP, R> ParallelIteratorState for MapState<M, MAP_OP>
          MapState { base: right, map_op: PhantomMapOp::new() })
     }
 
-    fn for_each<F>(self, shared: &Self::Shared, mut op: F)
-        where F: FnMut(R)
-    {
-        self.base.for_each(&shared.base, |item| {
-            op((shared.map_op)(item));
-        });
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
+        self.base.next(&shared.base)
+                 .map(|base| (shared.map_op)(base))
     }
 }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -37,6 +37,13 @@ pub trait IntoParallelIterator {
     fn into_par_iter(self) -> Self::Iter;
 }
 
+pub trait IntoParallelRefIterator<'r> {
+    type Iter: ParallelIterator<Item=&'r Self::Item>;
+    type Item: Sync + 'r;
+
+    fn par_iter(&'r self) -> Self::Iter;
+}
+
 /// The `ParallelIterator` interface.
 pub trait ParallelIterator {
     type Item: Send;

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -9,6 +9,7 @@
 //! The submodules of this module mostly just contain implementaton
 //! details of little interest to an end-user.
 
+use std::f64;
 use std::ops::Fn;
 use self::collect::collect_into;
 use self::enumerate::Enumerate;
@@ -66,14 +67,25 @@ pub trait ParallelIterator {
     /// parallel subtasks. 1.0 indicates something very cheap and
     /// uniform, like copying a value out of an array, or computing `x
     /// + 1`. If your tasks are either very expensive, or very
-    /// unpredictable, you are better off with higher values. Using
-    /// `f64::INFINITY` will cause the finest grained parallel
-    /// subtasks possible. Tuning this value should not affect
-    /// correctness but can improve (or hurt) performance.
+    /// unpredictable, you are better off with higher values. See also
+    /// `weight_max`, which is a convenient shorthand to force the
+    /// finest grained parallel execution posible. Tuning this value
+    /// should not affect correctness but can improve (or hurt)
+    /// performance.
     fn weight(self, scale: f64) -> Weight<Self>
         where Self: Sized
     {
         Weight::new(self, scale)
+    }
+
+    /// Shorthand for `self.weight(f64::INFINITY)`. This forces the
+    /// smallest granularity of parallel execution, which makes sense
+    /// when your parallel tasks are (potentially) very expensive to
+    /// execute.
+    fn weight_max(self) -> Weight<Self>
+        where Self: Sized
+    {
+        self.weight(f64::INFINITY)
     }
 
     /// Yields an index along with each item.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -18,6 +18,7 @@ use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    SUM, MUL, MIN, MAX};
 use self::state::ParallelIteratorState;
 use self::weight::Weight;
+use self::zip::ZipIter;
 
 pub mod collect;
 pub mod enumerate;
@@ -29,6 +30,7 @@ pub mod slice_mut;
 pub mod state;
 pub mod map;
 pub mod weight;
+pub mod zip;
 
 #[cfg(test)]
 mod test;
@@ -192,6 +194,17 @@ pub trait ParallelIterator {
         where Self: Sized, REDUCE_OP: ReduceOp<Self::Item>
     {
         reduce(self, reduce_op)
+    }
+
+    /// Iterate over tuples `(A, B)`, where the items `A` are from
+    /// this iterator and `B` are from the iterator given as argument.
+    /// Like the `zip` method on ordinary iterators, if the two
+    /// iterators are of unequal length, you only get the items they
+    /// have in common.
+    fn zip<ZIP_OP>(self, zip_op: ZIP_OP) -> ZipIter<Self, ZIP_OP::Iter>
+        where Self: Sized, ZIP_OP: IntoParallelIterator
+    {
+        ZipIter::new(self, zip_op.into_par_iter())
     }
 }
 

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -44,7 +44,7 @@ pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: &REDUCE_OP) -> T
     reduce_helper(state, &shared, len, reduce_op)
 }
 
-fn reduce_helper<STATE,REDUCE_OP,T>(state: STATE,
+fn reduce_helper<STATE,REDUCE_OP,T>(mut state: STATE,
                                     shared: &STATE::Shared,
                                     len: ParallelLen,
                                     reduce_op: &REDUCE_OP)
@@ -62,9 +62,9 @@ fn reduce_helper<STATE,REDUCE_OP,T>(state: STATE,
         reduce_op.reduce(left_val, right_val)
     } else {
         let mut value = Some(reduce_op.start_value());
-        state.for_each(shared, |item| {
+        while let Some(item) = state.next(shared) {
             value = Some(reduce_op.reduce(value.take().unwrap(), item));
-        });
+        }
         value.unwrap()
     }
 }

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -1,6 +1,8 @@
 use api::join;
 use std;
-use super::{ParallelIterator, ParallelIteratorState, ParallelLen, THRESHOLD};
+use super::ParallelIterator;
+use super::len::{ParallelLen, THRESHOLD};
+use super::state::ParallelIteratorState;
 
 /// Specifies a "reduce operator". This is the combination of a start
 /// value and a reduce function. The reduce function takes two items

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -1,4 +1,6 @@
-use super::{IntoParallelIterator, ParallelIterator, ParallelIteratorState, ParallelLen};
+use super::{ParallelIterator, IntoParallelIterator};
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
 
 pub struct SliceIter<'map, T: 'map + Sync> {
     slice: &'map [T]

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -51,11 +51,11 @@ unsafe impl<'r, T: Sync> ParallelIteratorState for SliceIter<'r, T> {
         (left.into_par_iter(), right.into_par_iter())
     }
 
-    fn for_each<OP>(self, _shared: &Self::Shared, mut op: OP)
-        where OP: FnMut(&'r T)
-    {
-        for item in self.slice {
-            op(item);
-        }
+    fn next(&mut self, _shared: &Self::Shared) -> Option<&'r T> {
+        self.slice.split_first()
+                  .map(|(head, tail)| {
+                      self.slice = tail;
+                      head
+                  })
     }
 }

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -1,0 +1,61 @@
+use super::{ParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator};
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
+
+pub struct SliceIterMut<'r, T: 'r + Send> {
+    slice: &'r mut [T]
+}
+
+impl<'r, T: Send> IntoParallelIterator for &'r mut [T] {
+    type Item = &'r mut T;
+    type Iter = SliceIterMut<'r, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        SliceIterMut { slice: self }
+    }
+}
+
+impl<'r, T: Send + 'r> IntoParallelRefMutIterator<'r> for [T] {
+    type Item = T;
+    type Iter = SliceIterMut<'r, T>;
+
+    fn par_iter_mut(&'r mut self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}
+
+impl<'r, T: Send> ParallelIterator for SliceIterMut<'r, T> {
+    type Item = &'r mut T;
+    type Shared = ();
+    type State = Self;
+
+    fn state(self) -> (Self::Shared, Self::State) {
+        ((), self)
+    }
+}
+
+unsafe impl<'r, T: Send> ParallelIteratorState for SliceIterMut<'r, T> {
+    type Item = &'r mut T;
+    type Shared = ();
+
+    fn len(&mut self, _shared: &Self::Shared) -> ParallelLen {
+        ParallelLen {
+            maximal_len: self.slice.len(),
+            cost: self.slice.len() as f64,
+            sparse: false,
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.slice.split_at_mut(index);
+        (left.into_par_iter(), right.into_par_iter())
+    }
+
+    fn for_each<OP>(self, _shared: &Self::Shared, mut op: OP)
+        where OP: FnMut(&'r mut T)
+    {
+        for item in self.slice {
+            op(item);
+        }
+    }
+}

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -20,10 +20,20 @@ pub unsafe trait ParallelIteratorState: Sized {
     type Item;
     type Shared: Sync;
 
+    /// Returns an estimate of how much work is to be done.
+    ///
+    /// # Safety note
+    ///
+    /// If sparse is false, then `maximal_len` must be precisely
+    /// correct.
     fn len(&mut self, shared: &Self::Shared) -> ParallelLen;
 
+    /// Split this state into two other states, ideally of roughly
+    /// equal size.
     fn split_at(self, index: usize) -> (Self, Self);
 
-    fn for_each<OP>(self, shared: &Self::Shared, op: OP)
-        where OP: FnMut(Self::Item);
+    /// Extract the next item from this iterator state. Once this
+    /// method is called, sequential iteration has begun, and the
+    /// other methods will no longer be called.
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item>;
 }

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -1,0 +1,29 @@
+use super::len::ParallelLen;
+
+/// The trait for types representing the internal *state* during
+/// parallelization. This basically represents a group of tasks
+/// to be done.
+///
+/// Note that this trait is declared as an **unsafe trait**. That
+/// means that the trait is unsafe to implement. The reason is that
+/// other bits of code, such as the `collect` routine on
+/// `ParallelIterator`, rely on the `len` and `for_each` functions
+/// being accurate and correct. For example, if the `len` function
+/// reports that it will produce N items, then `for_each` *must*
+/// produce `N` items or else the resulting vector will contain
+/// uninitialized memory.
+///
+/// This trait is not really intended to be implemented outside of the
+/// Rayon crate at this time. The precise safety requirements are kind
+/// of ill-documented for this reason (i.e., they are ill-understood).
+pub unsafe trait ParallelIteratorState: Sized {
+    type Item;
+    type Shared: Sync;
+
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen;
+
+    fn split_at(self, index: usize) -> (Self, Self);
+
+    fn for_each<OP>(self, shared: &Self::Shared, op: OP)
+        where OP: FnMut(Self::Item);
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::state::ParallelIteratorState;
 
 #[test]
 pub fn execute() {

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -79,3 +79,14 @@ pub fn check_enumerate() {
      .collect_into(&mut b);
     assert!(b.iter().all(|&x| x == a.len() - 1));
 }
+
+#[test]
+pub fn check_increment() {
+    let mut a: Vec<usize> = (0..1024).rev().collect();
+
+    a.par_iter_mut()
+     .enumerate()
+     .for_each(|(i, v)| *v += i);
+
+    assert!(a.iter().all(|&x| x == a.len() - 1));
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -90,3 +90,15 @@ pub fn check_increment() {
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
 }
+
+#[test]
+pub fn check_zip() {
+    let mut a: Vec<usize> = (0..1024).rev().collect();
+    let b: Vec<usize> = (0..1024).collect();
+
+    a.par_iter_mut()
+     .zip(&b[..])
+     .for_each(|(a, &b)| *a += b);
+
+    assert!(a.iter().all(|&x| x == a.len() - 1));
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -5,7 +5,7 @@ use super::state::ParallelIteratorState;
 pub fn execute() {
     let a: Vec<i32> = (0..1024).collect();
     let mut b = vec![];
-    a.into_par_iter()
+    a.par_iter()
      .map(|&i| i + 1)
      .collect_into(&mut b);
     let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
@@ -15,7 +15,7 @@ pub fn execute() {
 #[test]
 pub fn map_reduce() {
     let a: Vec<i32> = (0..1024).collect();
-    let r1 = a.into_par_iter()
+    let r1 = a.par_iter()
               .map(|&i| i + 1)
               .sum();
     let r2 = a.iter()
@@ -27,7 +27,7 @@ pub fn map_reduce() {
 #[test]
 pub fn map_reduce_with() {
     let a: Vec<i32> = (0..1024).collect();
-    let r1 = a.into_par_iter()
+    let r1 = a.par_iter()
               .map(|&i| i + 1)
               .reduce_with(|i, j| i + j);
     let r2 = a.iter()
@@ -39,7 +39,7 @@ pub fn map_reduce_with() {
 #[test]
 pub fn map_reduce_weighted() {
     let a: Vec<i32> = (0..1024).collect();
-    let r1 = a.into_par_iter()
+    let r1 = a.par_iter()
               .map(|&i| i + 1)
               .weight(2.0)
               .reduce_with(|i, j| i + j);
@@ -54,12 +54,12 @@ pub fn check_weight() {
     let a: Vec<i32> = (0..1024).collect();
 
     let len1 = {
-        let (shared, mut state) = a.into_par_iter().state();
+        let (shared, mut state) = a.par_iter().state();
         state.len(&shared)
     };
 
     let len2 = {
-        let (shared, mut state) = a.into_par_iter()
+        let (shared, mut state) = a.par_iter()
                                .weight(2.0)
                                .state();
         state.len(&shared)
@@ -73,7 +73,7 @@ pub fn check_enumerate() {
     let a: Vec<usize> = (0..1024).rev().collect();
 
     let mut b = vec![];
-    a.into_par_iter()
+    a.par_iter()
      .enumerate()
      .map(|(i, &x)| i + x)
      .collect_into(&mut b);

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,4 +1,6 @@
-use super::{ParallelIterator, ParallelIteratorState, ParallelLen};
+use super::ParallelIterator;
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
 
 pub struct Weight<M> {
     base: M,

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -57,9 +57,7 @@ unsafe impl<M> ParallelIteratorState for WeightState<M>
         (WeightState { base: left }, WeightState { base: right })
     }
 
-    fn for_each<F>(self, shared: &Self::Shared, op: F)
-        where F: FnMut(Self::Item)
-    {
-        self.base.for_each(&shared.base, op)
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
+        self.base.next(&shared.base)
     }
 }

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,0 +1,81 @@
+use super::ParallelIterator;
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
+use std::cmp::min;
+
+pub struct ZipIter<A: ParallelIterator, B: ParallelIterator> {
+    a: A,
+    b: B,
+}
+
+impl<A: ParallelIterator, B: ParallelIterator> ZipIter<A, B> {
+    pub fn new(a: A, b: B) -> ZipIter<A, B> {
+        ZipIter { a: a, b: b }
+    }
+}
+
+impl<A, B> ParallelIterator for ZipIter<A, B>
+    where A: ParallelIterator, B: ParallelIterator
+{
+    type Item = (A::Item, B::Item);
+    type Shared = ZipShared<A,B>;
+    type State = ZipState<A,B>;
+
+    fn state(self) -> (Self::Shared, Self::State) {
+        let (a_shared, a_state) = self.a.state();
+        let (b_shared, b_state) = self.b.state();
+        (ZipShared { a: a_shared, b: b_shared }, ZipState { a: a_state, b: b_state })
+    }
+}
+
+pub struct ZipShared<A: ParallelIterator, B: ParallelIterator> {
+    a: A::Shared,
+    b: B::Shared,
+}
+
+pub struct ZipState<A: ParallelIterator, B: ParallelIterator> {
+    a: A::State,
+    b: B::State,
+}
+
+unsafe impl<A, B> ParallelIteratorState for ZipState<A,B>
+    where A: ParallelIterator, B: ParallelIterator
+{
+    type Item = (A::Item, B::Item);
+    type Shared = ZipShared<A, B>;
+
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
+        let a_len = self.a.len(&shared.a);
+        let b_len = self.b.len(&shared.b);
+
+        // At the moment, we don't have any sparse iterators.  When we
+        // add them, we should ensure that zip (like enumerate) can't
+        // be used with them, because it's not possible to support the
+        // split-at method.
+        assert!(!a_len.sparse);
+        assert!(!b_len.sparse);
+
+        ParallelLen {
+            maximal_len: min(a_len.maximal_len, b_len.maximal_len),
+            cost: a_len.cost + b_len.cost,
+            sparse: false,
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (a_left, a_right) = self.a.split_at(index);
+        let (b_left, b_right) = self.b.split_at(index);
+        (ZipState { a: a_left, b: b_left }, ZipState { a: a_right, b: b_right })
+    }
+
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
+        let a_next = self.a.next(&shared.a);
+        let b_next = self.b.next(&shared.b);
+        if let Some(a_item) = a_next {
+            if let Some(b_item) = b_next {
+                return Some((a_item, b_item));
+            }
+        }
+        None
+    }
+}


### PR DESCRIPTION
This branch rearranges the `par_iter` module somewhat and closes various relatively simple issues. In terms of how `par_iter` is used, it adds various traits, and the new recommend pattern is as follows:

```rust
use rayon::par_iter::*; // get all the relevant traits
```

and then you can write `vec.par_iter()` and `vec.par_iter_mut()` and that sort of thing as normal. Note that calling `into_par_iter` directly is not recommended, as I plan to implement it for `Vec<T>` eventually, which would cause your code to start moving out of the vector rather than iterating over references.

Other changes:

- add `for_each`
- change how `ParallelIteratorState` works to be external-iterator-like
- add `zip`
- add `weight_max` convenience function

cc @polyfractal @eddyb @bjz @kaksmet