### PR TITLE
Keep rayon stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: rust
 rust:
+  - stable
   - nightly
 script:
-  - cargo test
+  - cargo build
+  - |
+    [ $TRAVIS_RUST_VERSION != nightly ] ||
+    cargo test
   - cd demo/quicksort
   - cargo build

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -5,7 +5,7 @@ pub struct SliceIter<'data, T: 'data + Sync> {
     slice: &'data [T]
 }
 
-impl<'data, T: Sync> IntoParallelIterator for &'data [T] {
+impl<'data, T: Sync + 'data> IntoParallelIterator for &'data [T] {
     type Item = &'data T;
     type Iter = SliceIter<'data, T>;
 


### PR DESCRIPTION
Slice's IntoParallelIterator was missing a `T: 'data`, upsetting rust 1.6.

This also adds rust stable to the travis script.  We can't run tests on stable
since compiletest_rs requires nightly features, but we can at least build it.