### PR TITLE
Restructure producer to use a callback.

### DIFF
--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -64,16 +64,16 @@ impl<M> IndexedParallelIterator for Enumerate<M>
             where CB: ProducerCallback<(usize, ITEM)>
         {
             type Output = CB::Output;
-            fn with_producer<'produce, P>(self,
-                                          base: P,
-                                          shared: &'produce P::Shared)
-                                          -> CB::Output
+            fn callback<'produce, P>(self,
+                                     base: P,
+                                     shared: &'produce P::Shared)
+                                     -> CB::Output
                 where P: Producer<'produce, Item=ITEM>
             {
                 let producer = EnumerateProducer { base: base,
                                                    offset: 0,
                                                    phantoms: PhantomType::new() };
-                self.callback.with_producer(producer, shared)
+                self.callback.callback(producer, shared)
             }
         }
     }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -51,29 +51,29 @@ unsafe impl<M> ExactParallelIterator for Enumerate<M>
 impl<M> IndexedParallelIterator for Enumerate<M>
     where M: IndexedParallelIterator,
 {
-    fn with_producer<WP>(self, wp: WP) -> WP::Output
-        where WP: ProducerContinuation<Self::Item>
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
     {
-        return self.base.with_producer(Continuation { wp: wp });
+        return self.base.with_producer(Callback { callback: callback });
 
-        struct Continuation<WP> {
-            wp: WP,
+        struct Callback<CB> {
+            callback: CB,
         }
 
-        impl<ITEM, WP> ProducerContinuation<ITEM> for Continuation<WP>
-            where WP: ProducerContinuation<(usize, ITEM)>
+        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
+            where CB: ProducerCallback<(usize, ITEM)>
         {
-            type Output = WP::Output;
+            type Output = CB::Output;
             fn with_producer<'produce, P>(self,
                                           base: P,
                                           shared: &'produce P::Shared)
-                                          -> WP::Output
+                                          -> CB::Output
                 where P: Producer<'produce, Item=ITEM>
             {
                 let producer = EnumerateProducer { base: base,
                                                    offset: 0,
                                                    phantoms: PhantomType::new() };
-                self.wp.with_producer(producer, shared)
+                self.callback.with_producer(producer, shared)
             }
         }
     }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,5 +1,6 @@
 use super::*;
 use super::internal::*;
+use super::util::PhantomType;
 
 pub struct Enumerate<M> {
     base: M,
@@ -63,11 +64,15 @@ impl<M> IndexedParallelIterator for Enumerate<M>
             where WP: ProducerContinuation<(usize, ITEM)>
         {
             type Output = WP::Output;
-            fn with_producer<P:Producer<Item=ITEM>>(self,
-                                                    base: P,
-                                                    shared: P::Shared)
-                                                    -> WP::Output {
-                let producer = EnumerateProducer { base: base, offset: 0 };
+            fn with_producer<'produce, P>(self,
+                                          base: P,
+                                          shared: &'produce P::Shared)
+                                          -> WP::Output
+                where P: Producer<'produce, Item=ITEM>
+            {
+                let producer = EnumerateProducer { base: base,
+                                                   offset: 0,
+                                                   phantoms: PhantomType::new() };
                 self.wp.with_producer(producer, shared)
             }
         }
@@ -77,18 +82,19 @@ impl<M> IndexedParallelIterator for Enumerate<M>
 ///////////////////////////////////////////////////////////////////////////
 // Producer implementation
 
-pub struct EnumerateProducer<M>
-    where M: Producer,
+pub struct EnumerateProducer<'p, P>
+    where P: Producer<'p>,
 {
-    base: M,
+    base: P,
     offset: usize,
+    phantoms: PhantomType<&'p ()>,
 }
 
-impl<M> Producer for EnumerateProducer<M>
-    where M: Producer
+impl<'p, P> Producer<'p> for EnumerateProducer<'p, P>
+    where P: Producer<'p>
 {
-    type Item = (usize, M::Item);
-    type Shared = M::Shared;
+    type Item = (usize, P::Item);
+    type Shared = P::Shared;
 
     fn cost(&mut self, shared: &Self::Shared, items: usize) -> f64 {
         self.base.cost(shared, items) // enumerating is basically free
@@ -96,11 +102,15 @@ impl<M> Producer for EnumerateProducer<M>
 
     unsafe fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
-        (EnumerateProducer { base: left, offset: self.offset },
-         EnumerateProducer { base: right, offset: self.offset + index })
+        (EnumerateProducer { base: left,
+                             offset: self.offset,
+                             phantoms: PhantomType::new() },
+         EnumerateProducer { base: right,
+                             offset: self.offset + index,
+                             phantoms: PhantomType::new() })
     }
 
-    unsafe fn produce(&mut self, shared: &Self::Shared) -> (usize, M::Item) {
+    unsafe fn produce(&mut self, shared: &Self::Shared) -> (usize, P::Item) {
         let item = self.base.produce(shared);
         let index = self.offset;
         self.offset += 1;

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -7,7 +7,7 @@ use join;
 use super::IndexedParallelIterator;
 use super::len::*;
 
-pub trait ProducerContinuation<ITEM> {
+pub trait ProducerCallback<ITEM> {
     type Output;
     fn with_producer<'p, P>(self, producer: P, shared: &'p P::Shared) -> Self::Output
         where P: Producer<'p, Item=ITEM>;
@@ -80,17 +80,17 @@ pub fn bridge<'c,PAR_ITER,C>(mut par_iter: PAR_ITER,
     where PAR_ITER: IndexedParallelIterator, C: Consumer<'c, Item=PAR_ITER::Item>
 {
     let len = par_iter.len();
-    return par_iter.with_producer(Continuation { len: len,
+    return par_iter.with_producer(Callback { len: len,
                                                  consumer: consumer,
                                                  consumer_shared: consumer_shared });
 
-    struct Continuation<'c, C> where C: Consumer<'c> {
+    struct Callback<'c, C> where C: Consumer<'c> {
         len: usize,
         consumer: C,
         consumer_shared: &'c C::Shared,
     }
 
-    impl<'c, C> ProducerContinuation<C::Item> for Continuation<'c, C> where C: Consumer<'c> {
+    impl<'c, C> ProducerCallback<C::Item> for Callback<'c, C> where C: Consumer<'c> {
         type Output = C::Result;
         fn with_producer<'p, P>(mut self,
                                 mut producer: P,

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -9,7 +9,7 @@ use super::len::*;
 
 pub trait ProducerCallback<ITEM> {
     type Output;
-    fn with_producer<'p, P>(self, producer: P, shared: &'p P::Shared) -> Self::Output
+    fn callback<'p, P>(self, producer: P, shared: &'p P::Shared) -> Self::Output
         where P: Producer<'p, Item=ITEM>;
 }
 
@@ -92,10 +92,10 @@ pub fn bridge<'c,PAR_ITER,C>(mut par_iter: PAR_ITER,
 
     impl<'c, C> ProducerCallback<C::Item> for Callback<'c, C> where C: Consumer<'c> {
         type Output = C::Result;
-        fn with_producer<'p, P>(mut self,
-                                mut producer: P,
-                                producer_shared: &'p P::Shared)
-                                -> C::Result
+        fn callback<'p, P>(mut self,
+                           mut producer: P,
+                           producer_shared: &'p P::Shared)
+                           -> C::Result
             where P: Producer<'p, Item=C::Item>
         {
             let producer_cost = producer.cost(&producer_shared, self.len);

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -82,14 +82,14 @@ impl<M, MAP_OP, R> IndexedParallelIterator for Map<M, MAP_OP>
         {
             type Output = CB::Output;
 
-            fn with_producer<'p, P>(self,
-                                    base: P,
-                                    shared: &'p P::Shared)
-                                    -> CB::Output
+            fn callback<'p, P>(self,
+                               base: P,
+                               shared: &'p P::Shared)
+                               -> CB::Output
                 where P: Producer<'p, Item=ITEM>
             {
                 let producer = MapProducer { base: base, phantoms: PhantomType::new() };
-                self.callback.with_producer(producer, &(shared, &self.map_op))
+                self.callback.callback(producer, &(shared, &self.map_op))
             }
         }
     }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! The submodules of this module mostly just contain implementaton
 //! details of little interest to an end-user. If you'd like to read
-//! the code itself, the `internals` module and `README.md` file are a
+//! the code itself, the `internal` module and `README.md` file are a
 //! good place to start.
 
 use std::f64;

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -285,7 +285,7 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
     /// producer that can be used to request the items. Users of the
     /// API never need to know about this fn.
     #[doc(hidden)]
-    fn with_producer<WP: ProducerContinuation<Self::Item>>(self, wp: WP) -> WP::Output;
+    fn with_producer<CB: ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output;
 
     /// Iterate over tuples `(A, B)`, where the items `A` are from
     /// this iterator and `B` are from the iterator given as argument.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -281,16 +281,11 @@ pub unsafe trait ExactParallelIterator: BoundedParallelIterator {
 /// that you can split it at arbitrary indices and draw data from
 /// those points.
 pub trait IndexedParallelIterator: ExactParallelIterator {
-    /// Producer type that this iterator creates. Users of the API
-    /// never need to know about this type.
-    #[doc(hidden)]
-    type Producer: Producer<Item=Self::Item>;
-
     /// Internal method to convert this parallel iterator into a
     /// producer that can be used to request the items. Users of the
     /// API never need to know about this fn.
     #[doc(hidden)]
-    fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared);
+    fn with_producer<WP: ProducerContinuation<Self::Item>>(self, wp: WP) -> WP::Output;
 
     /// Iterate over tuples `(A, B)`, where the items `A` are from
     /// this iterator and `B` are from the iterator given as argument.

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -51,11 +51,11 @@ macro_rules! range_impl {
             fn with_producer<WP>(self, wp: WP) -> WP::Output
                 where WP: ProducerContinuation<Self::Item>
             {
-                wp.with_producer(self, ())
+                wp.with_producer(self, &())
             }
         }
 
-        impl Producer for RangeIter<$t> {
+        impl<'p> Producer<'p> for RangeIter<$t> {
             type Item = $t;
             type Shared = ();
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -48,10 +48,10 @@ macro_rules! range_impl {
         }
 
         impl IndexedParallelIterator for RangeIter<$t> {
-            fn with_producer<WP>(self, wp: WP) -> WP::Output
-                where WP: ProducerContinuation<Self::Item>
+            fn with_producer<CB>(self, callback: CB) -> CB::Output
+                where CB: ProducerCallback<Self::Item>
             {
-                wp.with_producer(self, &())
+                callback.with_producer(self, &())
             }
         }
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -51,7 +51,7 @@ macro_rules! range_impl {
             fn with_producer<CB>(self, callback: CB) -> CB::Output
                 where CB: ProducerCallback<Self::Item>
             {
-                callback.with_producer(self, &())
+                callback.callback(self, &())
             }
         }
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -48,10 +48,10 @@ macro_rules! range_impl {
         }
 
         impl IndexedParallelIterator for RangeIter<$t> {
-            type Producer = Self;
-
-            fn into_producer(self) -> (Self::Producer, <Self::Producer as Producer>::Shared) {
-                (self, ())
+            fn with_producer<WP>(self, wp: WP) -> WP::Output
+                where WP: ProducerContinuation<Self::Item>
+            {
+                wp.with_producer(self, ())
             }
         }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -57,7 +57,7 @@ impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
     fn with_producer<WP>(self, wp: WP) -> WP::Output
         where WP: ProducerContinuation<Self::Item>
     {
-        wp.with_producer(SliceProducer { slice: self.slice }, ())
+        wp.with_producer(SliceProducer { slice: self.slice }, &())
     }
 }
 
@@ -67,7 +67,7 @@ pub struct SliceProducer<'data, T: 'data + Sync> {
     slice: &'data [T]
 }
 
-impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T>
+impl<'p, 'data, T: 'data + Sync> Producer<'p> for SliceProducer<'data, T>
 {
     type Item = &'data T;
     type Shared = ();

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -54,10 +54,10 @@ unsafe impl<'data, T: Sync + 'data> ExactParallelIterator for SliceIter<'data, T
 }
 
 impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
-    fn with_producer<WP>(self, wp: WP) -> WP::Output
-        where WP: ProducerContinuation<Self::Item>
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
     {
-        wp.with_producer(SliceProducer { slice: self.slice }, &())
+        callback.with_producer(SliceProducer { slice: self.slice }, &())
     }
 }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -54,10 +54,10 @@ unsafe impl<'data, T: Sync + 'data> ExactParallelIterator for SliceIter<'data, T
 }
 
 impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
-    type Producer = SliceProducer<'data, T>;
-
-    fn into_producer(self) -> (Self::Producer, ()) {
-        (SliceProducer { slice: self.slice }, ())
+    fn with_producer<WP>(self, wp: WP) -> WP::Output
+        where WP: ProducerContinuation<Self::Item>
+    {
+        wp.with_producer(SliceProducer { slice: self.slice }, ())
     }
 }
 

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -57,7 +57,7 @@ impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.with_producer(SliceProducer { slice: self.slice }, &())
+        callback.callback(SliceProducer { slice: self.slice }, &())
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -58,7 +58,7 @@ impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> 
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.with_producer(SliceMutProducer { slice: self.slice }, &())
+        callback.callback(SliceMutProducer { slice: self.slice }, &())
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -55,10 +55,10 @@ unsafe impl<'data, T: Send + 'data> ExactParallelIterator for SliceIterMut<'data
 }
 
 impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> {
-    fn with_producer<WP>(self, wp: WP) -> WP::Output
-        where WP: ProducerContinuation<Self::Item>
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
     {
-        wp.with_producer(SliceMutProducer { slice: self.slice }, &())
+        callback.with_producer(SliceMutProducer { slice: self.slice }, &())
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -55,10 +55,10 @@ unsafe impl<'data, T: Send + 'data> ExactParallelIterator for SliceIterMut<'data
 }
 
 impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> {
-    type Producer = SliceMutProducer<'data, T>;
-
-    fn into_producer(self) -> (Self::Producer, ()) {
-        (SliceMutProducer { slice: self.slice }, ())
+    fn with_producer<WP>(self, wp: WP) -> WP::Output
+        where WP: ProducerContinuation<Self::Item>
+    {
+        wp.with_producer(SliceMutProducer { slice: self.slice }, ())
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -58,7 +58,7 @@ impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> 
     fn with_producer<WP>(self, wp: WP) -> WP::Output
         where WP: ProducerContinuation<Self::Item>
     {
-        wp.with_producer(SliceMutProducer { slice: self.slice }, ())
+        wp.with_producer(SliceMutProducer { slice: self.slice }, &())
     }
 }
 
@@ -68,7 +68,7 @@ pub struct SliceMutProducer<'data, T: 'data + Send> {
     slice: &'data mut [T]
 }
 
-impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T>
+impl<'p, 'data, T: 'data + Send> Producer<'p> for SliceMutProducer<'data, T>
 {
     type Item = &'data mut T;
     type Shared = ();

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -73,25 +73,6 @@ pub fn map_reduce_weighted() {
 }
 
 #[test]
-pub fn check_weight() {
-    let a: Vec<i32> = (0..1024).collect();
-
-    let cost1 = {
-        let (mut producer, shared) = a.par_iter().into_producer();
-        producer.cost(&shared, 1024)
-    };
-
-    let cost2 = {
-        let (mut producer, shared) = a.par_iter()
-                                      .weight(2.0)
-                                      .into_producer();
-        producer.cost(&shared, 1024)
-    };
-
-    assert_eq!(cost1 * 2.0, cost2);
-}
-
-#[test]
 pub fn check_weight_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().weight(2.0));

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -50,25 +50,25 @@ unsafe impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
 }
 
 impl<M: IndexedParallelIterator> IndexedParallelIterator for Weight<M> {
-    fn with_producer<WP>(self, wp: WP) -> WP::Output
-        where WP: ProducerContinuation<Self::Item>
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
     {
-        return self.base.with_producer(Continuation { weight: self.weight, wp: wp });
+        return self.base.with_producer(Callback { weight: self.weight, callback: callback });
 
-        struct Continuation<WP> {
+        struct Callback<CB> {
             weight: f64,
-            wp: WP
+            callback: CB
         }
 
-        impl<ITEM,WP> ProducerContinuation<ITEM> for Continuation<WP>
-            where WP: ProducerContinuation<ITEM>
+        impl<ITEM,CB> ProducerCallback<ITEM> for Callback<CB>
+            where CB: ProducerCallback<ITEM>
         {
-            type Output = WP::Output;
+            type Output = CB::Output;
 
             fn with_producer<'p, P>(self, base: P, shared: &'p P::Shared) -> Self::Output
                 where P: Producer<'p, Item=ITEM>
             {
-                self.wp.with_producer(WeightProducer { base: base, phantoms: PhantomType::new() },
+                self.callback.with_producer(WeightProducer { base: base, phantoms: PhantomType::new() },
                                       &(shared, self.weight))
             }
         }

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -65,11 +65,11 @@ impl<M: IndexedParallelIterator> IndexedParallelIterator for Weight<M> {
         {
             type Output = CB::Output;
 
-            fn with_producer<'p, P>(self, base: P, shared: &'p P::Shared) -> Self::Output
+            fn callback<'p, P>(self, base: P, shared: &'p P::Shared) -> Self::Output
                 where P: Producer<'p, Item=ITEM>
             {
-                self.callback.with_producer(WeightProducer { base: base, phantoms: PhantomType::new() },
-                                      &(shared, self.weight))
+                self.callback.callback(WeightProducer { base: base, phantoms: PhantomType::new() },
+                                       &(shared, self.weight))
             }
         }
     }

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -109,17 +109,17 @@ impl<A,B> IndexedParallelIterator for ZipIter<A,B>
 
 ///////////////////////////////////////////////////////////////////////////
 
-pub struct ZipProducer<'p, 'q, P: Producer<'p>, Q: Producer<'q>> {
-    p: P,
-    q: Q,
-    phantoms: PhantomType<(&'p (), &'q ())>,
+pub struct ZipProducer<'a, 'b, A: Producer<'a>, B: Producer<'b>> {
+    p: A,
+    q: B,
+    phantoms: PhantomType<(&'a (), &'b ())>,
 }
 
-impl<'z, 'p, 'q, P: Producer<'p>, Q: Producer<'q>> Producer<'z> for ZipProducer<'p, 'q, P, Q>
-    where 'p: 'z, 'q: 'z
+impl<'z, 'a, 'b, A: Producer<'a>, B: Producer<'b>> Producer<'z> for ZipProducer<'a, 'b, A, B>
+    where 'a: 'z, 'b: 'z
 {
-    type Item = (P::Item, Q::Item);
-    type Shared = (&'p P::Shared, &'q Q::Shared);
+    type Item = (A::Item, B::Item);
+    type Shared = (&'a A::Shared, &'b B::Shared);
 
     fn cost(&mut self, shared: &Self::Shared, len: usize) -> f64 {
         // Rather unclear that this should be `+`. It might be that max is better?
@@ -133,7 +133,7 @@ impl<'z, 'p, 'q, P: Producer<'p>, Q: Producer<'q>> Producer<'z> for ZipProducer<
          ZipProducer { p: p_right, q: q_right, phantoms: PhantomType::new() })
     }
 
-    unsafe fn produce(&mut self, shared: &(&P::Shared, &Q::Shared)) -> (P::Item, Q::Item) {
+    unsafe fn produce(&mut self, shared: &(&A::Shared, &B::Shared)) -> (A::Item, B::Item) {
         let p = self.p.produce(shared.0);
         let q = self.q.produce(shared.1);
         (p, q)

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -72,7 +72,7 @@ impl<A,B> IndexedParallelIterator for ZipIter<A,B>
         {
             type Output = CB::Output;
 
-            fn with_producer<'a, A>(self, a_producer: A, a_shared: &'a A::Shared) -> Self::Output
+            fn callback<'a, A>(self, a_producer: A, a_shared: &'a A::Shared) -> Self::Output
                 where A: Producer<'a, Item=A_ITEM>
             {
                 return self.b.with_producer(CallbackB {
@@ -95,12 +95,12 @@ impl<A,B> IndexedParallelIterator for ZipIter<A,B>
         {
             type Output = CB::Output;
 
-            fn with_producer<'b, B>(self, b_producer: B, b_shared: &'b B::Shared) -> Self::Output
+            fn callback<'b, B>(self, b_producer: B, b_shared: &'b B::Shared) -> Self::Output
                 where B: Producer<'b, Item=B_ITEM>
             {
-                self.callback.with_producer(ZipProducer { p: self.a_producer, q: b_producer,
-                                                    phantoms: PhantomType::new() },
-                                      &(self.a_shared, b_shared))
+                self.callback.callback(ZipProducer { p: self.a_producer, q: b_producer,
+                                                     phantoms: PhantomType::new() },
+                                       &(self.a_shared, b_shared))
             }
         }
 


### PR DESCRIPTION
This change was a bit of a pain, but makes sense conceptually, and should enable "moving" iterators quite gracefully (e.g., `Vec::into_par_iter`). The idea is to change `fn into_producer(self)` to instead be:

```rust
    fn with_producer<WP: ProducerContinuation<Self::Item>>(self, wp: WP) -> WP::Output;
```

where `ProducerContinuation` is basically a callback with a specific continuation:

```rust
pub trait ProducerContinuation<ITEM> {
    type Output;
    fn with_producer<'p, P>(self, producer: P, shared: &'p P::Shared) -> Self::Output
        where P: Producer<'p, Item=ITEM>;
}
```

This would be a closure, except that closures can't be generic in the way that `with_producer` is monomorphic. That is, to use a closure, we'd have to specify a particular kind of producer, whereas with the trait, the producer type is not known to the continuation. It's sort of the difference between having `T: Fn(SomeType)` and `T: for<P> Fn(P)` (the latter is not syntax we support).

Anyway, this requires rewriting some really simple code into really horrific explicit continuations. However, the benefits are:

1. We can pass the shared state using only references, which means we never move the `map` closures and the like (before, we used to move them out of a structure and onto the stack, etc). I would expect this to be a perf-win, though how large I have no idea.
    - The reason this is possible is that the produce type `P` can now contain local lifetimes.
2. Later, we can implement `into_par_iter` for `Vec<T>` relatively easily; I guess before it was possible if ownership of the vec was moved into the `Shared` type, but that was both unsafe and unfortunate, since it requires the moves I was complaining about above. Now that the processing of the producer takes place inside the `with_producer` call, we can handle the freeing ourselves more easily.

