### PR TITLE
Implement a new parallel iterator scheme that supports flat-map

### DIFF
--- a/src/par_iter/README.md
+++ b/src/par_iter/README.md
@@ -22,8 +22,8 @@ modes (which is why there are two):
   this mode, the iterator instead is *given* each item in turn, which
   is then processed. This is the opposite of a normal iterator. It's
   more like a `for_each` call: each time a new item is produced, the
-  `consume` method is called with that item. (The traits themselves is
-  a bit more complex, as it supports state that can be threaded
+  `consume` method is called with that item. (The traits themselves are
+  a bit more complex, as they support state that can be threaded
   through and ultimately reduced.) Unlike producers, there are two
   variants of consumers. The difference is how the split is performed:
   - in the `Consumer` trait, splitting is done with `split_at`, which

--- a/src/par_iter/README.md
+++ b/src/par_iter/README.md
@@ -1,7 +1,7 @@
 # Parallel Iterators
 
 These are some notes on the design of the parallel iterator traits.
-This module does not describe how to **use** parallel iterators.
+This file does not describe how to **use** parallel iterators.
 
 ## The challenge
 

--- a/src/par_iter/README.md
+++ b/src/par_iter/README.md
@@ -1,0 +1,132 @@
+# Parallel Iterators
+
+These are some notes on the design of the parallel iterator traits.
+This module does not describe how to **use** parallel iterators.
+
+## The challenge
+
+Parallel iterators are more complicated than sequential iterators.
+The reason is that they have to be able to split themselves up and
+operate in parallel across the two halves.
+
+The current design for parallel iterators has two distinct modes in
+which they can be used; as we will see, not all iterators support both
+modes (which is why there are two):
+
+- **Pull mode** (the `Producer` trait): in this mode, the iterator is
+  asked to produce the next item using a call to `next`. This is
+  basically like a normal iterator, but with a twist: you can split
+  the iterator at a given point by calling `split_at`, which produces
+  two iterators.
+- **Push mode** (the `Consumer` and `UnindexedConsumer` traits): in
+  this mode, the iterator instead is *given* each item in turn, which
+  is then processed. This is the opposite of a normal iterator. It's
+  more like a `for_each` call: each time a new item is produced, the
+  `consume` method is called with that item. (The traits themselves is
+  a bit more complex, as it supports state that can be threaded
+  through and ultimately reduced.) Unlike producers, there are two
+  variants of consumers. The difference is how the split is performed:
+  - in the `Consumer` trait, splitting is done with `split_at`, which
+    accepts an index where the split should be performed. All
+    iterators can work in this mode. The resulting halves thus have an
+    idea about how much data they expect to consume.
+  - in the `UnindexedConsumer` trait, splitting is done with `split`.
+    There is no index: the resulting halves must be prepared to
+    process any amount of data, and they don't know where that data
+    falls in the overall stream.
+    - Not all consumers can operate in this mode. It works for
+      `for_each` and `reduce`, for example, but it does not work for
+      `collect_into`, since in that case the position of each item is
+      important for knowing where it ends up in the target collection.
+
+## How iterator execution proceeds  
+
+We'll walk through this example iterator chain to start. This chain
+demonstrates more-or-less the full complexity of what can happen.
+
+```rust
+vec1.par_iter()
+    .zip(vec2.par_iter())
+    .flat_map(some_function)
+    .for_each(some_other_function)
+```
+
+To handle an iterator chain, we start by creating consumers. This
+works from the end. So in this case, the call to `for_each` is the
+final step, so it will create a `ForEachConsumer` that, given an item,
+just calls `some_other_function` with that item. (`ForEachConsumer` is
+a very simple consumer because it doesn't need to thread any state
+between items at all.)
+
+Now, the `for_each` call will pass this consumer to the base iterator,
+which is the `flat_map`. It will do by calling the `drive_unindexed`
+method on the `ParallelIterator` trait. `drive_unindexed` basically
+says "produce items for this iterator and feed them to this consumer";
+it only works for unindexed consumers.
+
+(As an aside, it is interesting that only some consumers can work in
+unindexed mode, but all producers can *drive* an unindexed consumer.
+In contrast, only some producers can drive an *indexed* consumer, but
+all consumers can be supplied indexes. Isn't variance neat.)
+
+As it happens, `FlatMap` only works with unindexed consumers anyway.
+This is because flat-map basically has no idea how many items it will
+produce. If you ask flat-map to produce the 22nd item, it can't do it,
+at least not without some intermediate state. It doesn't know whether
+processing the first item will create 1 item, 3 items, or 100;
+therefore, to produce an arbitrary item, it would basically just have
+to start at the beginning and execute sequentially, which is not what
+we want. But for unindexed consumers, this doesn't matter, since they
+don't need to know how much data they will get.
+
+Therefore, `FlatMap` can wrap the `ForEachConsumer` with a
+`FlatMapConsumer` that feeds to it. This `FlatMapConsumer` will be
+given one item. It will then invoke `some_function` to get a parallel
+iterator out. It will then ask this new parallel iterator to drive the
+`ForEachConsumer`. The `drive_unindexed` method on `flat_map` can then
+pass the `FlatMapConsumer` up the chain to the previous item, which is
+`zip`. At this point, something interesting happens.
+
+## Switching from push to pull mode
+
+If you think about `zip`, it can't really be implemented as a
+consumer, at least not without an intermediate thread and some
+channels or something (or maybe coroutines). The problem is that it
+has to walk two iterators *in lockstep*. Basically, it can't call two
+`drive` methods simultaneously, it can only call one at a time. So at
+this point, the `zip` iterator needs to switch from *push mode* into
+*pull mode*.
+
+You'll note that `Zip` is only usable if its inputs implement
+`IndexedParallelIterator`, meaning that they can produce data starting
+at random points in the stream. This need to switch to push mode is
+exactly why. If we want to split a zip iterator at position 22, we
+need to be able to start zipping items from index 22 right away,
+without having to start from index 0.
+
+Anyway, so at this point, the `drive_unindexed` method for `Zip` stops
+creating consumers. Instead, it creates a *producer*, a `ZipProducer`,
+to be exact, and calls the `bridge` function in the `internals`
+module. Creating a `ZipProducer` will in turn create producers for
+the two iterators being zipped. This is possible because they both
+implement `IndexedParallelIterator`.
+
+The `bridge` function will then connect the consumer, which is
+handling the `flat_map` and `for_each`, with the producer, which is
+handling the `zip` and its preecessors. It will split down until the
+chunks seem reasonably small, then pull items from the producer and
+feed them to the consumer.
+
+## The base case
+
+The other time that `bridge` gets used is when we bottom out in an
+indexed producer, such as a slice or range.
+
+## Why is there no `UnindexedProducer`?
+
+You may be wondering why there is no `UnindexedProducer` trait.  The
+answer is that there isn't really a need for one: the
+`drive_unindexed` method basically *is* an unindexed producer. As it
+happens, in the current code base, all parallel iterators bottom out
+in something indexed (a slice, a range, etc), but we may extend that
+in the future, no problem.

--- a/src/par_iter/collect.rs
+++ b/src/par_iter/collect.rs
@@ -1,6 +1,6 @@
 use super::ExactParallelIterator;
 use super::len::*;
-use super::state::*;
+use super::internal::*;
 use std::isize;
 use std::mem;
 use std::ptr;

--- a/src/par_iter/collect.rs
+++ b/src/par_iter/collect.rs
@@ -1,31 +1,29 @@
 use api::join;
 use super::ExactParallelIterator;
-use super::len::{ParallelLen, THRESHOLD};
-use super::state::ParallelIteratorState;
+use super::len::*;
+use super::state::*;
 use std::isize;
 use std::mem;
 use std::ptr;
 
-pub fn collect_into<PAR_ITER,T>(pi: PAR_ITER, v: &mut Vec<T>)
+pub fn collect_into<PAR_ITER,T>(mut pi: PAR_ITER, v: &mut Vec<T>)
     where PAR_ITER: ExactParallelIterator<Item=T>,
           PAR_ITER: ExactParallelIterator,
           PAR_ITER::State: Send,
           T: Send,
 {
-    let (shared, mut state) = pi.state();
-    let len = state.len(&shared);
+    let len = pi.len();
+    assert!(len < (isize::MAX) as usize);
 
     v.truncate(0); // clear any old data
-    v.reserve(len.maximal_len); // reserve enough space
+    v.reserve(len); // reserve enough space
     let target = v.as_mut_ptr(); // get a raw ptr
-
-    unsafe {
-        collect_into_helper(state, &shared, len, CollectTarget(target));
-    }
+    let consumer = CollectConsumer { target: target, len: len };
+    pi.drive(consumer, &());
 
     unsafe {
         // TODO -- drops are not quite right here!
-        v.set_len(len.maximal_len);
+        v.set_len(len);
     }
 }
 
@@ -91,5 +89,52 @@ impl<T> Drop for DropInitialized<T> {
                 p = p.offset(1);
             }
         }
+    }
+}
+
+struct CollectConsumer<ITEM: Send> {
+    target: *mut ITEM,
+    len: usize,
+}
+
+unsafe impl<ITEM: Send> Send for CollectConsumer<ITEM> { }
+
+impl<'c, ITEM: Send + 'c> Consumer<'c> for CollectConsumer<ITEM> {
+    type Item = ITEM;
+    type Shared = ();
+    type SeqState = DropInitialized<ITEM>;
+    type Result = ();
+
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+        cost * FUNC_ADJUSTMENT
+    }
+
+    unsafe fn split_at(self, _: &Self::Shared, index: usize) -> (Self, Self) {
+        assert!(index < self.len);
+        (CollectConsumer { target: self.target, len: index },
+         CollectConsumer { target: self.target.offset(index as isize), len: self.len - index })
+    }
+
+    unsafe fn start(&mut self, _reduce_op: &()) -> DropInitialized<ITEM> {
+        DropInitialized::new(self.target)
+    }
+
+    unsafe fn consume(&mut self,
+                      _: &(),
+                      mut p: DropInitialized<ITEM>,
+                      item: ITEM)
+                      -> DropInitialized<ITEM> {
+        ptr::write(p.next, item);
+        p.bump();
+        p
+    }
+
+    unsafe fn complete(self,
+                       _: &(),
+                       p: DropInitialized<ITEM>) {
+        mem::forget(p); // fully initialized, so don't run the destructor
+    }
+
+    unsafe fn reduce(_: &(), a: (), b: ()) {
     }
 }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 
 pub struct Enumerate<M> {
     base: M,

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -12,7 +12,7 @@ impl<M> Enumerate<M> {
 }
 
 impl<M> ParallelIterator for Enumerate<M>
-    where M: PullParallelIterator,
+    where M: IndexedParallelIterator,
 {
     type Item = (usize, M::Item);
 
@@ -25,7 +25,7 @@ impl<M> ParallelIterator for Enumerate<M>
 }
 
 unsafe impl<M> BoundedParallelIterator for Enumerate<M>
-    where M: PullParallelIterator,
+    where M: IndexedParallelIterator,
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -40,15 +40,15 @@ unsafe impl<M> BoundedParallelIterator for Enumerate<M>
 }
 
 unsafe impl<M> ExactParallelIterator for Enumerate<M>
-    where M: PullParallelIterator,
+    where M: IndexedParallelIterator,
 {
     fn len(&mut self) -> usize {
         self.base.len()
     }
 }
 
-impl<M> PullParallelIterator for Enumerate<M>
-    where M: PullParallelIterator,
+impl<M> IndexedParallelIterator for Enumerate<M>
+    where M: IndexedParallelIterator,
 {
     type Producer = EnumerateProducer<M::Producer>;
 

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,6 +1,6 @@
 use super::{ParallelIterator, BoundedParallelIterator, ExactParallelIterator};
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
+use super::state::*;
 
 pub struct Enumerate<M> {
     base: M,
@@ -19,6 +19,10 @@ impl<M> ParallelIterator for Enumerate<M>
     type Shared = EnumerateShared<M>;
     type State = EnumerateState<M>;
 
+    fn drive<C: Consumer<Item=Self::Item>>(self, _consumer: C) -> C::Result {
+        unimplemented!()
+    }
+
     fn state(self) -> (Self::Shared, Self::State) {
         let (base_shared, base_state) = self.base.state();
         (EnumerateShared { base: base_shared },
@@ -28,7 +32,11 @@ impl<M> ParallelIterator for Enumerate<M>
 
 unsafe impl<M> BoundedParallelIterator for Enumerate<M>
     where M: ExactParallelIterator,
-{}
+{
+    fn upper_bound(&mut self) -> u64 {
+        self.len()
+    }
+}
 
 unsafe impl<M> ExactParallelIterator for Enumerate<M>
     where M: ExactParallelIterator,

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -16,10 +16,10 @@ impl<M> ParallelIterator for Enumerate<M>
 {
     type Item = (usize, M::Item);
 
-    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
-                                                   consumer: C,
-                                                   shared: &'c C::Shared)
-                                                   -> C::Result {
+    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                       consumer: C,
+                                                                       shared: &'c C::Shared)
+                                                                       -> C::Result {
         bridge(self, consumer, &shared)
     }
 }
@@ -29,6 +29,13 @@ unsafe impl<M> BoundedParallelIterator for Enumerate<M>
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
+    }
+
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
+        bridge(self, consumer, &shared)
     }
 }
 

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -112,7 +112,7 @@ impl<M> Producer for EnumerateProducer<M>
     type Item = (usize, M::Item);
     type Shared = M::Shared;
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+    fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
         self.base.cost(shared, items) // enumerating is basically free
     }
 

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -33,7 +33,7 @@ impl<M> ParallelIterator for Enumerate<M>
 unsafe impl<M> BoundedParallelIterator for Enumerate<M>
     where M: ExactParallelIterator,
 {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         self.len()
     }
 }
@@ -41,7 +41,7 @@ unsafe impl<M> BoundedParallelIterator for Enumerate<M>
 unsafe impl<M> ExactParallelIterator for Enumerate<M>
     where M: ExactParallelIterator,
 {
-    fn len(&mut self) -> u64 {
+    fn len(&mut self) -> usize {
         self.base.len()
     }
 }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -19,8 +19,8 @@ impl<M> ParallelIterator for Enumerate<M>
     type Shared = EnumerateShared<M>;
     type State = EnumerateState<M>;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, _consumer: C) -> C::Result {
-        unimplemented!()
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+        bridge(self, consumer, &shared)
     }
 
     fn state(self) -> (Self::Shared, Self::State) {

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -32,7 +32,11 @@ unsafe impl<M> BoundedParallelIterator for Enumerate<M>
 
 unsafe impl<M> ExactParallelIterator for Enumerate<M>
     where M: ExactParallelIterator,
-{}
+{
+    fn len(&mut self) -> u64 {
+        self.base.len()
+    }
+}
 
 pub struct EnumerateState<M>
     where M: ParallelIterator

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -112,6 +112,10 @@ impl<M> Producer for EnumerateProducer<M>
     type Item = (usize, M::Item);
     type Shared = EnumerateProducerShared<M>;
 
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        self.base.cost(&shared.base, items) // enumerating is basically free
+    }
+
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (EnumerateProducer { base: left, offset: self.offset },

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,4 +1,4 @@
-use super::{ParallelIterator, BoundedParallelIterator, ExactParallelIterator};
+use super::*;
 use super::len::ParallelLen;
 use super::state::*;
 
@@ -13,7 +13,7 @@ impl<M> Enumerate<M> {
 }
 
 impl<M> ParallelIterator for Enumerate<M>
-    where M: ExactParallelIterator,
+    where M: PullParallelIterator,
 {
     type Item = (usize, M::Item);
     type Shared = EnumerateShared<M>;
@@ -31,7 +31,7 @@ impl<M> ParallelIterator for Enumerate<M>
 }
 
 unsafe impl<M> BoundedParallelIterator for Enumerate<M>
-    where M: ExactParallelIterator,
+    where M: PullParallelIterator,
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -39,11 +39,16 @@ unsafe impl<M> BoundedParallelIterator for Enumerate<M>
 }
 
 unsafe impl<M> ExactParallelIterator for Enumerate<M>
-    where M: ExactParallelIterator,
+    where M: PullParallelIterator,
 {
     fn len(&mut self) -> usize {
         self.base.len()
     }
+}
+
+impl<M> PullParallelIterator for Enumerate<M>
+    where M: PullParallelIterator,
+{
 }
 
 pub struct EnumerateState<M>

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -106,7 +106,6 @@ impl<M> Producer for EnumerateProducer<M>
 {
     type Item = (usize, M::Item);
     type Shared = EnumerateProducerShared<M>;
-    type SeqState = (usize, M::SeqState);
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
@@ -114,25 +113,13 @@ impl<M> Producer for EnumerateProducer<M>
          EnumerateProducer { base: right, offset: self.offset + index })
     }
 
-    unsafe fn start(&mut self, shared: &EnumerateProducerShared<M>) -> (usize, M::SeqState) {
-        let state = self.base.start(&shared.base);
-        (self.offset, state)
-    }
-
     unsafe fn produce(&mut self,
-                      shared: &EnumerateProducerShared<M>,
-                      state: &mut (usize, M::SeqState))
+                      shared: &EnumerateProducerShared<M>)
                       -> (usize, M::Item)
     {
-        let item = self.base.produce(&shared.base, &mut state.1);
-        let index = state.0;
-        state.0 += 1;
+        let item = self.base.produce(&shared.base);
+        let index = self.offset;
+        self.offset += 1;
         (index, item)
-    }
-
-    unsafe fn complete(self,
-                       shared: &EnumerateProducerShared<M>,
-                       state: (usize, M::SeqState)) {
-        self.base.complete(&shared.base, state.1);
     }
 }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -19,7 +19,10 @@ impl<M> ParallelIterator for Enumerate<M>
     type Shared = EnumerateShared<M>;
     type State = EnumerateState<M>;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
         bridge(self, consumer, &shared)
     }
 

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -16,7 +16,7 @@ impl<M> ParallelIterator for Enumerate<M>
 {
     type Item = (usize, M::Item);
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                        consumer: C,
                                                                        shared: &'c C::Shared)
                                                                        -> C::Result {

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -20,13 +20,13 @@ impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
 {
     type Item = M::Item;
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {
         let consumer1: FilterConsumer<C, FILTER_OP> = FilterConsumer::new(consumer);
         let shared1 = (shared, &self.filter_op);
-        self.base.drive_stateless(consumer1, &shared1)
+        self.base.drive_unindexed(consumer1, &shared1)
     }
 }
 
@@ -110,8 +110,8 @@ impl<'f, 'c, C, FILTER_OP: 'f> Consumer<'f> for FilterConsumer<'c, C, FILTER_OP>
     }
 }
 
-impl<'f, 'c, C, FILTER_OP: 'f> StatelessConsumer<'f> for FilterConsumer<'c, C, FILTER_OP>
-    where C: StatelessConsumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync, 'c: 'f,
+impl<'f, 'c, C, FILTER_OP: 'f> UnindexedConsumer<'f> for FilterConsumer<'c, C, FILTER_OP>
+    where C: UnindexedConsumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync, 'c: 'f,
 {
     fn split(&self) -> Self {
         FilterConsumer::new(self.base.split())

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -20,13 +20,13 @@ impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
 {
     type Item = M::Item;
 
-    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
-                                                   consumer: C,
-                                                   shared: &'c C::Shared)
-                                                   -> C::Result {
+    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                      consumer: C,
+                                                                      shared: &'c C::Shared)
+                                                                      -> C::Result {
         let consumer1: FilterConsumer<C, FILTER_OP> = FilterConsumer::new(consumer);
         let shared1 = (shared, &self.filter_op);
-        self.base.drive(consumer1, &shared1)
+        self.base.drive_stateless(consumer1, &shared1)
     }
 }
 
@@ -36,6 +36,15 @@ unsafe impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
 {
     fn upper_bound(&mut self) -> usize {
         self.base.upper_bound()
+    }
+
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
+        let consumer1: FilterConsumer<C, FILTER_OP> = FilterConsumer::new(consumer);
+        let shared1 = (shared, &self.filter_op);
+        self.base.drive(consumer1, &shared1)
     }
 }
 
@@ -100,3 +109,12 @@ impl<'f, 'c, C, FILTER_OP: 'f> Consumer<'f> for FilterConsumer<'f, 'c, C, FILTER
         C::reduce(&shared.0, left, right)
     }
 }
+
+impl<'f, 'c, C, FILTER_OP: 'f> StatelessConsumer<'f> for FilterConsumer<'f, 'c, C, FILTER_OP>
+    where C: StatelessConsumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+{
+    fn split(&self) -> Self {
+        FilterConsumer::new(self.base.split())
+    }
+}
+

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -118,8 +118,8 @@ impl<C, FILTER_OP> Consumer for FilterConsumer<C, FILTER_OP>
     type Result = C::Result;
 
     /// Cost to process `items` number of items.
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+        self.base.cost(&shared.base, cost) * FUNC_ADJUSTMENT
     }
 
     unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -38,7 +38,7 @@ unsafe impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
     where M: BoundedParallelIterator,
           FILTER_OP: Fn(&M::Item) -> bool + Sync
 {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 }
@@ -117,7 +117,7 @@ impl<C, FILTER_OP> Consumer for FilterConsumer<C, FILTER_OP>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn split_at(self, index: u64) -> (Self, Self) {
+    unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (FilterConsumer::new(left), FilterConsumer::new(right))
     }

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::len::*;
-use super::state::*;
+use super::internal::*;
 use super::util::PhantomType;
 
 pub struct Filter<M, FILTER_OP> {

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -51,23 +51,23 @@ unsafe impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
 ///////////////////////////////////////////////////////////////////////////
 // Consumer implementation
 
-struct FilterConsumer<'f, 'c, C, FILTER_OP>
-    where C: Consumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync, 'c: 'f
+struct FilterConsumer<'c, C, FILTER_OP>
+    where C: Consumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync
 {
     base: C,
-    filter_op: PhantomType<(&'f &'c (), FILTER_OP)>,
+    filter_op: PhantomType<(&'c (), FILTER_OP)>,
 }
 
-impl<'f, 'c, C, FILTER_OP> FilterConsumer<'f, 'c, C, FILTER_OP>
-    where C: Consumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync, 'c: 'f
+impl<'c, C, FILTER_OP> FilterConsumer<'c, C, FILTER_OP>
+    where C: Consumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync
 {
-    fn new(base: C) -> FilterConsumer<'f, 'c, C, FILTER_OP> {
+    fn new(base: C) -> FilterConsumer<'c, C, FILTER_OP> {
         FilterConsumer { base: base, filter_op: PhantomType::new() }
     }
 }
 
-impl<'f, 'c, C, FILTER_OP: 'f> Consumer<'f> for FilterConsumer<'f, 'c, C, FILTER_OP>
-    where C: Consumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+impl<'f, 'c, C, FILTER_OP: 'f> Consumer<'f> for FilterConsumer<'c, C, FILTER_OP>
+    where C: Consumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync, 'c: 'f,
 {
     type Item = C::Item;
     type Shared = (&'c C::Shared, &'f FILTER_OP);
@@ -110,8 +110,8 @@ impl<'f, 'c, C, FILTER_OP: 'f> Consumer<'f> for FilterConsumer<'f, 'c, C, FILTER
     }
 }
 
-impl<'f, 'c, C, FILTER_OP: 'f> StatelessConsumer<'f> for FilterConsumer<'f, 'c, C, FILTER_OP>
-    where C: StatelessConsumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+impl<'f, 'c, C, FILTER_OP: 'f> StatelessConsumer<'f> for FilterConsumer<'c, C, FILTER_OP>
+    where C: StatelessConsumer<'c>, FILTER_OP: Fn(&C::Item) -> bool + Sync, 'c: 'f,
 {
     fn split(&self) -> Self {
         FilterConsumer::new(self.base.split())

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::len::ParallelLen;
+use super::len::*;
 use super::state::*;
 use super::util::PhantomType;
 
@@ -117,8 +117,13 @@ impl<C, FILTER_OP> Consumer for FilterConsumer<C, FILTER_OP>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.base.split_at(index);
+    /// Cost to process `items` number of items.
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    }
+
+    unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(&shared.base, index);
         (FilterConsumer::new(left), FilterConsumer::new(right))
     }
 

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -1,7 +1,7 @@
 use super::*;
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
-use std::marker::PhantomData;
+use super::state::*;
+use super::util::PhantomType;
 
 pub struct Filter<M, FILTER_OP> {
     base: M,
@@ -22,17 +22,26 @@ impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
     type Shared = FilterShared<M, FILTER_OP>;
     type State = FilterState<M, FILTER_OP>;
 
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
+        let filter_consumer: FilterConsumer<C, FILTER_OP> = FilterConsumer::new(consumer);
+        self.base.drive(filter_consumer)
+    }
+
     fn state(self) -> (Self::Shared, Self::State) {
         let (base_shared, base_state) = self.base.state();
         (FilterShared { base: base_shared, filter_op: self.filter_op },
-         FilterState { base: base_state, filter_op: PhantomFilterOp::new() })
+         FilterState { base: base_state, filter_op: PhantomType::new() })
     }
 }
 
 unsafe impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
     where M: BoundedParallelIterator,
           FILTER_OP: Fn(&M::Item) -> bool + Sync
-{}
+{
+    fn upper_bound(&mut self) -> u64 {
+        self.base.upper_bound()
+    }
+}
 
 pub struct FilterShared<M, FILTER_OP>
     where M: ParallelIterator,
@@ -45,19 +54,8 @@ pub struct FilterState<M, FILTER_OP>
     where M: ParallelIterator,
 {
     base: M::State,
-    filter_op: PhantomFilterOp<FILTER_OP>,
+    filter_op: PhantomType<FILTER_OP>,
 }
-
-// Wrapper for `PhantomData` to allow `FilterState` to impl `Send`
-struct PhantomFilterOp<FILTER_OP>(PhantomData<*const FILTER_OP>);
-
-impl<FILTER_OP> PhantomFilterOp<FILTER_OP> {
-    fn new() -> PhantomFilterOp<FILTER_OP> {
-        PhantomFilterOp(PhantomData)
-    }
-}
-
-unsafe impl<FILTER_OP: Sync> Send for PhantomFilterOp<FILTER_OP> { }
 
 unsafe impl<M, FILTER_OP> ParallelIteratorState for FilterState<M, FILTER_OP>
     where M: ParallelIterator,
@@ -72,8 +70,8 @@ unsafe impl<M, FILTER_OP> ParallelIteratorState for FilterState<M, FILTER_OP>
 
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
-        (FilterState { base: left, filter_op: PhantomFilterOp::new() },
-         FilterState { base: right, filter_op: PhantomFilterOp::new() })
+        (FilterState { base: left, filter_op: PhantomType::new() },
+         FilterState { base: right, filter_op: PhantomType::new() })
     }
 
     fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
@@ -83,5 +81,69 @@ unsafe impl<M, FILTER_OP> ParallelIteratorState for FilterState<M, FILTER_OP>
             }
         }
         None
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Consumer implementation
+
+struct FilterConsumer<C, FILTER_OP>
+    where C: Consumer, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+{
+    base: C,
+    filter_op: PhantomType<FILTER_OP>,
+}
+
+impl<C, FILTER_OP> FilterConsumer<C, FILTER_OP>
+    where C: Consumer, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+{
+    fn new(base: C) -> FilterConsumer<C, FILTER_OP> {
+        FilterConsumer { base: base, filter_op: PhantomType::new() }
+    }
+}
+
+struct FilterConsumerShared<C, FILTER_OP>
+    where C: Consumer, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+{
+    base: C::Shared,
+    filter_op: FILTER_OP,
+}
+
+impl<C, FILTER_OP> Consumer for FilterConsumer<C, FILTER_OP>
+    where C: Consumer, FILTER_OP: Fn(&C::Item) -> bool + Sync,
+{
+    type Item = C::Item;
+    type Shared = FilterConsumerShared<C, FILTER_OP>;
+    type SeqState = C::SeqState;
+    type Result = C::Result;
+
+    unsafe fn split_at(self, index: u64) -> (Self, Self) {
+        let (left, right) = self.base.split_at(index);
+        (FilterConsumer::new(left), FilterConsumer::new(right))
+    }
+
+    unsafe fn start(&mut self, shared: &Self::Shared) -> C::SeqState {
+        self.base.start(&shared.base)
+    }
+
+    unsafe fn consume(&mut self,
+                      shared: &Self::Shared,
+                      state: C::SeqState,
+                      item: Self::Item)
+                      -> C::SeqState
+    {
+        if (shared.filter_op)(&item) {
+            self.base.consume(&shared.base, state, item)
+        } else {
+            state
+        }
+    }
+
+    unsafe fn complete(self, shared: &Self::Shared, state: C::SeqState) -> C::Result {
+        self.base.complete(&shared.base, state)
+    }
+
+    unsafe fn reduce(shared: &Self::Shared, left: C::Result, right: C::Result) -> C::Result {
+        C::reduce(&shared.base, left, right)
     }
 }

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -133,8 +133,8 @@ impl<ITEM, C, FILTER_OP> Consumer for FilterMapConsumer<ITEM, C, FILTER_OP>
     type Result = C::Result;
 
     /// Cost to process `items` number of items.
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+        self.base.cost(&shared.base, cost) * FUNC_ADJUSTMENT
     }
 
     unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -2,7 +2,6 @@ use super::*;
 use super::len::*;
 use super::state::*;
 use super::util::PhantomType;
-use std::marker::PhantomData;
 
 pub struct FilterMap<M, FILTER_OP> {
     base: M,
@@ -21,8 +20,6 @@ impl<M, FILTER_OP, R> ParallelIterator for FilterMap<M, FILTER_OP>
           R: Send,
 {
     type Item = R;
-    type Shared = FilterShared<M, FILTER_OP>;
-    type State = FilterState<M, FILTER_OP>;
 
     fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
                                                    consumer: C,
@@ -31,12 +28,6 @@ impl<M, FILTER_OP, R> ParallelIterator for FilterMap<M, FILTER_OP>
         let consumer: FilterMapConsumer<M::Item, C, FILTER_OP> = FilterMapConsumer::new(consumer);
         let shared = (shared, &self.filter_op);
         self.base.drive(consumer, &shared)
-    }
-
-    fn state(self) -> (Self::Shared, Self::State) {
-        let (base_shared, base_state) = self.base.state();
-        (FilterShared { base: base_shared, filter_op: self.filter_op },
-         FilterState { base: base_state, filter_op: PhantomFilterOp::new() })
     }
 }
 
@@ -47,58 +38,6 @@ unsafe impl<M, FILTER_OP, R> BoundedParallelIterator for FilterMap<M, FILTER_OP>
 {
     fn upper_bound(&mut self) -> usize {
         self.base.upper_bound()
-    }
-}
-
-pub struct FilterShared<M, FILTER_OP>
-    where M: ParallelIterator,
-{
-    base: M::Shared,
-    filter_op: FILTER_OP,
-}
-
-pub struct FilterState<M, FILTER_OP>
-    where M: ParallelIterator,
-{
-    base: M::State,
-    filter_op: PhantomFilterOp<FILTER_OP>,
-}
-
-// Wrapper for `PhantomData` to allow `FilterState` to impl `Send`
-struct PhantomFilterOp<FILTER_OP>(PhantomData<*const FILTER_OP>);
-
-impl<FILTER_OP> PhantomFilterOp<FILTER_OP> {
-    fn new() -> PhantomFilterOp<FILTER_OP> {
-        PhantomFilterOp(PhantomData)
-    }
-}
-
-unsafe impl<FILTER_OP: Sync> Send for PhantomFilterOp<FILTER_OP> { }
-
-unsafe impl<M, FILTER_OP, R> ParallelIteratorState for FilterState<M, FILTER_OP>
-    where M: ParallelIterator,
-          FILTER_OP: Fn(M::Item) -> Option<R> + Sync
-{
-    type Item = R;
-    type Shared = FilterShared<M, FILTER_OP>;
-
-    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
-        self.base.len(&shared.base)
-    }
-
-    fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.base.split_at(index);
-        (FilterState { base: left, filter_op: PhantomFilterOp::new() },
-         FilterState { base: right, filter_op: PhantomFilterOp::new() })
-    }
-
-    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
-        while let Some(base) = self.base.next(&shared.base) {
-            if let Some(mapped) = (shared.filter_op)(base) {
-                return Some(mapped);
-            }
-        }
-        None
     }
 }
 

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -21,13 +21,13 @@ impl<M, FILTER_OP, R> ParallelIterator for FilterMap<M, FILTER_OP>
 {
     type Item = R;
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {
         let consumer: FilterMapConsumer<M::Item, C, FILTER_OP> = FilterMapConsumer::new(consumer);
         let shared = (shared, &self.filter_op);
-        self.base.drive_stateless(consumer, &shared)
+        self.base.drive_unindexed(consumer, &shared)
     }
 }
 
@@ -112,8 +112,8 @@ impl<'f, 'c, ITEM, C, FILTER_OP> Consumer<'f> for FilterMapConsumer<'c, ITEM, C,
     }
 }
 
-impl<'f, 'c, ITEM, C, FILTER_OP> StatelessConsumer<'f> for FilterMapConsumer<'c, ITEM, C, FILTER_OP>
-    where C: StatelessConsumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, ITEM: 'f, FILTER_OP: 'f, 'c: 'f
+impl<'f, 'c, ITEM, C, FILTER_OP> UnindexedConsumer<'f> for FilterMapConsumer<'c, ITEM, C, FILTER_OP>
+    where C: UnindexedConsumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, ITEM: 'f, FILTER_OP: 'f, 'c: 'f
 {
     fn split(&self) -> Self {
         FilterMapConsumer::new(self.base.split())

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::len::*;
-use super::state::*;
+use super::internal::*;
 use super::util::PhantomType;
 
 pub struct FilterMap<M, FILTER_OP> {

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -53,23 +53,23 @@ unsafe impl<M, FILTER_OP, R> BoundedParallelIterator for FilterMap<M, FILTER_OP>
 ///////////////////////////////////////////////////////////////////////////
 // Consumer implementation
 
-struct FilterMapConsumer<'f, 'c, ITEM, C, FILTER_OP>
-    where C: Consumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, 'c: 'f
+struct FilterMapConsumer<'c, ITEM, C, FILTER_OP>
+    where C: Consumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync,
 {
     base: C,
-    phantoms: PhantomType<(&'f &'c (), ITEM, FILTER_OP)>,
+    phantoms: PhantomType<(&'c (), ITEM, FILTER_OP)>,
 }
 
-impl<'f, 'c, ITEM, C, FILTER_OP> FilterMapConsumer<'f, 'c, ITEM, C, FILTER_OP>
-    where C: Consumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, 'c: 'f
+impl<'c, ITEM, C, FILTER_OP> FilterMapConsumer<'c, ITEM, C, FILTER_OP>
+    where C: Consumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync,
 {
-    fn new(base: C) -> FilterMapConsumer<'f, 'c, ITEM, C, FILTER_OP> {
+    fn new(base: C) -> FilterMapConsumer<'c, ITEM, C, FILTER_OP> {
         FilterMapConsumer { base: base, phantoms: PhantomType::new() }
     }
 }
 
-impl<'f, 'c, ITEM, C, FILTER_OP> Consumer<'f> for FilterMapConsumer<'f, 'c, ITEM, C, FILTER_OP>
-    where C: Consumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, ITEM: 'f, FILTER_OP: 'f,
+impl<'f, 'c, ITEM, C, FILTER_OP> Consumer<'f> for FilterMapConsumer<'c, ITEM, C, FILTER_OP>
+    where C: Consumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, ITEM: 'f, FILTER_OP: 'f, 'c: 'f
 {
     type Item = ITEM;
     type Shared = (&'c C::Shared, &'f FILTER_OP);
@@ -112,8 +112,8 @@ impl<'f, 'c, ITEM, C, FILTER_OP> Consumer<'f> for FilterMapConsumer<'f, 'c, ITEM
     }
 }
 
-impl<'f, 'c, ITEM, C, FILTER_OP> StatelessConsumer<'f> for FilterMapConsumer<'f, 'c, ITEM, C, FILTER_OP>
-    where C: StatelessConsumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, ITEM: 'f, FILTER_OP: 'f,
+impl<'f, 'c, ITEM, C, FILTER_OP> StatelessConsumer<'f> for FilterMapConsumer<'c, ITEM, C, FILTER_OP>
+    where C: StatelessConsumer<'c>, FILTER_OP: Fn(ITEM) -> Option<C::Item> + Sync, ITEM: 'f, FILTER_OP: 'f, 'c: 'f
 {
     fn split(&self) -> Self {
         FilterMapConsumer::new(self.base.split())

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -41,7 +41,7 @@ unsafe impl<M, FILTER_OP, R> BoundedParallelIterator for FilterMap<M, FILTER_OP>
           FILTER_OP: Fn(M::Item) -> Option<R> + Sync,
           R: Send,
 {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 }
@@ -132,7 +132,7 @@ impl<ITEM, C, FILTER_OP> Consumer for FilterMapConsumer<ITEM, C, FILTER_OP>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn split_at(self, index: u64) -> (Self, Self) {
+    unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (FilterMapConsumer::new(left), FilterMapConsumer::new(right))
     }

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::len::ParallelLen;
+use super::len::*;
 use super::state::*;
 use super::util::PhantomType;
 use std::marker::PhantomData;
@@ -132,8 +132,13 @@ impl<ITEM, C, FILTER_OP> Consumer for FilterMapConsumer<ITEM, C, FILTER_OP>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.base.split_at(index);
+    /// Cost to process `items` number of items.
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    }
+
+    unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(&shared.base, index);
         (FilterMapConsumer::new(left), FilterMapConsumer::new(right))
     }
 

--- a/src/par_iter/flat_map.rs
+++ b/src/par_iter/flat_map.rs
@@ -1,0 +1,126 @@
+use super::*;
+use super::state::*;
+use super::util::PhantomType;
+use std::f64;
+
+pub struct FlatMap<M, MAP_OP> {
+    base: M,
+    map_op: MAP_OP,
+}
+
+impl<M, MAP_OP> FlatMap<M, MAP_OP> {
+    pub fn new(base: M, map_op: MAP_OP) -> FlatMap<M, MAP_OP> {
+        FlatMap { base: base, map_op: map_op }
+    }
+}
+
+impl<M, MAP_OP, PI> ParallelIterator for FlatMap<M, MAP_OP>
+    where M: ParallelIterator,
+          MAP_OP: Fn(M::Item) -> PI + Sync,
+          PI: ParallelIterator,
+{
+    type Item = PI::Item;
+
+    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                      consumer: C,
+                                                                      shared: &'c C::Shared)
+                                                                      -> C::Result {
+        let consumer = FlatMapConsumer { base: consumer, phantoms: PhantomType::new() };
+        self.base.drive_stateless(consumer, &(shared, &self.map_op))
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Consumer implementation
+
+struct FlatMapConsumer<'c, ITEM, C, MAP_OP, PI>
+    where C: StatelessConsumer<'c>,
+          MAP_OP: Fn(ITEM) -> PI + Sync,
+          PI: ParallelIterator<Item=C::Item>,
+          C::Item: Send,
+{
+    base: C,
+    phantoms: PhantomType<(&'c (), ITEM, MAP_OP)>,
+}
+
+impl<'c, ITEM, C, MAP_OP, PI> FlatMapConsumer<'c, ITEM, C, MAP_OP, PI>
+    where C: StatelessConsumer<'c>,
+          MAP_OP: Fn(ITEM) -> PI + Sync,
+          PI: ParallelIterator<Item=C::Item>,
+          C::Item: Send,
+{
+    fn new(base: C) -> FlatMapConsumer<'c, ITEM, C, MAP_OP, PI> {
+        FlatMapConsumer { base: base, phantoms: PhantomType::new() }
+    }
+}
+
+impl<'c, 'm, ITEM, C, MAP_OP, PI> Consumer<'m> for FlatMapConsumer<'c, ITEM, C, MAP_OP, PI>
+    where C: StatelessConsumer<'c>,
+          MAP_OP: Fn(ITEM) -> PI + Sync + 'm,
+          PI: ParallelIterator<Item=C::Item>,
+          C::Item: Send,
+          ITEM: 'm,
+          'c: 'm,
+{
+    type Item = ITEM;
+    type Shared = (&'c C::Shared, &'m MAP_OP);
+    type SeqState = Option<C::Result>;
+    type Result = C::Result;
+
+    fn cost(&mut self, _shared: &Self::Shared, _cost: f64) -> f64 {
+        // We have no idea how many items we will produce, so ramp up
+        // the cost, so as to encourage the producer to do a
+        // fine-grained divison. This is not necessarily a good
+        // policy.
+        f64::INFINITY
+    }
+
+    unsafe fn split_at(self, _shared: &Self::Shared, _index: usize) -> (Self, Self) {
+        (FlatMapConsumer::new(self.base.split()), FlatMapConsumer::new(self.base.split()))
+    }
+
+    unsafe fn start(&mut self, _shared: &Self::Shared) -> Option<C::Result> {
+        None
+    }
+
+    unsafe fn consume(&mut self,
+                      shared: &Self::Shared,
+                      previous: Option<C::Result>,
+                      item: Self::Item)
+                      -> Option<C::Result>
+    {
+        let par_iter = (shared.1)(item).into_par_iter();
+        let result = par_iter.drive_stateless(self.base.split(), &shared.0);
+
+        // We expect that `previous` is `None`, because we drive
+        // the cost up so high, but just in case.
+        match previous {
+            Some(previous) => Some(C::reduce(&shared.0, result, previous)),
+            None => Some(result),
+        }
+    }
+
+    unsafe fn complete(self, _shared: &Self::Shared, state: Option<C::Result>) -> C::Result {
+        // should have processed at least one item -- but is this
+        // really a fair assumption?
+        state.unwrap()
+    }
+
+    unsafe fn reduce(shared: &Self::Shared, left: C::Result, right: C::Result) -> C::Result {
+        C::reduce(&shared.0, left, right)
+    }
+}
+
+impl<'c, 'm, ITEM, C, MAP_OP, PI> StatelessConsumer<'m> for FlatMapConsumer<'c, ITEM, C, MAP_OP, PI>
+    where C: StatelessConsumer<'c>,
+          MAP_OP: Fn(ITEM) -> PI + Sync + 'm,
+          PI: ParallelIterator<Item=C::Item>,
+          C::Item: Send,
+          ITEM: 'm,
+          'c: 'm,
+{
+    fn split(&self) -> Self {
+        FlatMapConsumer::new(self.base.split())
+    }
+}
+

--- a/src/par_iter/flat_map.rs
+++ b/src/par_iter/flat_map.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 use super::util::PhantomType;
 use std::f64;
 

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -9,7 +9,7 @@ pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
           T: Send,
 {
     let consumer: ForEachConsumer<PAR_ITER::Item, OP> = ForEachConsumer { data: PhantomType::new() };
-    pi.drive_stateless(consumer, op)
+    pi.drive_unindexed(consumer, op)
 }
 
 struct ForEachConsumer<ITEM, OP>
@@ -54,7 +54,7 @@ impl<'c, ITEM, OP> Consumer<'c> for ForEachConsumer<ITEM, OP>
     }
 }
 
-impl<'c, ITEM, OP> StatelessConsumer<'c> for ForEachConsumer<ITEM, OP>
+impl<'c, ITEM, OP> UnindexedConsumer<'c> for ForEachConsumer<ITEM, OP>
     where OP: Fn(ITEM) + Sync + 'c, ITEM: 'c,
 {
     fn split(&self) -> Self {

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -1,6 +1,6 @@
 use super::ParallelIterator;
 use super::len::*;
-use super::state::*;
+use super::internal::*;
 use super::util::*;
 
 pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -1,4 +1,3 @@
-use api::join;
 use super::ParallelIterator;
 use super::len::*;
 use super::state::*;
@@ -6,32 +5,11 @@ use super::util::*;
 
 pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
     where PAR_ITER: ParallelIterator<Item=T>,
-          PAR_ITER::State: Send,
           OP: Fn(T) + Sync,
           T: Send,
 {
     let consumer: ForEachConsumer<PAR_ITER::Item, OP> = ForEachConsumer { data: PhantomType::new() };
     pi.drive(consumer, op)
-}
-
-fn for_each_helper<STATE,OP,T>(mut state: STATE,
-                               shared: &STATE::Shared,
-                               len: ParallelLen,
-                               op: &OP)
-    where STATE: ParallelIteratorState<Item=T> + Send,
-          OP: Fn(T) + Sync,
-          T: Send,
-{
-    if len.cost > THRESHOLD && len.maximal_len > 1 {
-        let mid = len.maximal_len / 2;
-        let (left, right) = state.split_at(mid);
-        join(|| for_each_helper(left, shared, len.left_cost(mid), op),
-             || for_each_helper(right, shared, len.right_cost(mid), op));
-    } else {
-        while let Some(item) = state.next(shared) {
-            op(item);
-        }
-    }
 }
 
 struct ForEachConsumer<ITEM, OP>
@@ -59,7 +37,7 @@ impl<'c, ITEM, OP> Consumer<'c> for ForEachConsumer<ITEM, OP>
     type SeqState = ();
     type Result = ();
 
-    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+    fn cost(&mut self, _shared: &Self::Shared, cost: f64) -> f64 {
         // This isn't quite right, as we will do more than O(n) reductions, but whatever.
         cost * FUNC_ADJUSTMENT
     }
@@ -73,16 +51,16 @@ impl<'c, ITEM, OP> Consumer<'c> for ForEachConsumer<ITEM, OP>
 
     unsafe fn consume(&mut self,
                       op: &OP,
-                      prev_value: (),
+                      _prev_value: (),
                       item: ITEM) {
         op(item);
     }
 
     unsafe fn complete(self,
                        _op: &OP,
-                       state: ()) {
+                       _state: ()) {
     }
 
-    unsafe fn reduce(reduce_op: &OP, a: (), b: ()) {
+    unsafe fn reduce(_reduce_op: &OP, _: (), _: ()) {
     }
 }

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -1,7 +1,8 @@
 use api::join;
 use super::ParallelIterator;
-use super::len::{ParallelLen, THRESHOLD};
-use super::state::ParallelIteratorState;
+use super::len::*;
+use super::state::*;
+use super::util::*;
 
 pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
     where PAR_ITER: ParallelIterator<Item=T>,
@@ -9,9 +10,8 @@ pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
           OP: Fn(T) + Sync,
           T: Send,
 {
-    let (shared, mut state) = pi.state();
-    let len = state.len(&shared);
-    for_each_helper(state, &shared, len, op)
+    let consumer: ForEachConsumer<PAR_ITER::Item, OP> = ForEachConsumer { data: PhantomType::new() };
+    pi.drive(consumer, op)
 }
 
 fn for_each_helper<STATE,OP,T>(mut state: STATE,
@@ -34,3 +34,55 @@ fn for_each_helper<STATE,OP,T>(mut state: STATE,
     }
 }
 
+struct ForEachConsumer<ITEM, OP>
+    where OP: Fn(ITEM) + Sync,
+{
+    data: PhantomType<(ITEM, OP)>
+}
+
+impl<ITEM, OP> Copy for ForEachConsumer<ITEM, OP>
+    where OP: Fn(ITEM) + Sync,
+{
+}
+
+impl<ITEM, OP> Clone for ForEachConsumer<ITEM, OP>
+    where OP: Fn(ITEM) + Sync,
+{
+    fn clone(&self) -> Self { *self }
+}
+
+impl<'c, ITEM, OP> Consumer<'c> for ForEachConsumer<ITEM, OP>
+    where OP: Fn(ITEM) + Sync + 'c, ITEM: 'c,
+{
+    type Item = ITEM;
+    type Shared = OP;
+    type SeqState = ();
+    type Result = ();
+
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+        // This isn't quite right, as we will do more than O(n) reductions, but whatever.
+        cost * FUNC_ADJUSTMENT
+    }
+
+    unsafe fn split_at(self, _: &Self::Shared, _index: usize) -> (Self, Self) {
+        (self, self)
+    }
+
+    unsafe fn start(&mut self, _reduce_op: &OP) {
+    }
+
+    unsafe fn consume(&mut self,
+                      op: &OP,
+                      prev_value: (),
+                      item: ITEM) {
+        op(item);
+    }
+
+    unsafe fn complete(self,
+                       _op: &OP,
+                       state: ()) {
+    }
+
+    unsafe fn reduce(reduce_op: &OP, a: (), b: ()) {
+    }
+}

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -1,3 +1,7 @@
+//! Internal traits and functions used to implement parallel
+//! iteration. These should be considered highly unstable: users of
+//! parallel iterators should not need to interact with them directly.
+
 use join;
 use super::IndexedParallelIterator;
 use super::len::*;

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -1,6 +1,7 @@
 //! Internal traits and functions used to implement parallel
 //! iteration. These should be considered highly unstable: users of
 //! parallel iterators should not need to interact with them directly.
+//! See `README.md` for a high-level overview.
 
 use join;
 use super::IndexedParallelIterator;

--- a/src/par_iter/len.rs
+++ b/src/par_iter/len.rs
@@ -34,3 +34,7 @@ impl ParallelLen {
 // The threshold cost where it is worth falling back to sequential.
 // This may be tweaked over time!
 pub const THRESHOLD: f64 = 10. * 1024.0;
+
+// The default is to assume that each function we execute (e.g., map,
+// filter) takes an additional 5% of time per item.
+pub const FUNC_ADJUSTMENT: f64 = 1.05;

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -2,7 +2,6 @@ use super::*;
 use super::len::*;
 use super::state::*;
 use super::util::PhantomType;
-use std::marker::PhantomData;
 
 pub struct Map<M, MAP_OP> {
     base: M,
@@ -21,8 +20,6 @@ impl<M, MAP_OP, R> ParallelIterator for Map<M, MAP_OP>
           R: Send,
 {
     type Item = R;
-    type Shared = MapShared<M, MAP_OP>;
-    type State = MapState<M, MAP_OP>;
 
     fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
                                                    consumer: C,
@@ -31,12 +28,6 @@ impl<M, MAP_OP, R> ParallelIterator for Map<M, MAP_OP>
         let consumer1: MapConsumer<M::Item, C, MAP_OP> = MapConsumer::new(consumer);
         let shared1 = (shared, &self.map_op);
         self.base.drive(consumer1, &shared1)
-    }
-
-    fn state(self) -> (Self::Shared, Self::State) {
-        let (base_shared, base_state) = self.base.state();
-        (MapShared { base: base_shared, map_op: self.map_op },
-         MapState { base: base_state, map_op: PhantomMapOp::new() })
     }
 }
 
@@ -71,54 +62,6 @@ impl<M, MAP_OP, R, P> PullParallelIterator for Map<M, MAP_OP>
     fn into_producer(self) -> (Self::Producer, (P::Shared, MAP_OP)) {
         let (base, shared) = self.base.into_producer();
         (MapProducer { base: base, phantoms: PhantomType::new() }, (shared, self.map_op))
-    }
-}
-
-pub struct MapShared<M, MAP_OP>
-    where M: ParallelIterator,
-{
-    base: M::Shared,
-    map_op: MAP_OP,
-}
-
-pub struct MapState<M, MAP_OP>
-    where M: ParallelIterator,
-{
-    base: M::State,
-    map_op: PhantomMapOp<MAP_OP>,
-}
-
-// Wrapper for `PhantomData` to allow `MapState` to impl `Send`
-struct PhantomMapOp<MAP_OP>(PhantomData<*const MAP_OP>);
-
-impl<MAP_OP> PhantomMapOp<MAP_OP> {
-    fn new() -> PhantomMapOp<MAP_OP> {
-        PhantomMapOp(PhantomData)
-    }
-}
-
-unsafe impl<MAP_OP: Sync> Send for PhantomMapOp<MAP_OP> { }
-
-unsafe impl<M, MAP_OP, R> ParallelIteratorState for MapState<M, MAP_OP>
-    where M: ParallelIterator,
-          MAP_OP: Fn(M::Item) -> R + Sync,
-{
-    type Item = R;
-    type Shared = MapShared<M, MAP_OP>;
-
-    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
-        self.base.len(&shared.base)
-    }
-
-    fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.base.split_at(index);
-        (MapState { base: left, map_op: PhantomMapOp::new() },
-         MapState { base: right, map_op: PhantomMapOp::new() })
-    }
-
-    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
-        self.base.next(&shared.base)
-                 .map(|base| (shared.map_op)(base))
     }
 }
 

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::len::ParallelLen;
+use super::len::*;
 use super::state::*;
 use super::util::PhantomType;
 use std::marker::PhantomData;
@@ -184,8 +184,12 @@ impl<ITEM, C, MAP_OP> Consumer for MapConsumer<ITEM, C, MAP_OP>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.base.split_at(index);
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    }
+
+    unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(&shared.base, index);
         (MapConsumer::new(left), MapConsumer::new(right))
     }
 

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -39,7 +39,7 @@ unsafe impl<M, MAP_OP, R> BoundedParallelIterator for Map<M, MAP_OP>
           MAP_OP: Fn(M::Item) -> R + Sync,
           R: Send,
 {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 }
@@ -49,7 +49,7 @@ unsafe impl<M, MAP_OP, R> ExactParallelIterator for Map<M, MAP_OP>
           MAP_OP: Fn(M::Item) -> R + Sync,
           R: Send,
 {
-    fn len(&mut self) -> u64 {
+    fn len(&mut self) -> usize {
         self.base.len()
     }
 }

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -138,6 +138,10 @@ impl<M, MAP_OP, R> Producer for MapProducer<M, MAP_OP, R>
     type Item = R;
     type Shared = MapProducerShared<M, MAP_OP, R>;
 
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    }
+
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (MapProducer { base: left, phantoms: PhantomType::new() },

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -40,7 +40,11 @@ unsafe impl<M, MAP_OP, R> ExactParallelIterator for Map<M, MAP_OP>
     where M: ExactParallelIterator,
           MAP_OP: Fn(M::Item) -> R + Sync,
           R: Send,
-{}
+{
+    fn len(&mut self) -> u64 {
+        self.base.len()
+    }
+}
 
 pub struct MapShared<M, MAP_OP>
     where M: ParallelIterator,

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -130,7 +130,6 @@ impl<M, MAP_OP, R> Producer for MapProducer<M, MAP_OP, R>
 {
     type Item = R;
     type Shared = MapProducerShared<M, MAP_OP, R>;
-    type SeqState = M::SeqState;
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
@@ -138,22 +137,8 @@ impl<M, MAP_OP, R> Producer for MapProducer<M, MAP_OP, R>
          MapProducer { base: right, phantoms: PhantomType::new() })
     }
 
-    unsafe fn start(&mut self, shared: &Self::Shared) -> M::SeqState {
-        self.base.start(&shared.base)
-    }
-
-    unsafe fn produce(&mut self,
-                      shared: &Self::Shared,
-                      state: &mut M::SeqState)
-                      -> R
-    {
-        let item = self.base.produce(&shared.base, state);
+    unsafe fn produce(&mut self, shared: &Self::Shared) -> R {
+        let item = self.base.produce(&shared.base);
         (shared.map_op)(item)
-    }
-
-    unsafe fn complete(self,
-                       shared: &Self::Shared,
-                       state: M::SeqState) {
-        self.base.complete(&shared.base, state)
     }
 }

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -55,6 +55,13 @@ unsafe impl<M, MAP_OP, R> ExactParallelIterator for Map<M, MAP_OP>
     }
 }
 
+impl<M, MAP_OP, R> PullParallelIterator for Map<M, MAP_OP>
+    where M: PullParallelIterator,
+          MAP_OP: Fn(M::Item) -> R + Sync,
+          R: Send,
+{
+}
+
 pub struct MapShared<M, MAP_OP>
     where M: ParallelIterator,
 {

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::len::*;
-use super::state::*;
+use super::internal::*;
 use super::util::PhantomType;
 
 pub struct Map<M, MAP_OP> {

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -21,13 +21,13 @@ impl<M, MAP_OP, R> ParallelIterator for Map<M, MAP_OP>
 {
     type Item = R;
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {
         let consumer1: MapConsumer<M::Item, C, MAP_OP> = MapConsumer::new(consumer);
         let shared1 = (shared, &self.map_op);
-        self.base.drive_stateless(consumer1, &shared1)
+        self.base.drive_unindexed(consumer1, &shared1)
     }
 }
 
@@ -171,8 +171,8 @@ impl<'m, 'c, ITEM, C, MAP_OP> Consumer<'m> for MapConsumer<'c, ITEM, C, MAP_OP>
     }
 }
 
-impl<'m, 'c, ITEM, C, MAP_OP> StatelessConsumer<'m> for MapConsumer<'c, ITEM, C, MAP_OP>
-    where C: StatelessConsumer<'c>,
+impl<'m, 'c, ITEM, C, MAP_OP> UnindexedConsumer<'m> for MapConsumer<'c, ITEM, C, MAP_OP>
+    where C: UnindexedConsumer<'c>,
           MAP_OP: Fn(ITEM) -> C::Item + Sync,
           ITEM: 'm,
           MAP_OP: 'm,

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -136,8 +136,8 @@ impl<M, MAP_OP, R> Producer for MapProducer<M, MAP_OP, R>
     type Item = R;
     type Shared = (M::Shared, MAP_OP);
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        self.base.cost(&shared.0, items) * FUNC_ADJUSTMENT
+    fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
+        self.base.cost(&shared.0, len) * FUNC_ADJUSTMENT
     }
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
@@ -186,8 +186,8 @@ impl<ITEM, C, MAP_OP> Consumer for MapConsumer<ITEM, C, MAP_OP>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        self.base.cost(&shared.base, items) * FUNC_ADJUSTMENT
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+        self.base.cost(&shared.base, cost) * FUNC_ADJUSTMENT
     }
 
     unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -60,8 +60,8 @@ unsafe impl<M, MAP_OP, R> ExactParallelIterator for Map<M, MAP_OP>
     }
 }
 
-impl<M, MAP_OP, R, P> PullParallelIterator for Map<M, MAP_OP>
-    where M: PullParallelIterator<Producer=P>,
+impl<M, MAP_OP, R, P> IndexedParallelIterator for Map<M, MAP_OP>
+    where M: IndexedParallelIterator<Producer=P>,
           MAP_OP: Fn(M::Item) -> R + Sync,
           R: Send,
           P: Producer<Item=M::Item>,

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -112,26 +112,27 @@ impl<M, MAP_OP, R> Producer for MapProducer<M, MAP_OP, R>
 ///////////////////////////////////////////////////////////////////////////
 // Consumer implementation
 
-struct MapConsumer<'m, 'c, ITEM, C, MAP_OP>
-    where C: Consumer<'c>, MAP_OP: Fn(ITEM) -> C::Item + Sync, 'c: 'm
+struct MapConsumer<'c, ITEM, C, MAP_OP>
+    where C: Consumer<'c>, MAP_OP: Fn(ITEM) -> C::Item + Sync,
 {
     base: C,
-    phantoms: PhantomType<(&'m &'c (), ITEM, MAP_OP)>,
+    phantoms: PhantomType<(&'c (), ITEM, MAP_OP)>,
 }
 
-impl<'m, 'c, ITEM, C, MAP_OP> MapConsumer<'m, 'c, ITEM, C, MAP_OP>
-    where C: Consumer<'c>, MAP_OP: Fn(ITEM) -> C::Item + Sync, 'm: 'c
+impl<'c, ITEM, C, MAP_OP> MapConsumer<'c, ITEM, C, MAP_OP>
+    where C: Consumer<'c>, MAP_OP: Fn(ITEM) -> C::Item + Sync,
 {
-    fn new(base: C) -> MapConsumer<'m, 'c, ITEM, C, MAP_OP> {
+    fn new(base: C) -> MapConsumer<'c, ITEM, C, MAP_OP> {
         MapConsumer { base: base, phantoms: PhantomType::new() }
     }
 }
 
-impl<'m, 'c, ITEM, C, MAP_OP> Consumer<'m> for MapConsumer<'m, 'c, ITEM, C, MAP_OP>
+impl<'m, 'c, ITEM, C, MAP_OP> Consumer<'m> for MapConsumer<'c, ITEM, C, MAP_OP>
     where C: Consumer<'c>,
           MAP_OP: Fn(ITEM) -> C::Item + Sync,
           ITEM: 'm,
           MAP_OP: 'm,
+          'c: 'm,
 {
     type Item = ITEM;
     type Shared = (&'c C::Shared, &'m MAP_OP);
@@ -170,11 +171,12 @@ impl<'m, 'c, ITEM, C, MAP_OP> Consumer<'m> for MapConsumer<'m, 'c, ITEM, C, MAP_
     }
 }
 
-impl<'m, 'c, ITEM, C, MAP_OP> StatelessConsumer<'m> for MapConsumer<'m, 'c, ITEM, C, MAP_OP>
+impl<'m, 'c, ITEM, C, MAP_OP> StatelessConsumer<'m> for MapConsumer<'c, ITEM, C, MAP_OP>
     where C: StatelessConsumer<'c>,
           MAP_OP: Fn(ITEM) -> C::Item + Sync,
           ITEM: 'm,
           MAP_OP: 'm,
+          'c: 'm,
 {
     fn split(&self) -> Self {
         MapConsumer::new(self.base.split())

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -18,7 +18,7 @@ use self::filter_map::FilterMap;
 use self::map::Map;
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    SUM, MUL, MIN, MAX};
-use self::state::{Consumer, ParallelIteratorState, Producer};
+use self::state::{Consumer, Producer};
 use self::weight::Weight;
 use self::zip::ZipIter;
 
@@ -65,10 +65,6 @@ pub trait IntoParallelRefMutIterator<'data> {
 /// The `ParallelIterator` interface.
 pub trait ParallelIterator: Sized {
     type Item: Send;
-    type Shared: Sync;
-    type State: ParallelIteratorState<Shared=Self::Shared, Item=Self::Item> + Send;
-
-    fn state(self) -> (Self::Shared, Self::State);
 
     /// Internal method used to define the behavior of this parallel
     /// iterator. You should not need to call this directly.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -15,6 +15,7 @@ use self::collect::collect_into;
 use self::enumerate::Enumerate;
 use self::filter::Filter;
 use self::filter_map::FilterMap;
+use self::flat_map::FlatMap;
 use self::map::Map;
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    SUM, MUL, MIN, MAX};
@@ -118,6 +119,14 @@ pub trait ParallelIterator: Sized {
         where FILTER_OP: Fn(Self::Item) -> Option<R>
     {
         FilterMap::new(self, filter_op)
+    }
+
+    /// Applies `map_op` to each item of his iterator, producing a new
+    /// iterator with the results.
+    fn flat_map<MAP_OP,PI>(self, map_op: MAP_OP) -> FlatMap<Self, MAP_OP>
+        where MAP_OP: Fn(Self::Item) -> PI, PI: ParallelIterator
+    {
+        FlatMap::new(self, map_op)
     }
 
     /// Reduces the items in the iterator into one item using `op`.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -7,7 +7,9 @@
 //! the various traits and methods you need.
 //!
 //! The submodules of this module mostly just contain implementaton
-//! details of little interest to an end-user.
+//! details of little interest to an end-user. If you'd like to read
+//! the code itself, the `internals` module and `README.md` file are a
+//! good place to start.
 
 use std::f64;
 use std::ops::Fn;

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -138,7 +138,7 @@ pub trait ParallelIterator: Sized {
     fn reduce_with<OP>(self, op: OP) -> Option<Self::Item>
         where OP: Fn(Self::Item, Self::Item) -> Self::Item + Sync,
     {
-        reduce(self.map(Some), &ReduceWithOp::new(op))
+        reduce(self.map(Some), ReduceWithOp::new(op))
     }
 
     /// Sums up the items in the iterator.
@@ -195,7 +195,7 @@ pub trait ParallelIterator: Sized {
     /// Note that the order in items will be reduced is not specified,
     /// so if the `reduce_op` impl is not truly commutative and
     /// associative, then the results are not deterministic.
-    fn reduce<REDUCE_OP>(self, reduce_op: &REDUCE_OP) -> Self::Item
+    fn reduce<REDUCE_OP>(self, reduce_op: REDUCE_OP) -> Self::Item
         where REDUCE_OP: ReduceOp<Self::Item>
     {
         reduce(self, reduce_op)

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -205,6 +205,7 @@ pub trait ParallelIterator: Sized {
 
     /// Internal method used to define the behavior of this parallel
     /// iterator. You should not need to call this directly.
+    #[doc(hidden)]
     fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
@@ -235,6 +236,7 @@ pub unsafe trait BoundedParallelIterator: ParallelIterator {
 
     /// Internal method used to define the behavior of this parallel
     /// iterator. You should not need to call this directly.
+    #[doc(hidden)]
     fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
                                                    consumer: C,
                                                    shared: &'c C::Shared)
@@ -279,11 +281,13 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
 pub trait PullParallelIterator: ExactParallelIterator {
     /// Producer type that this iterator creates. Users of the API
     /// never need to know about this type.
+    #[doc(hidden)]
     type Producer: Producer<Item=Self::Item>;
 
     /// Internal method to convert this parallel iterator into a
     /// producer that can be used to request the items. Users of the
     /// API never need to know about this fn.
+    #[doc(hidden)]
     fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared);
 
     /// Iterate over tuples `(A, B)`, where the items `A` are from

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -222,7 +222,7 @@ impl<T: ParallelIterator> IntoParallelIterator for T {
 /// code relies on the fact that the estimated length is an upper
 /// bound in order to guarantee safety invariants.
 pub unsafe trait BoundedParallelIterator: ParallelIterator {
-    fn upper_bound(&mut self) -> u64;
+    fn upper_bound(&mut self) -> usize;
 }
 
 /// A trait for parallel iterators items where the precise number of
@@ -245,7 +245,7 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
     ///
     /// Returning an incorrect value here could lead to **undefined
     /// behavior**.
-    fn len(&mut self) -> u64;
+    fn len(&mut self) -> usize;
 
     /// Iterate over tuples `(A, B)`, where the items `A` are from
     /// this iterator and `B` are from the iterator given as argument.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -278,7 +278,7 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
 /// An iterator that supports "random access" to its data, meaning
 /// that you can split it at arbitrary indices and draw data from
 /// those points.
-pub trait PullParallelIterator: ExactParallelIterator {
+pub trait IndexedParallelIterator: ExactParallelIterator {
     /// Producer type that this iterator creates. Users of the API
     /// never need to know about this type.
     #[doc(hidden)]
@@ -296,7 +296,7 @@ pub trait PullParallelIterator: ExactParallelIterator {
     /// iterators are of unequal length, you only get the items they
     /// have in common.
     fn zip<ZIP_OP>(self, zip_op: ZIP_OP) -> ZipIter<Self, ZIP_OP::Iter>
-        where ZIP_OP: IntoParallelIterator, ZIP_OP::Iter: PullParallelIterator
+        where ZIP_OP: IntoParallelIterator, ZIP_OP::Iter: IndexedParallelIterator
     {
         ZipIter::new(self, zip_op.into_par_iter())
     }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -247,22 +247,6 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
     /// behavior**.
     fn len(&mut self) -> usize;
 
-    /// Iterate over tuples `(A, B)`, where the items `A` are from
-    /// this iterator and `B` are from the iterator given as argument.
-    /// Like the `zip` method on ordinary iterators, if the two
-    /// iterators are of unequal length, you only get the items they
-    /// have in common.
-    fn zip<ZIP_OP>(self, zip_op: ZIP_OP) -> ZipIter<Self, ZIP_OP::Iter>
-        where ZIP_OP: IntoParallelIterator, ZIP_OP::Iter: ExactParallelIterator
-    {
-        ZipIter::new(self, zip_op.into_par_iter())
-    }
-
-    /// Yields an index along with each item.
-    fn enumerate(self) -> Enumerate<Self> {
-        Enumerate::new(self)
-    }
-
     /// Collects the results of the iterator into the specified
     /// vector. The vector is always truncated before execution
     /// begins. If possible, reusing the vector across calls can lead
@@ -272,5 +256,24 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
     }
 }
 
+/// An iterator that supports "random access" to its data, meaning
+/// that you can split it at arbitrary indices and draw data from
+/// those points.
+pub trait PullParallelIterator: ExactParallelIterator {
+    /// Iterate over tuples `(A, B)`, where the items `A` are from
+    /// this iterator and `B` are from the iterator given as argument.
+    /// Like the `zip` method on ordinary iterators, if the two
+    /// iterators are of unequal length, you only get the items they
+    /// have in common.
+    fn zip<ZIP_OP>(self, zip_op: ZIP_OP) -> ZipIter<Self, ZIP_OP::Iter>
+        where ZIP_OP: IntoParallelIterator, ZIP_OP::Iter: PullParallelIterator
+    {
+        ZipIter::new(self, zip_op.into_par_iter())
+    }
 
+    /// Yields an index along with each item.
+    fn enumerate(self) -> Enumerate<Self> {
+        Enumerate::new(self)
+    }
+}
 

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -19,7 +19,7 @@ use self::flat_map::FlatMap;
 use self::map::Map;
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    SUM, MUL, MIN, MAX};
-use self::state::*;
+use self::internal::*;
 use self::weight::Weight;
 use self::zip::ZipIter;
 
@@ -28,12 +28,12 @@ pub mod enumerate;
 pub mod filter;
 pub mod filter_map;
 pub mod flat_map;
+pub mod internal;
 pub mod len;
 pub mod for_each;
 pub mod reduce;
 pub mod slice;
 pub mod slice_mut;
-pub mod state;
 pub mod map;
 pub mod weight;
 pub mod zip;

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -72,7 +72,10 @@ pub trait ParallelIterator: Sized {
 
     /// Internal method used to define the behavior of this parallel
     /// iterator. You should not need to call this directly.
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result;
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result;
 
     /// Indicates the relative "weight" of producing each item in this
     /// parallel iterator. A higher weight will cause finer-grained

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -18,7 +18,7 @@ use self::filter_map::FilterMap;
 use self::map::Map;
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    SUM, MUL, MIN, MAX};
-use self::state::{Consumer, ParallelIteratorState};
+use self::state::{Consumer, ParallelIteratorState, Producer};
 use self::weight::Weight;
 use self::zip::ZipIter;
 
@@ -260,6 +260,14 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
 /// that you can split it at arbitrary indices and draw data from
 /// those points.
 pub trait PullParallelIterator: ExactParallelIterator {
+    #[doc(hidden)]
+    type Producer: Producer<Item=Self::Item>;
+
+    /// Internal method to convert this parallel iterator into a producer
+    /// that can be used to request the items.
+    #[doc(hidden)]
+    fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared);
+
     /// Iterate over tuples `(A, B)`, where the items `A` are from
     /// this iterator and `B` are from the iterator given as argument.
     /// Like the `zip` method on ordinary iterators, if the two

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -72,7 +72,7 @@ pub trait ParallelIterator: Sized {
 
     /// Internal method used to define the behavior of this parallel
     /// iterator. You should not need to call this directly.
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result;
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result;
 
     /// Indicates the relative "weight" of producing each item in this
     /// parallel iterator. A higher weight will cause finer-grained
@@ -260,12 +260,13 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
 /// that you can split it at arbitrary indices and draw data from
 /// those points.
 pub trait PullParallelIterator: ExactParallelIterator {
-    #[doc(hidden)]
+    /// Producer type that this iterator creates. Users of the API
+    /// never need to know about this type.
     type Producer: Producer<Item=Self::Item>;
 
-    /// Internal method to convert this parallel iterator into a producer
-    /// that can be used to request the items.
-    #[doc(hidden)]
+    /// Internal method to convert this parallel iterator into a
+    /// producer that can be used to request the items. Users of the
+    /// API never need to know about this fn.
     fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared);
 
     /// Iterate over tuples `(A, B)`, where the items `A` are from

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -141,7 +141,7 @@ pub trait ParallelIterator: Sized {
     fn reduce_with<OP>(self, op: OP) -> Option<Self::Item>
         where OP: Fn(Self::Item, Self::Item) -> Self::Item + Sync,
     {
-        reduce(self.map(Some), ReduceWithOp::new(op))
+        reduce(self.map(Some), &ReduceWithOp::new(op))
     }
 
     /// Sums up the items in the iterator.
@@ -198,7 +198,7 @@ pub trait ParallelIterator: Sized {
     /// Note that the order in items will be reduced is not specified,
     /// so if the `reduce_op` impl is not truly commutative and
     /// associative, then the results are not deterministic.
-    fn reduce<REDUCE_OP>(self, reduce_op: REDUCE_OP) -> Self::Item
+    fn reduce<REDUCE_OP>(self, reduce_op: &REDUCE_OP) -> Self::Item
         where REDUCE_OP: ReduceOp<Self::Item>
     {
         reduce(self, reduce_op)

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -206,7 +206,7 @@ pub trait ParallelIterator: Sized {
     /// Internal method used to define the behavior of this parallel
     /// iterator. You should not need to call this directly.
     #[doc(hidden)]
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result;

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -232,6 +232,15 @@ pub unsafe trait BoundedParallelIterator: ParallelIterator {
 /// `ExactParallelIterator` is precisely correct in order to guarantee
 /// safety invariants.
 pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
+    /// Produces an exact count of how many items this iterator will
+    /// produce, presuming no panic occurs.
+    ///
+    /// # Safety note
+    ///
+    /// Returning an incorrect value here could lead to **undefined
+    /// behavior**.
+    fn len(&mut self) -> u64;
+
     /// Iterate over tuples `(A, B)`, where the items `A` are from
     /// this iterator and `B` are from the iterator given as argument.
     /// Like the `zip` method on ordinary iterators, if the two

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -74,7 +74,6 @@ macro_rules! range_impl {
         impl Producer for RangeIter<$t> {
             type Item = $t;
             type Shared = ();
-            type SeqState = ();
 
             unsafe fn split_at(self, index: usize) -> (Self, Self) {
                 assert!(index <= self.range.len());
@@ -86,14 +85,8 @@ macro_rules! range_impl {
                 (RangeIter { range: left }, RangeIter { range: right })
             }
 
-            unsafe fn start(&mut self, _: &()) {
-            }
-
-            unsafe fn produce(&mut self, shared: &(), state: &mut ()) -> $t {
+            unsafe fn produce(&mut self, shared: &()) -> $t {
                 self.range.next().unwrap()
-            }
-
-            unsafe fn complete(self, _: &(), _: ()) {
             }
         }
     }

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -23,8 +23,10 @@ macro_rules! range_impl {
             type Shared = ();
             type State = Self;
 
-            fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared)
-                                                   -> C::Result {
+            fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                           consumer: C,
+                                                           shared: &'c C::Shared)
+                                                           -> C::Result {
                 bridge(self, consumer, &shared)
             }
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -23,8 +23,9 @@ macro_rules! range_impl {
             type Shared = ();
             type State = Self;
 
-            fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
-                unimplemented!()
+            fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared)
+                                                   -> C::Result {
+                bridge(self, consumer, &shared)
             }
 
             fn state(self) -> (Self::Shared, Self::State) {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -83,8 +83,8 @@ macro_rules! range_impl {
             type Item = $t;
             type Shared = ();
 
-            unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-                items as f64
+            fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
+                len as f64
             }
 
             unsafe fn split_at(self, index: usize) -> (Self, Self) {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -33,14 +33,14 @@ macro_rules! range_impl {
         }
 
         unsafe impl BoundedParallelIterator for RangeIter<$t> {
-            fn upper_bound(&mut self) -> u64 {
+            fn upper_bound(&mut self) -> usize {
                 ExactParallelIterator::len(self)
             }
         }
 
         unsafe impl ExactParallelIterator for RangeIter<$t> {
-            fn len(&mut self) -> u64 {
-                self.range.len() as u64
+            fn len(&mut self) -> usize {
+                self.range.len() as usize
             }
         }
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 use std::ops::Range;
 
 pub struct RangeIter<T> {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -78,6 +78,10 @@ macro_rules! range_impl {
             type Item = $t;
             type Shared = ();
 
+            unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+                items as f64
+            }
+
             unsafe fn split_at(self, index: usize) -> (Self, Self) {
                 assert!(index <= self.range.len());
                 // For signed $t, the length and requested index could be greater than $t::MAX, and

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -45,6 +45,11 @@ macro_rules! range_impl {
         }
 
         impl PullParallelIterator for RangeIter<$t> {
+            type Producer = Self;
+
+            fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {
+                (self, ())
+            }
         }
 
         unsafe impl ParallelIteratorState for RangeIter<$t> {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -20,10 +20,10 @@ macro_rules! range_impl {
         impl ParallelIterator for RangeIter<$t> {
             type Item = $t;
 
-            fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
-                                                           consumer: C,
-                                                           shared: &'c C::Shared)
-                                                           -> C::Result {
+            fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                              consumer: C,
+                                                                              shared: &'c C::Shared)
+                                                                              -> C::Result {
                 bridge(self, consumer, &shared)
             }
         }
@@ -31,6 +31,13 @@ macro_rules! range_impl {
         unsafe impl BoundedParallelIterator for RangeIter<$t> {
             fn upper_bound(&mut self) -> usize {
                 ExactParallelIterator::len(self)
+            }
+
+            fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                           consumer: C,
+                                                           shared: &'c C::Shared)
+                                                           -> C::Result {
+                bridge(self, consumer, &shared)
             }
         }
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -23,12 +23,19 @@ macro_rules! range_impl {
             type Shared = ();
             type State = Self;
 
+            fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
+                unimplemented!()
+            }
+
             fn state(self) -> (Self::Shared, Self::State) {
                 ((), self)
             }
         }
 
         unsafe impl BoundedParallelIterator for RangeIter<$t> {
+            fn upper_bound(&mut self) -> u64 {
+                ExactParallelIterator::len(self)
+            }
         }
 
         unsafe impl ExactParallelIterator for RangeIter<$t> {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -20,7 +20,7 @@ macro_rules! range_impl {
         impl ParallelIterator for RangeIter<$t> {
             type Item = $t;
 
-            fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+            fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                               consumer: C,
                                                                               shared: &'c C::Shared)
                                                                               -> C::Result {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -44,6 +44,9 @@ macro_rules! range_impl {
             }
         }
 
+        impl PullParallelIterator for RangeIter<$t> {
+        }
+
         unsafe impl ParallelIteratorState for RangeIter<$t> {
             type Item = $t;
             type Shared = ();

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -47,7 +47,7 @@ macro_rules! range_impl {
             }
         }
 
-        impl PullParallelIterator for RangeIter<$t> {
+        impl IndexedParallelIterator for RangeIter<$t> {
             type Producer = Self;
 
             fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -32,6 +32,9 @@ macro_rules! range_impl {
         }
 
         unsafe impl ExactParallelIterator for RangeIter<$t> {
+            fn len(&mut self) -> u64 {
+                self.range.len() as u64
+            }
         }
 
         unsafe impl ParallelIteratorState for RangeIter<$t> {

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -101,9 +101,9 @@ impl<PAR_ITER, REDUCE_OP> Consumer for ReduceConsumer<PAR_ITER, REDUCE_OP>
     type SeqState = PAR_ITER::Item;
     type Result = PAR_ITER::Item;
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
         // This isn't quite right, as we will do more than O(n) reductions, but whatever.
-        (items as f64) * FUNC_ADJUSTMENT
+        cost * FUNC_ADJUSTMENT
     }
 
     unsafe fn split_at(self, _: &Self::Shared, _index: usize) -> (Self, Self) {

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -41,7 +41,7 @@ pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: REDUCE_OP) -> T
           T: Send,
 {
     let consumer: ReduceConsumer<PAR_ITER, REDUCE_OP> = ReduceConsumer::new();
-    pi.drive(consumer, reduce_op)
+    pi.drive(consumer, &reduce_op)
 }
 
 struct ReduceConsumer<PAR_ITER, REDUCE_OP>
@@ -65,9 +65,11 @@ unsafe impl<PAR_ITER, REDUCE_OP> Send for ReduceConsumer<PAR_ITER, REDUCE_OP>
           REDUCE_OP: ReduceOp<PAR_ITER::Item>,
 { }
 
-impl<PAR_ITER, REDUCE_OP> Consumer for ReduceConsumer<PAR_ITER, REDUCE_OP>
+impl<'c, PAR_ITER, REDUCE_OP> Consumer<'c> for ReduceConsumer<PAR_ITER, REDUCE_OP>
     where PAR_ITER: ParallelIterator,
           REDUCE_OP: ReduceOp<PAR_ITER::Item>,
+          PAR_ITER::Item: 'c,
+          REDUCE_OP: 'c,
 {
     type Item = PAR_ITER::Item;
     type Shared = REDUCE_OP;

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use super::ParallelIterator;
 use super::len::*;
 use super::state::*;
+use super::util::PhantomType;
 
 /// Specifies a "reduce operator". This is the combination of a start
 /// value and a reduce function. The reduce function takes two items
@@ -48,7 +49,7 @@ struct ReduceConsumer<PAR_ITER, REDUCE_OP>
     where PAR_ITER: ParallelIterator,
           REDUCE_OP: ReduceOp<PAR_ITER::Item>,
 {
-    data: PhantomData<(PAR_ITER, REDUCE_OP)>
+    data: PhantomType<(PAR_ITER, REDUCE_OP)>
 }
 
 impl<PAR_ITER, REDUCE_OP> ReduceConsumer<PAR_ITER, REDUCE_OP>
@@ -56,14 +57,9 @@ impl<PAR_ITER, REDUCE_OP> ReduceConsumer<PAR_ITER, REDUCE_OP>
           REDUCE_OP: ReduceOp<PAR_ITER::Item>,
 {
     fn new() -> ReduceConsumer<PAR_ITER, REDUCE_OP> {
-        ReduceConsumer { data: PhantomData }
+        ReduceConsumer { data: PhantomType::new() }
     }
 }
-
-unsafe impl<PAR_ITER, REDUCE_OP> Send for ReduceConsumer<PAR_ITER, REDUCE_OP>
-    where PAR_ITER: ParallelIterator,
-          REDUCE_OP: ReduceOp<PAR_ITER::Item>,
-{ }
 
 impl<'c, PAR_ITER, REDUCE_OP> Consumer<'c> for ReduceConsumer<PAR_ITER, REDUCE_OP>
     where PAR_ITER: ParallelIterator,

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -2,7 +2,7 @@ use api::join;
 use std;
 use std::marker::PhantomData;
 use super::ParallelIterator;
-use super::len::{ParallelLen, THRESHOLD};
+use super::len::*;
 use super::state::*;
 
 /// Specifies a "reduce operator". This is the combination of a start
@@ -101,7 +101,12 @@ impl<PAR_ITER, REDUCE_OP> Consumer for ReduceConsumer<PAR_ITER, REDUCE_OP>
     type SeqState = PAR_ITER::Item;
     type Result = PAR_ITER::Item;
 
-    unsafe fn split_at(self, _index: usize) -> (Self, Self) {
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        // This isn't quite right, as we will do more than O(n) reductions, but whatever.
+        (items as f64) * FUNC_ADJUSTMENT
+    }
+
+    unsafe fn split_at(self, _: &Self::Shared, _index: usize) -> (Self, Self) {
         (ReduceConsumer::new(), ReduceConsumer::new())
     }
 

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -1,7 +1,7 @@
 use std;
 use super::ParallelIterator;
 use super::len::*;
-use super::state::*;
+use super::internal::*;
 use super::util::PhantomType;
 
 /// Specifies a "reduce operator". This is the combination of a start

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -40,7 +40,7 @@ pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: &REDUCE_OP) -> T
 {
     let consumer: ReduceConsumer<PAR_ITER::Item, REDUCE_OP> =
         ReduceConsumer { data: PhantomType::new() };
-    pi.drive_stateless(consumer, reduce_op)
+    pi.drive_unindexed(consumer, reduce_op)
 }
 
 struct ReduceConsumer<ITEM, REDUCE_OP>
@@ -105,7 +105,7 @@ impl<'c, ITEM, REDUCE_OP> Consumer<'c> for ReduceConsumer<ITEM, REDUCE_OP>
     }
 }
 
-impl<'c, ITEM, REDUCE_OP> StatelessConsumer<'c> for ReduceConsumer<ITEM, REDUCE_OP>
+impl<'c, ITEM, REDUCE_OP> UnindexedConsumer<'c> for ReduceConsumer<ITEM, REDUCE_OP>
     where REDUCE_OP: ReduceOp<ITEM> + 'c,
           ITEM: Send + 'c,
 {

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -101,7 +101,7 @@ impl<PAR_ITER, REDUCE_OP> Consumer for ReduceConsumer<PAR_ITER, REDUCE_OP>
     type SeqState = PAR_ITER::Item;
     type Result = PAR_ITER::Item;
 
-    unsafe fn split_at(self, _index: u64) -> (Self, Self) {
+    unsafe fn split_at(self, _index: usize) -> (Self, Self) {
         (ReduceConsumer::new(), ReduceConsumer::new())
     }
 

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -34,14 +34,14 @@ pub trait ReduceOp<T>: Sync {
     fn reduce(&self, value1: T, value2: T) -> T;
 }
 
-pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: REDUCE_OP) -> T
+pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: &REDUCE_OP) -> T
     where PAR_ITER: ParallelIterator<Item=T>,
           PAR_ITER::State: Send,
           REDUCE_OP: ReduceOp<T>,
           T: Send,
 {
     let consumer: ReduceConsumer<PAR_ITER, REDUCE_OP> = ReduceConsumer::new();
-    pi.drive(consumer, &reduce_op)
+    pi.drive(consumer, reduce_op)
 }
 
 struct ReduceConsumer<PAR_ITER, REDUCE_OP>
@@ -117,7 +117,7 @@ impl<'c, PAR_ITER, REDUCE_OP> Consumer<'c> for ReduceConsumer<PAR_ITER, REDUCE_O
 
 pub struct SumOp;
 
-pub const SUM: SumOp = SumOp;
+pub const SUM: &'static SumOp = &SumOp;
 
 macro_rules! sum_rule {
     ($i:ty, $z:expr) => {
@@ -147,7 +147,7 @@ sum_rule!(f64, 0.0);
 
 pub struct MulOp;
 
-pub const MUL: MulOp = MulOp;
+pub const MUL: &'static MulOp = &MulOp;
 
 macro_rules! mul_rule {
     ($i:ty, $z:expr) => {
@@ -177,7 +177,7 @@ mul_rule!(f64, 1.0);
 
 pub struct MinOp;
 
-pub const MIN: MinOp = MinOp;
+pub const MIN: &'static MinOp = &MinOp;
 
 macro_rules! min_rule {
     ($i:ty, $z:expr, $f:expr) => {
@@ -207,7 +207,7 @@ min_rule!(f64, std::f64::INFINITY, f64::min);
 
 pub struct MaxOp;
 
-pub const MAX: MaxOp = MaxOp;
+pub const MAX: &'static MaxOp = &MaxOp;
 
 macro_rules! max_rule {
     ($i:ty, $z:expr, $f:expr) => {

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -100,8 +100,6 @@ impl<PAR_ITER, REDUCE_OP> Consumer for ReduceConsumer<PAR_ITER, REDUCE_OP>
     type Shared = REDUCE_OP;
     type SeqState = PAR_ITER::Item;
     type Result = PAR_ITER::Item;
-    type Left = Self;
-    type Right = Self;
 
     unsafe fn split_at(self, _index: u64) -> (Self, Self) {
         (ReduceConsumer::new(), ReduceConsumer::new())

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -40,7 +40,7 @@ pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: &REDUCE_OP) -> T
 {
     let consumer: ReduceConsumer<PAR_ITER::Item, REDUCE_OP> =
         ReduceConsumer { data: PhantomType::new() };
-    pi.drive(consumer, reduce_op)
+    pi.drive_stateless(consumer, reduce_op)
 }
 
 struct ReduceConsumer<ITEM, REDUCE_OP>
@@ -102,6 +102,15 @@ impl<'c, ITEM, REDUCE_OP> Consumer<'c> for ReduceConsumer<ITEM, REDUCE_OP>
                      b: ITEM)
                      -> ITEM {
         reduce_op.reduce(a, b)
+    }
+}
+
+impl<'c, ITEM, REDUCE_OP> StatelessConsumer<'c> for ReduceConsumer<ITEM, REDUCE_OP>
+    where REDUCE_OP: ReduceOp<ITEM> + 'c,
+          ITEM: Send + 'c,
+{
+    fn split(&self) -> Self {
+        ReduceConsumer { data: PhantomType::new() }
     }
 }
 

--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -1,6 +1,4 @@
-use api::join;
 use std;
-use std::marker::PhantomData;
 use super::ParallelIterator;
 use super::len::*;
 use super::state::*;
@@ -37,7 +35,6 @@ pub trait ReduceOp<T>: Sync {
 
 pub fn reduce<PAR_ITER,REDUCE_OP,T>(pi: PAR_ITER, reduce_op: &REDUCE_OP) -> T
     where PAR_ITER: ParallelIterator<Item=T>,
-          PAR_ITER::State: Send,
           REDUCE_OP: ReduceOp<T>,
           T: Send,
 {
@@ -72,7 +69,7 @@ impl<'c, ITEM, REDUCE_OP> Consumer<'c> for ReduceConsumer<ITEM, REDUCE_OP>
     type SeqState = ITEM;
     type Result = ITEM;
 
-    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+    fn cost(&mut self, _shared: &Self::Shared, cost: f64) -> f64 {
         // This isn't quite right, as we will do more than O(n) reductions, but whatever.
         cost * FUNC_ADJUSTMENT
     }

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -26,7 +26,7 @@ impl<'data, T: Sync + 'data> IntoParallelRefIterator<'data> for [T] {
 impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
     type Item = &'data T;
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -39,14 +39,14 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
 }
 
 unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 }
 
 unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
-    fn len(&mut self) -> u64 {
-        self.slice.len() as u64
+    fn len(&mut self) -> usize {
+        self.slice.len() as usize
     }
 }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -36,7 +36,11 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
 
 unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> { }
 
-unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> { }
+unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
+    fn len(&mut self) -> u64 {
+        self.slice.len() as u64
+    }
+}
 
 unsafe impl<'data, T: Sync> ParallelIteratorState for SliceIter<'data, T> {
     type Item = &'data T;

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 
 pub struct SliceIter<'data, T: 'data + Sync> {
     slice: &'data [T]

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -95,8 +95,8 @@ impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T>
     type Item = &'data T;
     type Shared = ();
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        items as f64
+    fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
+        len as f64
     }
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -53,7 +53,7 @@ unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync> PullParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync> IndexedParallelIterator for SliceIter<'data, T> {
     type Producer = SliceProducer<'data, T>;
 
     fn into_producer(self) -> (Self::Producer, ()) {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -29,7 +29,10 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
     type Shared = ();
     type State = Self;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
         bridge(self, consumer, &shared)
     }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -51,6 +51,11 @@ unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
 }
 
 impl<'data, T: Sync> PullParallelIterator for SliceIter<'data, T> {
+    type Producer = SliceProducer<'data, T>;
+
+    fn into_producer(self) -> (Self::Producer, ()) {
+        (SliceProducer { slice: self.slice }, ())
+    }
 }
 
 unsafe impl<'data, T: Sync> ParallelIteratorState for SliceIter<'data, T> {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -90,6 +90,10 @@ impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T>
     type Item = &'data T;
     type Shared = ();
 
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        items as f64
+    }
+
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.slice.split_at(index);
         (SliceProducer { slice: left }, SliceProducer { slice: right })

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -86,28 +86,15 @@ impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T>
 {
     type Item = &'data T;
     type Shared = ();
-    type SeqState = ();
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.slice.split_at(index);
         (SliceProducer { slice: left }, SliceProducer { slice: right })
     }
 
-    unsafe fn start(&mut self, _: &()) {
-    }
-
-    unsafe fn produce(&mut self,
-                      _: &(),
-                      _: &mut ())
-                      -> &'data T
-    {
+    unsafe fn produce(&mut self, _: &()) -> &'data T {
         let (head, tail) = self.slice.split_first().unwrap();
         self.slice = tail;
         head
-    }
-
-    unsafe fn complete(self,
-                       _: &(),
-                       _: ()) {
     }
 }

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -26,10 +26,10 @@ impl<'data, T: Sync + 'data> IntoParallelRefIterator<'data> for [T] {
 impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
     type Item = &'data T;
 
-    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
-                                                   consumer: C,
-                                                   shared: &'c C::Shared)
-                                                   -> C::Result {
+    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                      consumer: C,
+                                                                      shared: &'c C::Shared)
+                                                                      -> C::Result {
         bridge(self, consumer, &shared)
     }
 }
@@ -37,6 +37,13 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
 unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
+    }
+
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
+        bridge(self, consumer, &shared)
     }
 }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -23,7 +23,7 @@ impl<'data, T: Sync + 'data> IntoParallelRefIterator<'data> for [T] {
     }
 }
 
-impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
     type Item = &'data T;
 
     fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
@@ -34,7 +34,7 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
     }
 }
 
-unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> {
+unsafe impl<'data, T: Sync + 'data> BoundedParallelIterator for SliceIter<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -47,13 +47,13 @@ unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> {
     }
 }
 
-unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
+unsafe impl<'data, T: Sync + 'data> ExactParallelIterator for SliceIter<'data, T> {
     fn len(&mut self) -> usize {
-        self.slice.len() as usize
+        self.slice.len()
     }
 }
 
-impl<'data, T: Sync> IndexedParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
     type Producer = SliceProducer<'data, T>;
 
     fn into_producer(self) -> (Self::Producer, ()) {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -29,8 +29,8 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
     type Shared = ();
     type State = Self;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
-        unimplemented!()
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+        bridge(self, consumer, &shared)
     }
 
     fn state(self) -> (Self::Shared, Self::State) {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
+use super::state::*;
 
 pub struct SliceIter<'data, T: 'data + Sync> {
     slice: &'data [T]
@@ -29,12 +29,20 @@ impl<'data, T: Sync> ParallelIterator for SliceIter<'data, T> {
     type Shared = ();
     type State = Self;
 
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
+        unimplemented!()
+    }
+
     fn state(self) -> (Self::Shared, Self::State) {
         ((), self)
     }
 }
 
-unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> { }
+unsafe impl<'data, T: Sync> BoundedParallelIterator for SliceIter<'data, T> {
+    fn upper_bound(&mut self) -> u64 {
+        ExactParallelIterator::len(self)
+    }
+}
 
 unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
     fn len(&mut self) -> u64 {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -50,6 +50,9 @@ unsafe impl<'data, T: Sync> ExactParallelIterator for SliceIter<'data, T> {
     }
 }
 
+impl<'data, T: Sync> PullParallelIterator for SliceIter<'data, T> {
+}
+
 unsafe impl<'data, T: Sync> ParallelIteratorState for SliceIter<'data, T> {
     type Item = &'data T;
     type Shared = ();

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -52,6 +52,11 @@ unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
 }
 
 impl<'data, T: Send> PullParallelIterator for SliceIterMut<'data, T> {
+    type Producer = SliceMutProducer<'data, T>;
+
+    fn into_producer(self) -> (Self::Producer, ()) {
+        (SliceMutProducer { slice: self.slice }, ())
+    }
 }
 
 unsafe impl<'data, T: Send> ParallelIteratorState for SliceIterMut<'data, T> {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -92,6 +92,10 @@ impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T>
     type Item = &'data mut T;
     type Shared = ();
 
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        items as f64
+    }
+
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.slice.split_at_mut(index);
         (SliceMutProducer { slice: left }, SliceMutProducer { slice: right })

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -27,10 +27,10 @@ impl<'data, T: Send + 'data> IntoParallelRefMutIterator<'data> for [T] {
 impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
     type Item = &'data mut T;
 
-    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
-                                                   consumer: C,
-                                                   shared: &'c C::Shared)
-                                                   -> C::Result {
+    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                      consumer: C,
+                                                                      shared: &'c C::Shared)
+                                                                      -> C::Result {
         bridge(self, consumer, &shared)
     }
 }
@@ -38,6 +38,13 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
 unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
+    }
+
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
+        bridge(self, consumer, &shared)
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -40,14 +40,14 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
 }
 
 unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 }
 
 unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
-    fn len(&mut self) -> u64 {
-        self.slice.len() as u64
+    fn len(&mut self) -> usize {
+        self.slice.len() as usize
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
+use super::state::*;
 use std::mem;
 
 pub struct SliceIterMut<'data, T: 'data + Send> {
@@ -30,12 +30,20 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
     type Shared = ();
     type State = Self;
 
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
+        unimplemented!()
+    }
+
     fn state(self) -> (Self::Shared, Self::State) {
         ((), self)
     }
 }
 
-unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> { }
+unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> {
+    fn upper_bound(&mut self) -> u64 {
+        ExactParallelIterator::len(self)
+    }
+}
 
 unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
     fn len(&mut self) -> u64 {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -27,7 +27,7 @@ impl<'data, T: Send + 'data> IntoParallelRefMutIterator<'data> for [T] {
 impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
     type Item = &'data mut T;
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -6,7 +6,7 @@ pub struct SliceIterMut<'data, T: 'data + Send> {
     slice: &'data mut [T]
 }
 
-impl<'data, T: Send> IntoParallelIterator for &'data mut [T] {
+impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut [T] {
     type Item = &'data mut T;
     type Iter = SliceIterMut<'data, T>;
 
@@ -24,7 +24,7 @@ impl<'data, T: Send + 'data> IntoParallelRefMutIterator<'data> for [T] {
     }
 }
 
-impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
     type Item = &'data mut T;
 
     fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
@@ -35,7 +35,7 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
     }
 }
 
-unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> {
+unsafe impl<'data, T: Send + 'data> BoundedParallelIterator for SliceIterMut<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -48,13 +48,13 @@ unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> {
     }
 }
 
-unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
+unsafe impl<'data, T: Send + 'data> ExactParallelIterator for SliceIterMut<'data, T> {
     fn len(&mut self) -> usize {
-        self.slice.len() as usize
+        self.slice.len()
     }
 }
 
-impl<'data, T: Send> IndexedParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> {
     type Producer = SliceMutProducer<'data, T>;
 
     fn into_producer(self) -> (Self::Producer, ()) {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -30,7 +30,10 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
     type Shared = ();
     type State = Self;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
         bridge(self, consumer, &shared)
     }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -54,7 +54,7 @@ unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
     }
 }
 
-impl<'data, T: Send> PullParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send> IndexedParallelIterator for SliceIterMut<'data, T> {
     type Producer = SliceMutProducer<'data, T>;
 
     fn into_producer(self) -> (Self::Producer, ()) {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -30,8 +30,8 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
     type Shared = ();
     type State = Self;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
-        unimplemented!()
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+        bridge(self, consumer, &shared)
     }
 
     fn state(self) -> (Self::Shared, Self::State) {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -37,7 +37,11 @@ impl<'data, T: Send> ParallelIterator for SliceIterMut<'data, T> {
 
 unsafe impl<'data, T: Send> BoundedParallelIterator for SliceIterMut<'data, T> { }
 
-unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> { }
+unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
+    fn len(&mut self) -> u64 {
+        self.slice.len() as u64
+    }
+}
 
 unsafe impl<'data, T: Send> ParallelIteratorState for SliceIterMut<'data, T> {
     type Item = &'data mut T;

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 use std::mem;
 
 pub struct SliceIterMut<'data, T: 'data + Send> {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -97,8 +97,8 @@ impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T>
     type Item = &'data mut T;
     type Shared = ();
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        items as f64
+    fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
+        len as f64
     }
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -51,6 +51,9 @@ unsafe impl<'data, T: Send> ExactParallelIterator for SliceIterMut<'data, T> {
     }
 }
 
+impl<'data, T: Send> PullParallelIterator for SliceIterMut<'data, T> {
+}
+
 unsafe impl<'data, T: Send> ParallelIteratorState for SliceIterMut<'data, T> {
     type Item = &'data mut T;
     type Shared = ();

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -88,29 +88,16 @@ impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T>
 {
     type Item = &'data mut T;
     type Shared = ();
-    type SeqState = ();
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.slice.split_at_mut(index);
         (SliceMutProducer { slice: left }, SliceMutProducer { slice: right })
     }
 
-    unsafe fn start(&mut self, _: &()) {
-    }
-
-    unsafe fn produce(&mut self,
-                      _: &(),
-                      _: &mut ())
-                      -> &'data mut T
-    {
+    unsafe fn produce(&mut self, _: &()) -> &'data mut T {
         let slice = mem::replace(&mut self.slice, &mut []); // FIXME rust-lang/rust#10520
         let (head, tail) = slice.split_first_mut().unwrap();
         self.slice = tail;
         head
-    }
-
-    unsafe fn complete(self,
-                       _: &(),
-                       _: ()) {
     }
 }

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -77,3 +77,40 @@ unsafe impl<'data, T: Send> ParallelIteratorState for SliceIterMut<'data, T> {
              })
     }
 }
+
+///////////////////////////////////////////////////////////////////////////
+
+pub struct SliceMutProducer<'data, T: 'data + Send> {
+    slice: &'data mut [T]
+}
+
+impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T>
+{
+    type Item = &'data mut T;
+    type Shared = ();
+    type SeqState = ();
+
+    unsafe fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.slice.split_at_mut(index);
+        (SliceMutProducer { slice: left }, SliceMutProducer { slice: right })
+    }
+
+    unsafe fn start(&mut self, _: &()) {
+    }
+
+    unsafe fn produce(&mut self,
+                      _: &(),
+                      _: &mut ())
+                      -> &'data mut T
+    {
+        let slice = mem::replace(&mut self.slice, &mut []); // FIXME rust-lang/rust#10520
+        let (head, tail) = slice.split_first_mut().unwrap();
+        self.slice = tail;
+        head
+    }
+
+    unsafe fn complete(self,
+                       _: &(),
+                       _: ()) {
+    }
+}

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -49,7 +49,7 @@ pub trait Producer: Send {
 
     /// Split into two producers; one produces items `0..index`, the
     /// other `index..N`. Index must be less than `N`.
-    unsafe fn split_at(self, index: u64) -> (Self, Self);
+    unsafe fn split_at(self, index: usize) -> (Self, Self);
 
     /// Start producing items. Returns some sequential state that must
     /// be threaded.
@@ -68,7 +68,7 @@ pub trait Consumer: Send {
     type SeqState;
     type Result: Send;
 
-    unsafe fn split_at(self, index: u64) -> (Self, Self);
+    unsafe fn split_at(self, index: usize) -> (Self, Self);
     unsafe fn start(&mut self, shared: &Self::Shared) -> Self::SeqState;
     unsafe fn consume(&mut self,
                       shared: &Self::Shared,
@@ -82,7 +82,7 @@ pub trait Consumer: Send {
                      -> Self::Result;
 }
 
-pub fn bridge<P,C>(len: u64,
+pub fn bridge<P,C>(len: usize,
                    cost: f64,
                    mut producer: P,
                    producer_shared: &P::Shared,

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -46,6 +46,9 @@ pub trait Producer: Send {
     type Item;
     type Shared: Sync;
 
+    /// Cost to produce `items` items.
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64;
+
     /// Split into two producers; one produces items `0..index`, the
     /// other `index..N`. Index must be less than `N`.
     unsafe fn split_at(self, index: usize) -> (Self, Self);

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -1,4 +1,5 @@
-use super::len::ParallelLen;
+use join;
+use super::len::*;
 
 /// The trait for types representing the internal *state* during
 /// parallelization. This basically represents a group of tasks
@@ -36,4 +37,91 @@ pub unsafe trait ParallelIteratorState: Sized {
     /// method is called, sequential iteration has begun, and the
     /// other methods will no longer be called.
     fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item>;
+}
+
+/// A producer which will produce a fixed number of items N. This is
+/// not queryable through the API; the consumer is expected to track
+/// it.
+pub trait Producer: Send {
+    type Item;
+    type Shared: Sync;
+    type SeqState;
+
+    /// Split into two producers; one produces items `0..index`, the
+    /// other `index..N`. Index must be less than `N`.
+    unsafe fn split_at(self, index: u64) -> (Self, Self);
+
+    /// Start producing items. Returns some sequential state that must
+    /// be threaded.
+    unsafe fn start(&mut self, shared: &Self::Shared) -> Self::SeqState;
+
+    /// Unless a panic occurs, expects to be called *exactly N times*.
+    unsafe fn produce(&mut self, shared: &Self::Shared, state: &mut Self::SeqState) -> Self::Item;
+
+    /// Finish producing items.
+    unsafe fn complete(self, shared: &Self::Shared, state: Self::SeqState);
+}
+
+pub trait Consumer: Send {
+    type Item;
+    type Shared: Sync;
+    type SeqState;
+    type Result: Send;
+
+    /// When splitting, this is the type of the left consumer. It is
+    /// almost always `Self`, but separating out the type helps ensure
+    /// that generic code that drives consumers is more correct, since
+    /// they cannot mix up the results from the left and right side.
+    type Left: Consumer<Item=Self::Item, Shared=Self::Shared>;
+
+    /// See `Left`.
+    type Right: Consumer<Item=Self::Item, Shared=Self::Shared>;
+
+    unsafe fn split_at(self, index: u64) -> (Self::Left, Self::Right);
+    unsafe fn start(&mut self, shared: &Self::Shared) -> Self::SeqState;
+    unsafe fn consume(&mut self,
+                      shared: &Self::Shared,
+                      state: Self::SeqState,
+                      item: Self::Item)
+                      -> Self::SeqState;
+    unsafe fn complete(self, shared: &Self::Shared, state: Self::SeqState) -> Self::Result;
+    unsafe fn reduce(shared: &Self::Shared,
+                     left: <Self::Left as Consumer>::Result,
+                     right: <Self::Right as Consumer>::Result)
+                     -> Self::Result;
+}
+
+pub fn bridge<P,C>(len: u64,
+                   cost: f64,
+                   mut producer: P,
+                   producer_shared: &P::Shared,
+                   mut consumer: C,
+                   consumer_shared: &C::Shared)
+                   -> C::Result
+    where P: Producer, C: Consumer<Item=P::Item>
+{
+    unsafe { // asserting that we call the `op` methods in correct pattern
+        if len > 1 && cost > THRESHOLD {
+            let mid = len / 2;
+            let (left_producer, right_producer) = producer.split_at(mid);
+            let (left_consumer, right_consumer) = consumer.split_at(mid);
+            let (left_result, right_result) =
+                join(|| bridge(mid, cost / 2.0,
+                               left_producer, producer_shared,
+                               left_consumer, consumer_shared),
+                     || bridge(len - mid, cost / 2.0,
+                               right_producer, producer_shared,
+                               right_consumer, consumer_shared));
+            C::reduce(consumer_shared, left_result, right_result)
+        } else {
+            let mut producer_state = producer.start(producer_shared);
+            let mut consumer_state = consumer.start(consumer_shared);
+            for _ in 0..len {
+                let item = producer.produce(producer_shared, &mut producer_state);
+                consumer_state = consumer.consume(consumer_shared, consumer_state, item);
+            }
+            producer.complete(producer_shared, producer_state);
+            consumer.complete(consumer_shared, consumer_state)
+        }
+    }
 }

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -32,24 +32,7 @@ pub trait Consumer<'consume>: Send {
     fn cost(&mut self, shared: &Self::Shared, producer_cost: f64) -> f64;
 
     /// Divide the consumer into two consumers, one processing items
-    /// `0..index` and one processing items `index..`.
-    ///
-    /// # Warning
-    ///
-    /// Depending on what kind of iterator is driving this consumer,
-    /// `index` may be imprecise or a dummy value (`usize::MAX`):
-    ///
-    /// - `ExactParallelIterator`: precise indices will be given.
-    ///   The consumers you return should be fed exactly the expected
-    ///   number of items.
-    /// - `BoundedParallelIterator`: `index` is an "upper bound".
-    ///   The consumers you return should be fed at most the specified
-    ///   number of items.
-    /// - `ParallelIterator`: `index` is a dummy value. The consumers
-    ///   you return could be fed any number of items.
-    ///
-    /// Consumers should adjust their trait bounds appropriately to ensure
-    /// they are getting the precision they need.
+    /// `0..index` and one processing items from `index..`.
     unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self);
 
     /// Start processing items. This can return some sequential state

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -58,7 +58,7 @@ pub trait Consumer<'consume>: Send {
 }
 
 /// A stateless consumer can be freely copied.
-pub trait StatelessConsumer<'c>: Consumer<'c> {
+pub trait UnindexedConsumer<'c>: Consumer<'c> {
     fn split(&self) -> Self;
 }
 

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -68,16 +68,7 @@ pub trait Consumer: Send {
     type SeqState;
     type Result: Send;
 
-    /// When splitting, this is the type of the left consumer. It is
-    /// almost always `Self`, but separating out the type helps ensure
-    /// that generic code that drives consumers is more correct, since
-    /// they cannot mix up the results from the left and right side.
-    type Left: Consumer<Item=Self::Item, Shared=Self::Shared>;
-
-    /// See `Left`.
-    type Right: Consumer<Item=Self::Item, Shared=Self::Shared>;
-
-    unsafe fn split_at(self, index: u64) -> (Self::Left, Self::Right);
+    unsafe fn split_at(self, index: u64) -> (Self, Self);
     unsafe fn start(&mut self, shared: &Self::Shared) -> Self::SeqState;
     unsafe fn consume(&mut self,
                       shared: &Self::Shared,
@@ -86,8 +77,8 @@ pub trait Consumer: Send {
                       -> Self::SeqState;
     unsafe fn complete(self, shared: &Self::Shared, state: Self::SeqState) -> Self::Result;
     unsafe fn reduce(shared: &Self::Shared,
-                     left: <Self::Left as Consumer>::Result,
-                     right: <Self::Right as Consumer>::Result)
+                     left: Self::Result,
+                     right: Self::Result)
                      -> Self::Result;
 }
 

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -2,44 +2,6 @@ use join;
 use super::PullParallelIterator;
 use super::len::*;
 
-/// The trait for types representing the internal *state* during
-/// parallelization. This basically represents a group of tasks
-/// to be done.
-///
-/// Note that this trait is declared as an **unsafe trait**. That
-/// means that the trait is unsafe to implement. The reason is that
-/// other bits of code, such as the `collect` routine on
-/// `ParallelIterator`, rely on the `len` and `for_each` functions
-/// being accurate and correct. For example, if the `len` function
-/// reports that it will produce N items, then `for_each` *must*
-/// produce `N` items or else the resulting vector will contain
-/// uninitialized memory.
-///
-/// This trait is not really intended to be implemented outside of the
-/// Rayon crate at this time. The precise safety requirements are kind
-/// of ill-documented for this reason (i.e., they are ill-understood).
-pub unsafe trait ParallelIteratorState: Sized {
-    type Item;
-    type Shared: Sync;
-
-    /// Returns an estimate of how much work is to be done.
-    ///
-    /// # Safety note
-    ///
-    /// If sparse is false, then `maximal_len` must be precisely
-    /// correct.
-    fn len(&mut self, shared: &Self::Shared) -> ParallelLen;
-
-    /// Split this state into two other states, ideally of roughly
-    /// equal size.
-    fn split_at(self, index: usize) -> (Self, Self);
-
-    /// Extract the next item from this iterator state. Once this
-    /// method is called, sequential iteration has begun, and the
-    /// other methods will no longer be called.
-    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item>;
-}
-
 /// A producer which will produce a fixed number of items N. This is
 /// not queryable through the API; the consumer is expected to track
 /// it.

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -1,5 +1,5 @@
 use join;
-use super::PullParallelIterator;
+use super::IndexedParallelIterator;
 use super::len::*;
 
 /// A producer which will produce a fixed number of items N. This is
@@ -83,7 +83,7 @@ pub fn bridge<'c,PAR_ITER,C>(mut par_iter: PAR_ITER,
                              mut consumer: C,
                              consumer_shared: &'c C::Shared)
                              -> C::Result
-    where PAR_ITER: PullParallelIterator, C: Consumer<'c, Item=PAR_ITER::Item>
+    where PAR_ITER: IndexedParallelIterator, C: Consumer<'c, Item=PAR_ITER::Item>
 {
     let len = par_iter.len();
     let (mut producer, producer_shared) = par_iter.into_producer();

--- a/src/par_iter/state.rs
+++ b/src/par_iter/state.rs
@@ -74,6 +74,11 @@ pub trait Consumer<'consume>: Send {
                      -> Self::Result;
 }
 
+/// A stateless consumer can be freely copied.
+pub trait StatelessConsumer<'c>: Consumer<'c> {
+    fn split(&self) -> Self;
+}
+
 pub fn bridge<'c,PAR_ITER,C>(mut par_iter: PAR_ITER,
                              mut consumer: C,
                              consumer_shared: &'c C::Shared)

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -209,3 +209,21 @@ pub fn check_sum_filtermap_ints() {
     assert_eq!(par_sum_evens, seq_sum_evens);
 }
 
+#[test]
+pub fn check_flat_map_nested_ranges() {
+    // FIXME -- why are precise type hints required on the integers here?
+
+    let v =
+        (0_i32..10).into_par_iter()
+                   .flat_map(|i| (0_i32..10).into_par_iter().map(move |j| (i, j)))
+                   .map(|(i, j)| i * j)
+                   .sum();
+
+    let w =
+        (0_i32..10).flat_map(|i| (0_i32..10).map(move |j| (i, j)))
+                   .map(|(i, j)| i * j)
+                   .fold(0, |i, j| i + j);
+
+    assert_eq!(v, w);
+}
+

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
 fn is_exact<T: ExactParallelIterator>(_: T) { }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -3,7 +3,7 @@ use super::state::*;
 
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
 fn is_exact<T: ExactParallelIterator>(_: T) { }
-fn is_pull<T: PullParallelIterator>(_: T) { }
+fn is_indexed<T: IndexedParallelIterator>(_: T) { }
 
 #[test]
 pub fn execute() {
@@ -32,7 +32,7 @@ pub fn check_map_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().map(|x| x));
     is_exact(a.par_iter().map(|x| x));
-    is_pull(a.par_iter().map(|x| x));
+    is_indexed(a.par_iter().map(|x| x));
 }
 
 #[test]
@@ -96,7 +96,7 @@ pub fn check_weight_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().weight(2.0));
     is_exact(a.par_iter().weight(2.0));
-    is_pull(a.par_iter().weight(2.0));
+    is_indexed(a.par_iter().weight(2.0));
 }
 
 #[test]
@@ -127,7 +127,7 @@ pub fn check_slice_exact_and_bounded() {
     let a = vec![1, 2, 3];
     is_bounded(a.par_iter());
     is_exact(a.par_iter());
-    is_pull(a.par_iter());
+    is_indexed(a.par_iter());
 }
 
 #[test]
@@ -135,14 +135,14 @@ pub fn check_slice_mut_exact_and_bounded() {
     let mut a = vec![1, 2, 3];
     is_bounded(a.par_iter_mut());
     is_exact(a.par_iter_mut());
-    is_pull(a.par_iter_mut());
+    is_indexed(a.par_iter_mut());
 }
 
 #[test]
 pub fn check_range_exact_and_bounded() {
     is_bounded((1..5).into_par_iter());
     is_exact((1..5).into_par_iter());
-    is_pull((1..5).into_par_iter());
+    is_indexed((1..5).into_par_iter());
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -3,6 +3,7 @@ use super::state::ParallelIteratorState;
 
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
 fn is_exact<T: ExactParallelIterator>(_: T) { }
+fn is_pull<T: PullParallelIterator>(_: T) { }
 
 #[test]
 pub fn execute() {
@@ -31,6 +32,7 @@ pub fn check_map_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().map(|x| x));
     is_exact(a.par_iter().map(|x| x));
+    is_pull(a.par_iter().map(|x| x));
 }
 
 #[test]
@@ -94,6 +96,7 @@ pub fn check_weight_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().weight(2.0));
     is_exact(a.par_iter().weight(2.0));
+    is_pull(a.par_iter().weight(2.0));
 }
 
 #[test]
@@ -122,21 +125,24 @@ pub fn check_increment() {
 #[test]
 pub fn check_slice_exact_and_bounded() {
     let a = vec![1, 2, 3];
-    is_exact(a.par_iter());
     is_bounded(a.par_iter());
+    is_exact(a.par_iter());
+    is_pull(a.par_iter());
 }
 
 #[test]
 pub fn check_slice_mut_exact_and_bounded() {
     let mut a = vec![1, 2, 3];
-    is_exact(a.par_iter_mut());
     is_bounded(a.par_iter_mut());
+    is_exact(a.par_iter_mut());
+    is_pull(a.par_iter_mut());
 }
 
 #[test]
 pub fn check_range_exact_and_bounded() {
-    is_exact((1..5).into_par_iter());
     is_bounded((1..5).into_par_iter());
+    is_exact((1..5).into_par_iter());
+    is_pull((1..5).into_par_iter());
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -76,13 +76,13 @@ pub fn check_weight() {
 
     let len1 = {
         let (shared, mut state) = a.par_iter().state();
-        state.len(&shared)
+        ParallelIteratorState::len(&mut state, &shared)
     };
 
     let len2 = {
         let (shared, mut state) = a.par_iter()
-                               .weight(2.0)
-                               .state();
+                                   .weight(2.0)
+                                   .state();
         state.len(&shared)
     };
 

--- a/src/par_iter/util.rs
+++ b/src/par_iter/util.rs
@@ -1,0 +1,19 @@
+use std::marker::PhantomData;
+
+/// A little structure used to mark some type. This is often used when
+/// we have some phantom type we wish to remember as part of a struct.
+/// This doesn't represent "reachable data", and hence it is
+/// considered sendable regardless of `T`, unlike `PhantomData`.
+pub struct PhantomType<T> {
+    data: PhantomData<T>
+}
+
+unsafe impl<T> Send for PhantomType<T> { }
+
+unsafe impl<T> Sync for PhantomType<T> { }
+
+impl<T> PhantomType<T> {
+    pub fn new() -> PhantomType<T> {
+        PhantomType { data: PhantomData }
+    }
+}

--- a/src/par_iter/util.rs
+++ b/src/par_iter/util.rs
@@ -12,6 +12,12 @@ unsafe impl<T> Send for PhantomType<T> { }
 
 unsafe impl<T> Sync for PhantomType<T> { }
 
+impl<T> Copy for PhantomType<T> { }
+
+impl<T> Clone for PhantomType<T> {
+    fn clone(&self) -> Self { *self }
+}
+
 impl<T> PhantomType<T> {
     pub fn new() -> PhantomType<T> {
         PhantomType { data: PhantomData }

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
+use super::state::*;
 
 pub struct Weight<M> {
     base: M,
@@ -20,6 +20,10 @@ impl<M> ParallelIterator for Weight<M>
     type Shared = WeightShared<M>;
     type State = WeightState<M>;
 
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
+        unimplemented!()
+    }
+
     fn state(self) -> (Self::Shared, Self::State) {
         let (base_shared, base_state) = self.base.state();
         (WeightShared { base: base_shared, weight: self.weight },
@@ -27,7 +31,11 @@ impl<M> ParallelIterator for Weight<M>
     }
 }
 
-unsafe impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> { }
+unsafe impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> {
+    fn upper_bound(&mut self) -> u64 {
+        self.base.upper_bound()
+    }
+}
 
 unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
     fn len(&mut self) -> u64 {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 use super::util::*;
 
 pub struct Weight<M> {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -49,7 +49,7 @@ unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
     }
 }
 
-impl<M: PullParallelIterator> PullParallelIterator for Weight<M> {
+impl<M: IndexedParallelIterator> IndexedParallelIterator for Weight<M> {
     type Producer = WeightProducer<M::Producer>;
 
     fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -43,6 +43,9 @@ unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
     }
 }
 
+impl<M: PullParallelIterator> PullParallelIterator for Weight<M> {
+}
+
 pub struct WeightState<M>
     where M: ParallelIterator
 {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -90,15 +90,19 @@ pub struct WeightProducer<P: Producer> {
 impl<P: Producer> Producer for WeightProducer<P>
 {
     type Item = P::Item;
-    type Shared = P::Shared;
+    type Shared = (f64, P::Shared);
+
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        self.base.cost(&shared.1, items) * shared.0
+    }
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (WeightProducer { base: left }, WeightProducer { base: right })
     }
 
-    unsafe fn produce(&mut self, shared: &P::Shared) -> P::Item {
-        self.base.produce(shared)
+    unsafe fn produce(&mut self, shared: &Self::Shared) -> P::Item {
+        self.base.produce(&shared.1)
     }
 }
 

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -18,13 +18,13 @@ impl<M> ParallelIterator for Weight<M>
 {
     type Item = M::Item;
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {
         let consumer1: WeightConsumer<C> = WeightConsumer::new(consumer);
         let shared1 = (shared, self.weight);
-        self.base.drive_stateless(consumer1, &shared1)
+        self.base.drive_unindexed(consumer1, &shared1)
     }
 }
 
@@ -140,8 +140,8 @@ impl<'w, 'c, C> Consumer<'w> for WeightConsumer<'w, 'c, C>
     }
 }
 
-impl<'w, 'c, C> StatelessConsumer<'w> for WeightConsumer<'w, 'c, C>
-    where C: StatelessConsumer<'c>, 'c: 'w
+impl<'w, 'c, C> UnindexedConsumer<'w> for WeightConsumer<'w, 'c, C>
+    where C: UnindexedConsumer<'c>, 'c: 'w
 {
     fn split(&self) -> Self {
         WeightConsumer::new(self.base.split())

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -32,13 +32,13 @@ impl<M> ParallelIterator for Weight<M>
 }
 
 unsafe impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 }
 
 unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
-    fn len(&mut self) -> u64 {
+    fn len(&mut self) -> usize {
         self.base.len()
     }
 }

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -88,28 +88,13 @@ impl<P: Producer> Producer for WeightProducer<P>
 {
     type Item = P::Item;
     type Shared = P::Shared;
-    type SeqState = P::SeqState;
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
         (WeightProducer { base: left }, WeightProducer { base: right })
     }
 
-    unsafe fn start(&mut self, shared: &P::Shared) -> P::SeqState {
-        self.base.start(shared)
-    }
-
-    unsafe fn produce(&mut self,
-                      shared: &P::Shared,
-                      state: &mut P::SeqState)
-                      -> P::Item
-    {
-        self.base.produce(shared, state)
-    }
-
-    unsafe fn complete(self,
-                       shared: &P::Shared,
-                       state: P::SeqState) {
-        self.base.complete(shared, state)
+    unsafe fn produce(&mut self, shared: &P::Shared) -> P::Item {
+        self.base.produce(shared)
     }
 }

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,5 +1,4 @@
 use super::*;
-use super::len::ParallelLen;
 use super::state::*;
 use super::util::*;
 
@@ -18,8 +17,6 @@ impl<M> ParallelIterator for Weight<M>
     where M: ParallelIterator,
 {
     type Item = M::Item;
-    type Shared = WeightShared<M>;
-    type State = WeightState<M>;
 
     fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
                                                    consumer: C,
@@ -28,12 +25,6 @@ impl<M> ParallelIterator for Weight<M>
         let consumer1: WeightConsumer<C> = WeightConsumer::new(consumer);
         let shared1 = (shared, self.weight);
         self.base.drive(consumer1, &shared1)
-    }
-
-    fn state(self) -> (Self::Shared, Self::State) {
-        let (base_shared, base_state) = self.base.state();
-        (WeightShared { base: base_shared, weight: self.weight },
-         WeightState { base: base_state })
     }
 }
 
@@ -55,41 +46,6 @@ impl<M: PullParallelIterator> PullParallelIterator for Weight<M> {
     fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {
         let (base, shared) = self.base.into_producer();
         (WeightProducer { base: base }, (shared, self.weight))
-    }
-}
-
-pub struct WeightState<M>
-    where M: ParallelIterator
-{
-    base: M::State,
-}
-
-pub struct WeightShared<M>
-    where M: ParallelIterator
-{
-    base: M::Shared,
-    weight: f64,
-}
-
-unsafe impl<M> ParallelIteratorState for WeightState<M>
-    where M: ParallelIterator,
-{
-    type Item = M::Item;
-    type Shared = WeightShared<M>;
-
-    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
-        let mut l = self.base.len(&shared.base);
-        l.cost *= shared.weight;
-        l
-    }
-
-    fn split_at(self, index: usize) -> (Self, Self) {
-        let (left, right) = self.base.split_at(index);
-        (WeightState { base: left }, WeightState { base: right })
-    }
-
-    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
-        self.base.next(&shared.base)
     }
 }
 

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -29,7 +29,11 @@ impl<M> ParallelIterator for Weight<M>
 
 unsafe impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> { }
 
-unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> { }
+unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
+    fn len(&mut self) -> u64 {
+        self.base.len()
+    }
+}
 
 pub struct WeightState<M>
     where M: ParallelIterator

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -98,8 +98,8 @@ impl<P: Producer> Producer for WeightProducer<P>
     type Item = P::Item;
     type Shared = (f64, P::Shared);
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        self.base.cost(&shared.1, items) * shared.0
+    fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
+        self.base.cost(&shared.1, len) * shared.0
     }
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
@@ -137,8 +137,8 @@ impl<C> Consumer for WeightConsumer<C>
     type SeqState = C::SeqState;
     type Result = C::Result;
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
-        self.base.cost(&shared.1, items) * shared.0
+    fn cost(&mut self, shared: &Self::Shared, cost: f64) -> f64 {
+        self.base.cost(&shared.1, cost) * shared.0
     }
 
     unsafe fn split_at(self, shared: &Self::Shared, index: usize) -> (Self, Self) {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -44,6 +44,12 @@ unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
 }
 
 impl<M: PullParallelIterator> PullParallelIterator for Weight<M> {
+    type Producer = WeightProducer<M::Producer>;
+
+    fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {
+        let (base, shared) = self.base.into_producer();
+        (WeightProducer { base: base }, (self.weight, shared))
+    }
 }
 
 pub struct WeightState<M>

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -115,6 +115,11 @@ impl<P: Producer, Q: Producer> Producer for ZipProducer<P, Q>
     type Item = (P::Item, Q::Item);
     type Shared = (P::Shared, Q::Shared);
 
+    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+        // Rather unclear that this should be `+`. It might be that max is better?
+        self.p.cost(&shared.0, items) + self.q.cost(&shared.1, items)
+    }
+
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (p_left, p_right) = self.p.split_at(index);
         let (q_left, q_right) = self.q.split_at(index);

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -18,10 +18,10 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
 {
     type Item = (A::Item, B::Item);
 
-    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
-                                                   consumer: C,
-                                                   shared: &'c C::Shared)
-                                                   -> C::Result {
+    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+                                                                      consumer: C,
+                                                                      shared: &'c C::Shared)
+                                                                      -> C::Result {
         bridge(self, consumer, &shared)
     }
 }
@@ -31,6 +31,13 @@ unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
+    }
+
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
+        bridge(self, consumer, &shared)
     }
 }
 

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -21,8 +21,8 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     type Shared = ZipShared<A,B>;
     type State = ZipState<A,B>;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
-        unimplemented!()
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+        bridge(self, consumer, &shared)
     }
 
     fn state(self) -> (Self::Shared, Self::State) {

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -51,6 +51,13 @@ unsafe impl<A,B> ExactParallelIterator for ZipIter<A,B>
 impl<A,B> PullParallelIterator for ZipIter<A,B>
     where A: PullParallelIterator, B: PullParallelIterator
 {
+    type Producer = ZipProducer<A::Producer, B::Producer>;
+
+    fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {
+        let (a_producer, a_shared) = self.a.into_producer();
+        let (b_producer, b_shared) = self.b.into_producer();
+        (ZipProducer { p: a_producer, q: b_producer }, (a_shared, b_shared))
+    }
 }
 
 pub struct ZipShared<A: PullParallelIterator, B: PullParallelIterator> {

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -21,7 +21,10 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     type Shared = ZipShared<A,B>;
     type State = ZipState<A,B>;
 
-    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C, shared: C::Shared) -> C::Result {
+    fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
+                                                   consumer: C,
+                                                   shared: &'c C::Shared)
+                                                   -> C::Result {
         bridge(self, consumer, &shared)
     }
 

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -2,19 +2,19 @@ use super::*;
 use super::state::*;
 use std::cmp::min;
 
-pub struct ZipIter<A: PullParallelIterator, B: PullParallelIterator> {
+pub struct ZipIter<A: IndexedParallelIterator, B: IndexedParallelIterator> {
     a: A,
     b: B,
 }
 
-impl<A: PullParallelIterator, B: PullParallelIterator> ZipIter<A, B> {
+impl<A: IndexedParallelIterator, B: IndexedParallelIterator> ZipIter<A, B> {
     pub fn new(a: A, b: B) -> ZipIter<A, B> {
         ZipIter { a: a, b: b }
     }
 }
 
 impl<A, B> ParallelIterator for ZipIter<A, B>
-    where A: PullParallelIterator, B: PullParallelIterator
+    where A: IndexedParallelIterator, B: IndexedParallelIterator
 {
     type Item = (A::Item, B::Item);
 
@@ -27,7 +27,7 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
 }
 
 unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
-    where A: PullParallelIterator, B: PullParallelIterator
+    where A: IndexedParallelIterator, B: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -42,15 +42,15 @@ unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
 }
 
 unsafe impl<A,B> ExactParallelIterator for ZipIter<A,B>
-    where A: PullParallelIterator, B: PullParallelIterator
+    where A: IndexedParallelIterator, B: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         min(self.a.len(), self.b.len())
     }
 }
 
-impl<A,B> PullParallelIterator for ZipIter<A,B>
-    where A: PullParallelIterator, B: PullParallelIterator
+impl<A,B> IndexedParallelIterator for ZipIter<A,B>
+    where A: IndexedParallelIterator, B: IndexedParallelIterator
 {
     type Producer = ZipProducer<A::Producer, B::Producer>;
 

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,5 +1,4 @@
 use super::*;
-use super::len::ParallelLen;
 use super::state::*;
 use std::cmp::min;
 
@@ -18,20 +17,12 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     where A: PullParallelIterator, B: PullParallelIterator
 {
     type Item = (A::Item, B::Item);
-    type Shared = ZipShared<A,B>;
-    type State = ZipState<A,B>;
 
     fn drive<'c, C: Consumer<'c, Item=Self::Item>>(self,
                                                    consumer: C,
                                                    shared: &'c C::Shared)
                                                    -> C::Result {
         bridge(self, consumer, &shared)
-    }
-
-    fn state(self) -> (Self::Shared, Self::State) {
-        let (a_shared, a_state) = self.a.state();
-        let (b_shared, b_state) = self.b.state();
-        (ZipShared { a: a_shared, b: b_shared }, ZipState { a: a_state, b: b_state })
     }
 }
 
@@ -60,56 +51,6 @@ impl<A,B> PullParallelIterator for ZipIter<A,B>
         let (a_producer, a_shared) = self.a.into_producer();
         let (b_producer, b_shared) = self.b.into_producer();
         (ZipProducer { p: a_producer, q: b_producer }, (a_shared, b_shared))
-    }
-}
-
-pub struct ZipShared<A: PullParallelIterator, B: PullParallelIterator> {
-    a: A::Shared,
-    b: B::Shared,
-}
-
-pub struct ZipState<A: PullParallelIterator, B: PullParallelIterator> {
-    a: A::State,
-    b: B::State,
-}
-
-unsafe impl<A, B> ParallelIteratorState for ZipState<A,B>
-    where A: PullParallelIterator, B: PullParallelIterator
-{
-    type Item = (A::Item, B::Item);
-    type Shared = ZipShared<A, B>;
-
-    fn len(&mut self, shared: &Self::Shared) -> ParallelLen {
-        let a_len = self.a.len(&shared.a);
-        let b_len = self.b.len(&shared.b);
-
-        // Because A and B are exact parallel iterators, sparse should
-        // always be false.
-        assert!(!a_len.sparse, "A is an exact parallel iterator, so parse should be false");
-        assert!(!b_len.sparse, "B is an exact parallel iterator, so parse should be false");
-
-        ParallelLen {
-            maximal_len: min(a_len.maximal_len, b_len.maximal_len),
-            cost: a_len.cost + b_len.cost,
-            sparse: false,
-        }
-    }
-
-    fn split_at(self, index: usize) -> (Self, Self) {
-        let (a_left, a_right) = self.a.split_at(index);
-        let (b_left, b_right) = self.b.split_at(index);
-        (ZipState { a: a_left, b: b_left }, ZipState { a: a_right, b: b_right })
-    }
-
-    fn next(&mut self, shared: &Self::Shared) -> Option<Self::Item> {
-        let a_next = self.a.next(&shared.a);
-        let b_next = self.b.next(&shared.b);
-        if let Some(a_item) = a_next {
-            if let Some(b_item) = b_next {
-                return Some((a_item, b_item));
-            }
-        }
-        None
     }
 }
 

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,6 +1,6 @@
 use super::{ParallelIterator, BoundedParallelIterator, ExactParallelIterator};
 use super::len::ParallelLen;
-use super::state::ParallelIteratorState;
+use super::state::*;
 use std::cmp::min;
 
 pub struct ZipIter<A: ExactParallelIterator, B: ExactParallelIterator> {
@@ -21,6 +21,10 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     type Shared = ZipShared<A,B>;
     type State = ZipState<A,B>;
 
+    fn drive<C: Consumer<Item=Self::Item>>(self, consumer: C) -> C::Result {
+        unimplemented!()
+    }
+
     fn state(self) -> (Self::Shared, Self::State) {
         let (a_shared, a_state) = self.a.state();
         let (b_shared, b_state) = self.b.state();
@@ -30,7 +34,11 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
 
 unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
     where A: ExactParallelIterator, B: ExactParallelIterator
-{}
+{
+    fn upper_bound(&mut self) -> u64 {
+        self.len()
+    }
+}
 
 unsafe impl<A,B> ExactParallelIterator for ZipIter<A,B>
     where A: ExactParallelIterator, B: ExactParallelIterator

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -34,7 +34,11 @@ unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
 
 unsafe impl<A,B> ExactParallelIterator for ZipIter<A,B>
     where A: ExactParallelIterator, B: ExactParallelIterator
-{}
+{
+    fn len(&mut self) -> u64 {
+        min(self.a.len(), self.b.len())
+    }
+}
 
 pub struct ZipShared<A: ExactParallelIterator, B: ExactParallelIterator> {
     a: A::Shared,

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -18,7 +18,7 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
 {
     type Item = (A::Item, B::Item);
 
-    fn drive_stateless<'c, C: StatelessConsumer<'c, Item=Self::Item>>(self,
+    fn drive_unindexed<'c, C: UnindexedConsumer<'c, Item=Self::Item>>(self,
                                                                       consumer: C,
                                                                       shared: &'c C::Shared)
                                                                       -> C::Result {

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,21 +1,21 @@
-use super::{ParallelIterator, BoundedParallelIterator, ExactParallelIterator};
+use super::*;
 use super::len::ParallelLen;
 use super::state::*;
 use std::cmp::min;
 
-pub struct ZipIter<A: ExactParallelIterator, B: ExactParallelIterator> {
+pub struct ZipIter<A: PullParallelIterator, B: PullParallelIterator> {
     a: A,
     b: B,
 }
 
-impl<A: ExactParallelIterator, B: ExactParallelIterator> ZipIter<A, B> {
+impl<A: PullParallelIterator, B: PullParallelIterator> ZipIter<A, B> {
     pub fn new(a: A, b: B) -> ZipIter<A, B> {
         ZipIter { a: a, b: b }
     }
 }
 
 impl<A, B> ParallelIterator for ZipIter<A, B>
-    where A: ExactParallelIterator, B: ExactParallelIterator
+    where A: PullParallelIterator, B: PullParallelIterator
 {
     type Item = (A::Item, B::Item);
     type Shared = ZipShared<A,B>;
@@ -33,7 +33,7 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
 }
 
 unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
-    where A: ExactParallelIterator, B: ExactParallelIterator
+    where A: PullParallelIterator, B: PullParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -41,25 +41,30 @@ unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
 }
 
 unsafe impl<A,B> ExactParallelIterator for ZipIter<A,B>
-    where A: ExactParallelIterator, B: ExactParallelIterator
+    where A: PullParallelIterator, B: PullParallelIterator
 {
     fn len(&mut self) -> usize {
         min(self.a.len(), self.b.len())
     }
 }
 
-pub struct ZipShared<A: ExactParallelIterator, B: ExactParallelIterator> {
+impl<A,B> PullParallelIterator for ZipIter<A,B>
+    where A: PullParallelIterator, B: PullParallelIterator
+{
+}
+
+pub struct ZipShared<A: PullParallelIterator, B: PullParallelIterator> {
     a: A::Shared,
     b: B::Shared,
 }
 
-pub struct ZipState<A: ExactParallelIterator, B: ExactParallelIterator> {
+pub struct ZipState<A: PullParallelIterator, B: PullParallelIterator> {
     a: A::State,
     b: B::State,
 }
 
 unsafe impl<A, B> ParallelIteratorState for ZipState<A,B>
-    where A: ExactParallelIterator, B: ExactParallelIterator
+    where A: PullParallelIterator, B: PullParallelIterator
 {
     type Item = (A::Item, B::Item);
     type Shared = ZipShared<A, B>;

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -109,7 +109,6 @@ impl<P: Producer, Q: Producer> Producer for ZipProducer<P, Q>
 {
     type Item = (P::Item, Q::Item);
     type Shared = (P::Shared, Q::Shared);
-    type SeqState = (P::SeqState, Q::SeqState);
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (p_left, p_right) = self.p.split_at(index);
@@ -117,26 +116,9 @@ impl<P: Producer, Q: Producer> Producer for ZipProducer<P, Q>
         (ZipProducer { p: p_left, q: q_left }, ZipProducer { p: p_right, q: q_right })
     }
 
-    unsafe fn start(&mut self, shared: &(P::Shared, Q::Shared)) -> (P::SeqState, Q::SeqState) {
-        let p_state = self.p.start(&shared.0);
-        let q_state = self.q.start(&shared.1);
-        (p_state, q_state)
-    }
-
-    unsafe fn produce(&mut self,
-                      shared: &(P::Shared, Q::Shared),
-                      state: &mut (P::SeqState, Q::SeqState))
-                      -> (P::Item, Q::Item)
-    {
-        let p = self.p.produce(&shared.0, &mut state.0);
-        let q = self.q.produce(&shared.1, &mut state.1);
+    unsafe fn produce(&mut self, shared: &(P::Shared, Q::Shared)) -> (P::Item, Q::Item) {
+        let p = self.p.produce(&shared.0);
+        let q = self.q.produce(&shared.1);
         (p, q)
-    }
-
-    unsafe fn complete(self,
-                       shared: &(P::Shared, Q::Shared),
-                       state: (P::SeqState, Q::SeqState)) {
-        self.p.complete(&shared.0, state.0);
-        self.q.complete(&shared.1, state.1);
     }
 }

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::state::*;
+use super::internal::*;
 use std::cmp::min;
 
 pub struct ZipIter<A: IndexedParallelIterator, B: IndexedParallelIterator> {

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -35,7 +35,7 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
 unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
     where A: ExactParallelIterator, B: ExactParallelIterator
 {
-    fn upper_bound(&mut self) -> u64 {
+    fn upper_bound(&mut self) -> usize {
         self.len()
     }
 }
@@ -43,7 +43,7 @@ unsafe impl<A,B> BoundedParallelIterator for ZipIter<A,B>
 unsafe impl<A,B> ExactParallelIterator for ZipIter<A,B>
     where A: ExactParallelIterator, B: ExactParallelIterator
 {
-    fn len(&mut self) -> u64 {
+    fn len(&mut self) -> usize {
         min(self.a.len(), self.b.len())
     }
 }

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -122,9 +122,9 @@ impl<P: Producer, Q: Producer> Producer for ZipProducer<P, Q>
     type Item = (P::Item, Q::Item);
     type Shared = (P::Shared, Q::Shared);
 
-    unsafe fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
+    fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
         // Rather unclear that this should be `+`. It might be that max is better?
-        self.p.cost(&shared.0, items) + self.q.cost(&shared.1, items)
+        self.p.cost(&shared.0, len) + self.q.cost(&shared.1, len)
     }
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {


### PR DESCRIPTION
This commit history is kind of rambly but I don't have time to clean it up. The big bit of work here is support for flat-map, which required a lot of redesign. See the `par_iter/README.md` file for an overview. 

I think there is still tweaking to be done on these traits. For example, I'd like to reduce the unsafety, and maybe add some lifetimes to allow passing references for the shared state in the producer. But this will do for now.

cc @cuviper @bjz 