### PR TITLE
impl ParallelIterator for Range<T> (for some T)

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -31,6 +31,7 @@ pub mod state;
 pub mod map;
 pub mod weight;
 pub mod zip;
+pub mod range;
 
 #[cfg(test)]
 mod test;

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -1,57 +1,66 @@
-use super::{IntoParallelIterator, ParallelIterator, ParallelIteratorState, ParallelLen};
+use super::{IntoParallelIterator, ParallelIterator};
+use super::len::ParallelLen;
+use super::state::ParallelIteratorState;
 use std::ops::Range;
 
 pub struct RangeIter<T> {
-    slice: Range<T>
+    range: Range<T>
 }
 
-pub trait ParallelRange: Eq + Send {
-    fn len(start: Self, stop: Self) -> usize;
-    fn mid(start: Self, stop: Self) -> Self;
-    fn increment(start: Self) -> Self;
-}
+macro_rules! range_impl {
+    ( $t:ty ) => {
+        impl IntoParallelIterator for Range<$t> {
+            type Item = $t;
+            type Iter = RangeIter<$t>;
 
-impl<T: ParallelRange> IntoParallelIterator for Range<T> {
-    type Item = T;
-    type Iter = RangeIter<'map, T>;
-
-    fn into_par_iter(self) -> Self::Iter {
-        RangeIter { slice: self }
-    }
-}
-
-impl<T: ParallelRange> ParallelIterator for RangeIter<'map, T> {
-    type Item = T;
-    type Shared = ();
-    type State = Self;
-
-    fn state(self) -> (Self::Shared, Self::State) {
-        ((), self)
-    }
-}
-
-impl<T: ParallelRange> ParallelIteratorState for RangeIter<'map, T> {
-    type Item = T;
-    type Shared = ();
-
-    fn len(&mut self) -> ParallelLen {
-        ParallelLen {
-            maximal_len: self.slice.len(),
-            cost: self.slice.len() as f64,
-            sparse: false,
+            fn into_par_iter(self) -> Self::Iter {
+                RangeIter { range: self }
+            }
         }
-    }
 
-    fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.slice.split_at(index);
-        (left.into_par_iter(), right.into_par_iter())
-    }
+        impl ParallelIterator for RangeIter<$t> {
+            type Item = $t;
+            type Shared = ();
+            type State = Self;
 
-    fn for_each<OP>(self, _shared: &Self::Shared, mut op: OP)
-        where OP: FnMut(&'map T)
-    {
-        for item in self.slice {
-            op(item);
+            fn state(self) -> (Self::Shared, Self::State) {
+                ((), self)
+            }
+        }
+
+        unsafe impl ParallelIteratorState for RangeIter<$t> {
+            type Item = $t;
+            type Shared = ();
+
+            fn len(&mut self, _shared: &Self::Shared) -> ParallelLen {
+                ParallelLen {
+                    maximal_len: self.range.len(),
+                    cost: self.range.len() as f64,
+                    sparse: false,
+                }
+            }
+
+            fn split_at(self, index: usize) -> (Self, Self) {
+                assert!(index <= self.range.len());
+                let mid = self.range.start + index as $t;
+                let left = self.range.start .. mid;
+                let right = mid .. self.range.end;
+                (left.into_par_iter(), right.into_par_iter())
+            }
+
+            fn next(&mut self, _shared: &Self::Shared) -> Option<$t> {
+                self.range.next()
+            }
         }
     }
 }
+
+// all Range<T> with ExactSizeIterator
+range_impl!{u8}
+range_impl!{u16}
+range_impl!{u32}
+range_impl!{usize}
+range_impl!{i8}
+range_impl!{i16}
+range_impl!{i32}
+range_impl!{isize}

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -42,7 +42,9 @@ macro_rules! range_impl {
 
             fn split_at(self, index: usize) -> (Self, Self) {
                 assert!(index <= self.range.len());
-                let mid = self.range.start + index as $t;
+                // For signed $t, the length and requested index could be greater than $t::MAX, and
+                // then `index as $t` could wrap to negative, so wrapping_add is necessary.
+                let mid = self.range.start.wrapping_add(index as $t);
                 let left = self.range.start .. mid;
                 let right = mid .. self.range.end;
                 (left.into_par_iter(), right.into_par_iter())

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -124,3 +124,12 @@ pub fn check_zip_range() {
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
 }
+
+#[test]
+pub fn check_range_split_at_overflow() {
+    // Note, this split index overflows i8!
+    let (left, right) = (-100i8..100).into_par_iter().split_at(150);
+    let r1 = left.map(|i| i as i32).sum();
+    let r2 = right.map(|i| i as i32).sum();
+    assert_eq!(r1 + r2, -100);
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -13,6 +13,17 @@ pub fn execute() {
 }
 
 #[test]
+pub fn execute_range() {
+    let a = 0i32..1024;
+    let mut b = vec![];
+    a.into_par_iter()
+     .map(|i| i + 1)
+     .collect_into(&mut b);
+    let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
+    assert_eq!(b, c);
+}
+
+#[test]
 pub fn map_reduce() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
@@ -99,6 +110,17 @@ pub fn check_zip() {
     a.par_iter_mut()
      .zip(&b[..])
      .for_each(|(a, &b)| *a += b);
+
+    assert!(a.iter().all(|&x| x == a.len() - 1));
+}
+
+#[test]
+pub fn check_zip_range() {
+    let mut a: Vec<usize> = (0..1024).rev().collect();
+
+    a.par_iter_mut()
+     .zip(0usize..1024)
+     .for_each(|(a, b)| *a += b);
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
 }


### PR DESCRIPTION
A par_iter/range.rs was already started, but not actually pulled in.

Range<T> is annoying to deal with generically, since its Iterator
depends on unstable Step, and its ExactSizeIterator is only for select
integral types (all but i64/u64).

Use a macro to implement just those Range<T> with ExactSizeIterator.