### PR TITLE
Add a few simple benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ deque = "0.3.1"
 
 [dev-dependencies]
 compiletest_rs = "0.0.11"
+num = "0.1.30"

--- a/benches/factorial.rs
+++ b/benches/factorial.rs
@@ -1,0 +1,79 @@
+//! Benchmark Factorial N! = 1×2×⋯×N
+
+#![feature(test)]
+
+extern crate num;
+extern crate rayon;
+extern crate test;
+
+use num::{One, BigUint};
+use rayon::par_iter::*;
+use std::ops::Mul;
+
+const N: u32 = 9999;
+
+/// Compute the Factorial using a plain iterator.
+fn factorial(n: u32) -> BigUint {
+    (1 .. n + 1)
+        .map(BigUint::from)
+        .fold(BigUint::one(), Mul::mul)
+}
+
+
+#[bench]
+/// Benchmark the Factorial using a plain iterator.
+fn factorial_iterator(b: &mut test::Bencher) {
+    let f = factorial(N);
+    b.iter(|| assert_eq!(factorial(test::black_box(N)), f));
+}
+
+
+#[bench]
+/// Compute the Factorial using rayon::par_iter.
+fn factorial_par_iter(b: &mut test::Bencher) {
+    rayon::initialize();
+
+    fn fact(n: u32) -> BigUint {
+        (1 .. n + 1).into_par_iter().weight_max()
+            .map(BigUint::from)
+            .reduce_with(Mul::mul)
+            .unwrap()
+    }
+
+    let f = factorial(N);
+    b.iter(|| assert_eq!(fact(test::black_box(N)), f));
+}
+
+
+#[bench]
+/// Compute the Factorial using divide-and-conquer serial recursion.
+fn factorial_recursion(b: &mut test::Bencher) {
+
+    fn product(a: u32, b: u32) -> BigUint {
+        if a == b { return a.into(); }
+        let mid = (a + b) / 2;
+        product(a, mid) * product(mid + 1, b)
+    }
+
+    let f = factorial(N);
+    b.iter(|| assert_eq!(product(1, test::black_box(N)), f));
+}
+
+
+#[bench]
+/// Compute the Factorial using divide-and-conquer parallel join.
+fn factorial_join(b: &mut test::Bencher) {
+    rayon::initialize();
+
+    fn product(a: u32, b: u32) -> BigUint {
+        if a == b { return a.into(); }
+        let mid = (a + b) / 2;
+        let (x, y) = rayon::join(
+            || product(a, mid),
+            || product(mid + 1, b));
+        x * y
+    }
+
+    let f = factorial(N);
+    b.iter(|| assert_eq!(product(1, test::black_box(N)), f));
+}

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,0 +1,94 @@
+//! Benchmark Fibonacci numbers, F(n) = F(n-1) + F(n-2)
+//!
+//! Recursion is a horrible way to compute this -- roughly O(2ⁿ).
+//! 
+//! It's potentially interesting for rayon::join, because the splits are
+//! unequal.  F(n-1) has roughly twice as much work to do as F(n-2).  The
+//! imbalance might make it more likely to leave idle threads ready to steal
+//! jobs.  We can also see if there's any effect to having the larger job first
+//! or second.
+//!
+//! We're doing very little real work in each job, so the rayon overhead is
+//! going to dominate.  The serial recursive version will likely be faster,
+//! unless you have a whole lot of CPUs.  The iterative version reveals the
+//! joke.
+
+#![feature(test)]
+
+extern crate rayon;
+extern crate test;
+
+const N: u32 = 32;
+const FN: u32 = 2178309;
+
+
+#[bench]
+/// Compute the Fibonacci number recursively, without any parallelism.
+fn fibonacci_recursive(b: &mut test::Bencher) {
+
+    fn fib(n: u32) -> u32 {
+        if n < 2 { return n; }
+
+        fib(n - 1) + fib(n - 2)
+    }
+
+    b.iter(|| assert_eq!(fib(test::black_box(N)), FN));
+}
+
+
+#[bench]
+/// Compute the Fibonacci number recursively, using rayon::join.
+/// The larger branch F(N-1) is computed first.
+fn fibonacci_join_1_2(b: &mut test::Bencher) {
+    rayon::initialize();
+
+    fn fib(n: u32) -> u32 {
+        if n < 2 { return n; }
+
+        let (a, b) = rayon::join(
+            || fib(n - 1),
+            || fib(n - 2));
+        a + b
+    }
+
+    b.iter(|| assert_eq!(fib(test::black_box(N)), FN));
+}
+
+
+#[bench]
+/// Compute the Fibonacci number recursively, using rayon::join.
+/// The smaller branch F(N-2) is computed first.
+fn fibonacci_join_2_1(b: &mut test::Bencher) {
+    rayon::initialize();
+
+    fn fib(n: u32) -> u32 {
+        if n < 2 { return n; }
+
+        let (a, b) = rayon::join(
+            || fib(n - 2),
+            || fib(n - 1));
+        a + b
+    }
+
+    b.iter(|| assert_eq!(fib(test::black_box(N)), FN));
+}
+
+
+#[bench]
+/// Compute the Fibonacci number iteratively, just to show how silly the others
+/// are.  Parallelism can't make up for a bad choice of algorithm.
+fn fibonacci_iterative(b: &mut test::Bencher) {
+
+    fn fib(n: u32) -> u32 {
+        let mut a = 0;
+        let mut b = 1;
+        for _ in 0..n {
+            let c = a + b;
+            a = b;
+            b = c;
+        }
+        a
+    }
+
+    b.iter(|| assert_eq!(fib(test::black_box(N)), FN));
+}

--- a/benches/pythagoras.rs
+++ b/benches/pythagoras.rs
@@ -1,0 +1,79 @@
+//! How many Pythagorean triples exist less than or equal to a million?
+//! i.e. a²+b²=c² and a,b,c ≤ 1000000
+
+#![feature(test)]
+
+extern crate num;
+extern crate rayon;
+extern crate test;
+
+use num::Integer;
+use rayon::par_iter::*;
+use std::f64::INFINITY;
+use std::ops::Add;
+
+/// Use Euclid's formula to count Pythagorean triples
+///
+/// https://en.wikipedia.org/wiki/Pythagorean_triple#Generating_a_triple
+///
+/// For coprime integers m and n, with m > n and m-n is odd, then
+///     a = m²-n², b = 2mn, c = m²+n²
+///
+/// This is a coprime triple.  Multiplying by factors k covers all triples.
+fn par_euclid(m_weight: f64, n_weight: f64) -> u32 {
+    (1u32 .. 1000).into_par_iter().weight(m_weight).map(|m| {
+        (1 .. m).into_par_iter().weight(n_weight)
+            .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
+            .map(|n| 1000000 / (m*m + n*n))
+            .sum()
+    }).sum()
+}
+
+/// Same as par_euclid, without using rayon.
+fn euclid() -> u32 {
+    (1u32 .. 1000).map(|m| {
+        (1 .. m)
+            .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
+            .map(|n| 1000000 / (m*m + n*n))
+            .fold(0, Add::add)
+    }).fold(0, Add::add)
+}
+
+#[bench]
+/// Benchmark without rayon at all
+fn euclid_serial(b: &mut test::Bencher) {
+    let count = euclid();
+    b.iter(|| assert_eq!(euclid(), count))
+}
+
+#[bench]
+/// Use zero weights to force it fully serialized.
+fn euclid_faux_serial(b: &mut test::Bencher) {
+    rayon::initialize();
+    let count = euclid();
+    b.iter(|| assert_eq!(par_euclid(0.0, 0.0), count))
+}
+
+#[bench]
+/// Use the default weights (1.0)
+fn euclid_default(b: &mut test::Bencher) {
+    rayon::initialize();
+    let count = euclid();
+    b.iter(|| assert_eq!(par_euclid(1.0, 1.0), count))
+}
+
+#[bench]
+/// Use infinite weight to force the outer loop parallelized.
+fn euclid_parallel_outer(b: &mut test::Bencher) {
+    rayon::initialize();
+    let count = euclid();
+    b.iter(|| assert_eq!(par_euclid(INFINITY, 1.0), count))
+}
+
+#[bench]
+/// Use infinite weights to force it fully parallelized.
+fn euclid_parallel_full(b: &mut test::Bencher) {
+    rayon::initialize();
+    let count = euclid();
+    b.iter(|| assert_eq!(par_euclid(INFINITY, INFINITY), count))
+}


### PR DESCRIPTION
See each commit message for benchmark results on my i7-2600 (4 core, 8 threads)
running on Linux, Fedora 23 x86_64.

These aren't terribly interesting computations, nor are they really good demos
of rayon, as a lot of the results don't show good parallelization.  But they do
hammer on rayon pretty hard, so I hope they're still useful for comparing the
effects of any proposed rayon changes.