### PR TITLE
Implement filter and add notion of sparse iterators

### DIFF
--- a/neg-tests/cannot_collect_filtermap_data.rs
+++ b/neg-tests/cannot_collect_filtermap_data.rs
@@ -1,0 +1,14 @@
+extern crate rayon;
+
+use rayon::par_iter::*;
+
+// zip requires data of exact size, but filter yields only bounded
+// size, so check that we cannot apply it.
+
+fn main() {
+    let a: Vec<usize> = (0..1024).collect();
+    let mut v = vec![];
+    a.par_iter()
+     .filter_map(|&x| Some(x as f32))
+     .collect_into(&mut v); //~ ERROR no method
+}

--- a/neg-tests/cannot_zip_filtered_data.rs
+++ b/neg-tests/cannot_zip_filtered_data.rs
@@ -1,0 +1,14 @@
+extern crate rayon;
+
+use rayon::par_iter::*;
+
+// zip requires data of exact size, but filter yields only bounded
+// size, so check that we cannot apply it.
+
+fn main() {
+    let mut a: Vec<usize> = (0..1024).rev().collect();
+    let b: Vec<usize> = (0..1024).collect();
+
+    a.par_iter()
+     .zip(b.par_iter().filter(|&&x| x > 3)); //~ ERROR E0277
+}

--- a/src/par_iter/collect.rs
+++ b/src/par_iter/collect.rs
@@ -1,5 +1,5 @@
 use api::join;
-use super::ParallelIterator;
+use super::ExactParallelIterator;
 use super::len::{ParallelLen, THRESHOLD};
 use super::state::ParallelIteratorState;
 use std::isize;
@@ -7,7 +7,8 @@ use std::mem;
 use std::ptr;
 
 pub fn collect_into<PAR_ITER,T>(pi: PAR_ITER, v: &mut Vec<T>)
-    where PAR_ITER: ParallelIterator<Item=T>,
+    where PAR_ITER: ExactParallelIterator<Item=T>,
+          PAR_ITER: ExactParallelIterator,
           PAR_ITER::State: Send,
           T: Send,
 {

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,4 +1,4 @@
-use super::ParallelIterator;
+use super::{ParallelIterator, BoundedParallelIterator, ExactParallelIterator};
 use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 
@@ -13,7 +13,7 @@ impl<M> Enumerate<M> {
 }
 
 impl<M> ParallelIterator for Enumerate<M>
-    where M: ParallelIterator,
+    where M: ExactParallelIterator,
 {
     type Item = (usize, M::Item);
     type Shared = EnumerateShared<M>;
@@ -25,6 +25,14 @@ impl<M> ParallelIterator for Enumerate<M>
          EnumerateState { base: base_state, offset: 0 })
     }
 }
+
+unsafe impl<M> BoundedParallelIterator for Enumerate<M>
+    where M: ExactParallelIterator,
+{}
+
+unsafe impl<M> ExactParallelIterator for Enumerate<M>
+    where M: ExactParallelIterator,
+{}
 
 pub struct EnumerateState<M>
     where M: ParallelIterator

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -1,0 +1,87 @@
+use super::*;
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
+use std::marker::PhantomData;
+
+pub struct Filter<M, FILTER_OP> {
+    base: M,
+    filter_op: FILTER_OP,
+}
+
+impl<M, FILTER_OP> Filter<M, FILTER_OP> {
+    pub fn new(base: M, filter_op: FILTER_OP) -> Filter<M, FILTER_OP> {
+        Filter { base: base, filter_op: filter_op }
+    }
+}
+
+impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
+    where M: ParallelIterator,
+          FILTER_OP: Fn(&M::Item) -> bool + Sync,
+{
+    type Item = M::Item;
+    type Shared = FilterShared<M, FILTER_OP>;
+    type State = FilterState<M, FILTER_OP>;
+
+    fn state(self) -> (Self::Shared, Self::State) {
+        let (base_shared, base_state) = self.base.state();
+        (FilterShared { base: base_shared, filter_op: self.filter_op },
+         FilterState { base: base_state, filter_op: PhantomFilterOp::new() })
+    }
+}
+
+unsafe impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
+    where M: BoundedParallelIterator,
+          FILTER_OP: Fn(&M::Item) -> bool + Sync
+{}
+
+pub struct FilterShared<M, FILTER_OP>
+    where M: ParallelIterator,
+{
+    base: M::Shared,
+    filter_op: FILTER_OP,
+}
+
+pub struct FilterState<M, FILTER_OP>
+    where M: ParallelIterator,
+{
+    base: M::State,
+    filter_op: PhantomFilterOp<FILTER_OP>,
+}
+
+// Wrapper for `PhantomData` to allow `FilterState` to impl `Send`
+struct PhantomFilterOp<FILTER_OP>(PhantomData<*const FILTER_OP>);
+
+impl<FILTER_OP> PhantomFilterOp<FILTER_OP> {
+    fn new() -> PhantomFilterOp<FILTER_OP> {
+        PhantomFilterOp(PhantomData)
+    }
+}
+
+unsafe impl<FILTER_OP: Sync> Send for PhantomFilterOp<FILTER_OP> { }
+
+unsafe impl<M, FILTER_OP> ParallelIteratorState for FilterState<M, FILTER_OP>
+    where M: ParallelIterator,
+          FILTER_OP: Fn(&M::Item) -> bool + Sync
+{
+    type Item = M::Item;
+    type Shared = FilterShared<M, FILTER_OP>;
+
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
+        self.base.len(&shared.base)
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (FilterState { base: left, filter_op: PhantomFilterOp::new() },
+         FilterState { base: right, filter_op: PhantomFilterOp::new() })
+    }
+
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
+        while let Some(base) = self.base.next(&shared.base) {
+            if (shared.filter_op)(&base) {
+                return Some(base);
+            }
+        }
+        None
+    }
+}

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -1,0 +1,89 @@
+use super::*;
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
+use std::marker::PhantomData;
+
+pub struct FilterMap<M, FILTER_OP> {
+    base: M,
+    filter_op: FILTER_OP,
+}
+
+impl<M, FILTER_OP> FilterMap<M, FILTER_OP> {
+    pub fn new(base: M, filter_op: FILTER_OP) -> FilterMap<M, FILTER_OP> {
+        FilterMap { base: base, filter_op: filter_op }
+    }
+}
+
+impl<M, FILTER_OP, R> ParallelIterator for FilterMap<M, FILTER_OP>
+    where M: ParallelIterator,
+          FILTER_OP: Fn(M::Item) -> Option<R> + Sync,
+          R: Send,
+{
+    type Item = R;
+    type Shared = FilterShared<M, FILTER_OP>;
+    type State = FilterState<M, FILTER_OP>;
+
+    fn state(self) -> (Self::Shared, Self::State) {
+        let (base_shared, base_state) = self.base.state();
+        (FilterShared { base: base_shared, filter_op: self.filter_op },
+         FilterState { base: base_state, filter_op: PhantomFilterOp::new() })
+    }
+}
+
+unsafe impl<M, FILTER_OP, R> BoundedParallelIterator for FilterMap<M, FILTER_OP>
+    where M: BoundedParallelIterator,
+          FILTER_OP: Fn(M::Item) -> Option<R> + Sync,
+          R: Send,
+{}
+
+pub struct FilterShared<M, FILTER_OP>
+    where M: ParallelIterator,
+{
+    base: M::Shared,
+    filter_op: FILTER_OP,
+}
+
+pub struct FilterState<M, FILTER_OP>
+    where M: ParallelIterator,
+{
+    base: M::State,
+    filter_op: PhantomFilterOp<FILTER_OP>,
+}
+
+// Wrapper for `PhantomData` to allow `FilterState` to impl `Send`
+struct PhantomFilterOp<FILTER_OP>(PhantomData<*const FILTER_OP>);
+
+impl<FILTER_OP> PhantomFilterOp<FILTER_OP> {
+    fn new() -> PhantomFilterOp<FILTER_OP> {
+        PhantomFilterOp(PhantomData)
+    }
+}
+
+unsafe impl<FILTER_OP: Sync> Send for PhantomFilterOp<FILTER_OP> { }
+
+unsafe impl<M, FILTER_OP, R> ParallelIteratorState for FilterState<M, FILTER_OP>
+    where M: ParallelIterator,
+          FILTER_OP: Fn(M::Item) -> Option<R> + Sync
+{
+    type Item = R;
+    type Shared = FilterShared<M, FILTER_OP>;
+
+    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
+        self.base.len(&shared.base)
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (FilterState { base: left, filter_op: PhantomFilterOp::new() },
+         FilterState { base: right, filter_op: PhantomFilterOp::new() })
+    }
+
+    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
+        while let Some(base) = self.base.next(&shared.base) {
+            if let Some(mapped) = (shared.filter_op)(base) {
+                return Some(mapped);
+            }
+        }
+        None
+    }
+}

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -1,4 +1,4 @@
-use super::ParallelIterator;
+use super::*;
 use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 use std::marker::PhantomData;
@@ -29,6 +29,18 @@ impl<M, MAP_OP, R> ParallelIterator for Map<M, MAP_OP>
          MapState { base: base_state, map_op: PhantomMapOp::new() })
     }
 }
+
+unsafe impl<M, MAP_OP, R> BoundedParallelIterator for Map<M, MAP_OP>
+    where M: BoundedParallelIterator,
+          MAP_OP: Fn(M::Item) -> R + Sync,
+          R: Send,
+{}
+
+unsafe impl<M, MAP_OP, R> ExactParallelIterator for Map<M, MAP_OP>
+    where M: ExactParallelIterator,
+          MAP_OP: Fn(M::Item) -> R + Sync,
+          R: Send,
+{}
 
 pub struct MapShared<M, MAP_OP>
     where M: ParallelIterator,

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -45,18 +45,18 @@ pub trait IntoParallelIterator {
     fn into_par_iter(self) -> Self::Iter;
 }
 
-pub trait IntoParallelRefIterator<'r> {
-    type Iter: ParallelIterator<Item=&'r Self::Item>;
-    type Item: Sync + 'r;
+pub trait IntoParallelRefIterator<'data> {
+    type Iter: ParallelIterator<Item=&'data Self::Item>;
+    type Item: Sync + 'data;
 
-    fn par_iter(&'r self) -> Self::Iter;
+    fn par_iter(&'data self) -> Self::Iter;
 }
 
-pub trait IntoParallelRefMutIterator<'r> {
-    type Iter: ParallelIterator<Item=&'r mut Self::Item>;
-    type Item: Send + 'r;
+pub trait IntoParallelRefMutIterator<'data> {
+    type Iter: ParallelIterator<Item=&'data mut Self::Item>;
+    type Item: Send + 'data;
 
-    fn par_iter_mut(&'r mut self) -> Self::Iter;
+    fn par_iter_mut(&'data mut self) -> Self::Iter;
 }
 
 /// The `ParallelIterator` interface.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -14,6 +14,7 @@ use std::ops::Fn;
 use self::collect::collect_into;
 use self::enumerate::Enumerate;
 use self::filter::Filter;
+use self::filter_map::FilterMap;
 use self::map::Map;
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    SUM, MUL, MIN, MAX};
@@ -24,6 +25,7 @@ use self::zip::ZipIter;
 pub mod collect;
 pub mod enumerate;
 pub mod filter;
+pub mod filter_map;
 pub mod len;
 pub mod for_each;
 pub mod reduce;
@@ -114,6 +116,14 @@ pub trait ParallelIterator {
         where FILTER_OP: Fn(&Self::Item) -> bool, Self: Sized
     {
         Filter::new(self, filter_op)
+    }
+
+    /// Applies `map_op` to each item of his iterator, producing a new
+    /// iterator with the results.
+    fn filter_map<FILTER_OP,R>(self, filter_op: FILTER_OP) -> FilterMap<Self, FILTER_OP>
+        where FILTER_OP: Fn(Self::Item) -> Option<R>, Self: Sized
+    {
+        FilterMap::new(self, filter_op)
     }
 
     /// Reduces the items in the iterator into one item using `op`.

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -1,6 +1,6 @@
-use super::{IntoParallelIterator, ParallelIterator};
+use super::*;
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
+use super::state::*;
 use std::ops::Range;
 
 pub struct RangeIter<T> {
@@ -26,6 +26,12 @@ macro_rules! range_impl {
             fn state(self) -> (Self::Shared, Self::State) {
                 ((), self)
             }
+        }
+
+        unsafe impl BoundedParallelIterator for RangeIter<$t> {
+        }
+
+        unsafe impl ExactParallelIterator for RangeIter<$t> {
         }
 
         unsafe impl ParallelIteratorState for RangeIter<$t> {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -2,30 +2,30 @@ use super::*;
 use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 
-pub struct SliceIter<'r, T: 'r + Sync> {
-    slice: &'r [T]
+pub struct SliceIter<'data, T: 'data + Sync> {
+    slice: &'data [T]
 }
 
-impl<'r, T: Sync> IntoParallelIterator for &'r [T] {
-    type Item = &'r T;
-    type Iter = SliceIter<'r, T>;
+impl<'data, T: Sync> IntoParallelIterator for &'data [T] {
+    type Item = &'data T;
+    type Iter = SliceIter<'data, T>;
 
     fn into_par_iter(self) -> Self::Iter {
         SliceIter { slice: self }
     }
 }
 
-impl<'r, T: Sync + 'r> IntoParallelRefIterator<'r> for [T] {
+impl<'data, T: Sync + 'data> IntoParallelRefIterator<'data> for [T] {
     type Item = T;
-    type Iter = SliceIter<'r, T>;
+    type Iter = SliceIter<'data, T>;
 
-    fn par_iter(&'r self) -> Self::Iter {
+    fn par_iter(&'data self) -> Self::Iter {
         self.into_par_iter()
     }
 }
 
-impl<'r, T: Sync> ParallelIterator for SliceIter<'r, T> {
-    type Item = &'r T;
+impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
+    type Item = &'data T;
     type Shared = ();
     type State = Self;
 
@@ -34,12 +34,12 @@ impl<'r, T: Sync> ParallelIterator for SliceIter<'r, T> {
     }
 }
 
-unsafe impl<'r, T: Sync> BoundedParallelIterator for SliceIter<'r, T> { }
+unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> { }
 
-unsafe impl<'r, T: Sync> ExactParallelIterator for SliceIter<'r, T> { }
+unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> { }
 
-unsafe impl<'r, T: Sync> ParallelIteratorState for SliceIter<'r, T> {
-    type Item = &'r T;
+unsafe impl<'data, T: Sync> ParallelIteratorState for SliceIter<'data, T> {
+    type Item = &'data T;
     type Shared = ();
 
     fn len(&mut self, _shared: &Self::Shared) -> ParallelLen {
@@ -55,7 +55,7 @@ unsafe impl<'r, T: Sync> ParallelIteratorState for SliceIter<'r, T> {
         (left.into_par_iter(), right.into_par_iter())
     }
 
-    fn next(&mut self, _shared: &Self::Shared) -> Option<&'r T> {
+    fn next(&mut self, _shared: &Self::Shared) -> Option<&'data T> {
         self.slice.split_first()
                   .map(|(head, tail)| {
                       self.slice = tail;

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -1,4 +1,4 @@
-use super::{ParallelIterator, IntoParallelIterator, IntoParallelRefIterator};
+use super::*;
 use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 
@@ -33,6 +33,10 @@ impl<'r, T: Sync> ParallelIterator for SliceIter<'r, T> {
         ((), self)
     }
 }
+
+unsafe impl<'r, T: Sync> BoundedParallelIterator for SliceIter<'r, T> { }
+
+unsafe impl<'r, T: Sync> ExactParallelIterator for SliceIter<'r, T> { }
 
 unsafe impl<'r, T: Sync> ParallelIteratorState for SliceIter<'r, T> {
     type Item = &'r T;

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -1,4 +1,4 @@
-use super::{ParallelIterator, IntoParallelIterator, IntoParallelRefMutIterator};
+use super::*;
 use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 use std::mem;
@@ -34,6 +34,10 @@ impl<'r, T: Send> ParallelIterator for SliceIterMut<'r, T> {
         ((), self)
     }
 }
+
+unsafe impl<'r, T: Send> BoundedParallelIterator for SliceIterMut<'r, T> { }
+
+unsafe impl<'r, T: Send> ExactParallelIterator for SliceIterMut<'r, T> { }
 
 unsafe impl<'r, T: Send> ParallelIteratorState for SliceIterMut<'r, T> {
     type Item = &'r mut T;

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -3,30 +3,30 @@ use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 use std::mem;
 
-pub struct SliceIterMut<'r, T: 'r + Send> {
-    slice: &'r mut [T]
+pub struct SliceIterMut<'data, T: 'data + Send> {
+    slice: &'data mut [T]
 }
 
-impl<'r, T: Send> IntoParallelIterator for &'r mut [T] {
-    type Item = &'r mut T;
-    type Iter = SliceIterMut<'r, T>;
+impl<'data, T: Send> IntoParallelIterator for &'data mut [T] {
+    type Item = &'data mut T;
+    type Iter = SliceIterMut<'data, T>;
 
     fn into_par_iter(self) -> Self::Iter {
         SliceIterMut { slice: self }
     }
 }
 
-impl<'r, T: Send + 'r> IntoParallelRefMutIterator<'r> for [T] {
+impl<'data, T: Send + 'data> IntoParallelRefMutIterator<'data> for [T] {
     type Item = T;
-    type Iter = SliceIterMut<'r, T>;
+    type Iter = SliceIterMut<'data, T>;
 
-    fn par_iter_mut(&'r mut self) -> Self::Iter {
+    fn par_iter_mut(&'data mut self) -> Self::Iter {
         self.into_par_iter()
     }
 }
 
-impl<'r, T: Send> ParallelIterator for SliceIterMut<'r, T> {
-    type Item = &'r mut T;
+impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
+    type Item = &'data mut T;
     type Shared = ();
     type State = Self;
 
@@ -35,12 +35,12 @@ impl<'r, T: Send> ParallelIterator for SliceIterMut<'r, T> {
     }
 }
 
-unsafe impl<'r, T: Send> BoundedParallelIterator for SliceIterMut<'r, T> { }
+unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> { }
 
-unsafe impl<'r, T: Send> ExactParallelIterator for SliceIterMut<'r, T> { }
+unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> { }
 
-unsafe impl<'r, T: Send> ParallelIteratorState for SliceIterMut<'r, T> {
-    type Item = &'r mut T;
+unsafe impl<'data, T: Send> ParallelIteratorState for SliceIterMut<'data, T> {
+    type Item = &'data mut T;
     type Shared = ();
 
     fn len(&mut self, _shared: &Self::Shared) -> ParallelLen {
@@ -56,7 +56,7 @@ unsafe impl<'r, T: Send> ParallelIteratorState for SliceIterMut<'r, T> {
         (left.into_par_iter(), right.into_par_iter())
     }
 
-    fn next(&mut self, _shared: &Self::Shared) -> Option<&'r mut T> {
+    fn next(&mut self, _shared: &Self::Shared) -> Option<&'data mut T> {
         let slice = mem::replace(&mut self.slice, &mut []); // FIXME rust-lang/rust#10520
         slice.split_first_mut()
              .map(|(head, tail)| {

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -1,6 +1,9 @@
 use super::*;
 use super::state::ParallelIteratorState;
 
+fn is_bounded<T: ExactParallelIterator>(_: T) { }
+fn is_exact<T: ExactParallelIterator>(_: T) { }
+
 #[test]
 pub fn execute() {
     let a: Vec<i32> = (0..1024).collect();
@@ -21,6 +24,13 @@ pub fn execute_range() {
      .collect_into(&mut b);
     let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
     assert_eq!(b, c);
+}
+
+#[test]
+pub fn check_map_exact_and_bounded() {
+    let a = [1, 2, 3];
+    is_bounded(a.par_iter().map(|x| x));
+    is_exact(a.par_iter().map(|x| x));
 }
 
 #[test]
@@ -80,6 +90,13 @@ pub fn check_weight() {
 }
 
 #[test]
+pub fn check_weight_exact_and_bounded() {
+    let a = [1, 2, 3];
+    is_bounded(a.par_iter().weight(2.0));
+    is_exact(a.par_iter().weight(2.0));
+}
+
+#[test]
 pub fn check_enumerate() {
     let a: Vec<usize> = (0..1024).rev().collect();
 
@@ -100,6 +117,26 @@ pub fn check_increment() {
      .for_each(|(i, v)| *v += i);
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
+}
+
+#[test]
+pub fn check_slice_exact_and_bounded() {
+    let a = vec![1, 2, 3];
+    is_exact(a.par_iter());
+    is_bounded(a.par_iter());
+}
+
+#[test]
+pub fn check_slice_mut_exact_and_bounded() {
+    let mut a = vec![1, 2, 3];
+    is_exact(a.par_iter_mut());
+    is_bounded(a.par_iter_mut());
+}
+
+#[test]
+pub fn check_range_exact_and_bounded() {
+    is_exact((1..5).into_par_iter());
+    is_bounded((1..5).into_par_iter());
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -187,3 +187,17 @@ pub fn check_sum_filtered_ints() {
     assert_eq!(par_sum_evens, seq_sum_evens);
 }
 
+#[test]
+pub fn check_sum_filtermap_ints() {
+    let a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let par_sum_evens =
+        a.par_iter()
+         .filter_map(|&x| if (x & 1) == 0 {Some(x as f32)} else {None})
+         .sum();
+    let seq_sum_evens =
+        a.iter()
+         .filter_map(|&x| if (x & 1) == 0 {Some(x as f32)} else {None})
+         .fold(0.0, |a,b| a+b);
+    assert_eq!(par_sum_evens, seq_sum_evens);
+}
+

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -170,3 +170,20 @@ pub fn check_range_split_at_overflow() {
     let r2 = right.map(|i| i as i32).sum();
     assert_eq!(r1 + r2, -100);
 }
+
+#[test]
+pub fn check_sum_filtered_ints() {
+    let a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let par_sum_evens =
+        a.par_iter()
+         .filter(|&x| (x & 1) == 0)
+         .map(|&x| x)
+         .sum();
+    let seq_sum_evens =
+        a.iter()
+         .filter(|&x| (x & 1) == 0)
+         .map(|&x| x)
+         .fold(0, |a,b| a+b);
+    assert_eq!(par_sum_evens, seq_sum_evens);
+}
+

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,4 +1,4 @@
-use super::ParallelIterator;
+use super::*;
 use super::len::ParallelLen;
 use super::state::ParallelIteratorState;
 
@@ -26,6 +26,10 @@ impl<M> ParallelIterator for Weight<M>
          WeightState { base: base_state })
     }
 }
+
+unsafe impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> { }
+
+unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> { }
 
 pub struct WeightState<M>
     where M: ParallelIterator


### PR DESCRIPTION
@bjz here is an implementation of filter that I believe to be correct. I also refined the `ParallelIterator` hierarchy and fixed a few minor things.

I think a good next step would be to add `flat_map`, but also to generalize `collect` so that it works for collections of arbitrary types. In particular, one could add a rope-like version of vector that DOES work for filtered (or flat-mapped) iterators.

Note that this builds on https://github.com/nikomatsakis/rayon/pull/23.