### PR TITLE
Adapt benchmarks to the changes in the initialize function

### DIFF
--- a/benches/factorial.rs
+++ b/benches/factorial.rs
@@ -8,8 +8,10 @@ extern crate test;
 
 use num::{One, BigUint};
 use rayon::par_iter::*;
+use rayon::Configuration;
 use std::ops::Mul;
 
+const INIT_FAILED: &'static str = "Rayon failed to initialize";
 const N: u32 = 9999;
 
 /// Compute the Factorial using a plain iterator.
@@ -31,7 +33,8 @@ fn factorial_iterator(b: &mut test::Bencher) {
 #[bench]
 /// Compute the Factorial using rayon::par_iter.
 fn factorial_par_iter(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
 
     fn fact(n: u32) -> BigUint {
         (1 .. n + 1).into_par_iter().weight_max()
@@ -63,7 +66,8 @@ fn factorial_recursion(b: &mut test::Bencher) {
 #[bench]
 /// Compute the Factorial using divide-and-conquer parallel join.
 fn factorial_join(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
 
     fn product(a: u32, b: u32) -> BigUint {
         if a == b { return a.into(); }

--- a/benches/fibonacci.rs
+++ b/benches/fibonacci.rs
@@ -1,7 +1,7 @@
 //! Benchmark Fibonacci numbers, F(n) = F(n-1) + F(n-2)
 //!
 //! Recursion is a horrible way to compute this -- roughly O(2ⁿ).
-//! 
+//!
 //! It's potentially interesting for rayon::join, because the splits are
 //! unequal.  F(n-1) has roughly twice as much work to do as F(n-2).  The
 //! imbalance might make it more likely to leave idle threads ready to steal
@@ -18,6 +18,9 @@
 extern crate rayon;
 extern crate test;
 
+use rayon::Configuration;
+
+const INIT_FAILED: &'static str = "Rayon failed to initialize";
 const N: u32 = 32;
 const FN: u32 = 2178309;
 
@@ -40,7 +43,8 @@ fn fibonacci_recursive(b: &mut test::Bencher) {
 /// Compute the Fibonacci number recursively, using rayon::join.
 /// The larger branch F(N-1) is computed first.
 fn fibonacci_join_1_2(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
 
     fn fib(n: u32) -> u32 {
         if n < 2 { return n; }
@@ -59,7 +63,8 @@ fn fibonacci_join_1_2(b: &mut test::Bencher) {
 /// Compute the Fibonacci number recursively, using rayon::join.
 /// The smaller branch F(N-2) is computed first.
 fn fibonacci_join_2_1(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
 
     fn fib(n: u32) -> u32 {
         if n < 2 { return n; }

--- a/benches/pythagoras.rs
+++ b/benches/pythagoras.rs
@@ -9,8 +9,11 @@ extern crate test;
 
 use num::Integer;
 use rayon::par_iter::*;
+use rayon::Configuration;
 use std::f64::INFINITY;
 use std::ops::Add;
+
+const INIT_FAILED: &'static str = "Rayon failed to initialize";
 
 /// Use Euclid's formula to count Pythagorean triples
 ///
@@ -49,7 +52,9 @@ fn euclid_serial(b: &mut test::Bencher) {
 #[bench]
 /// Use zero weights to force it fully serialized.
 fn euclid_faux_serial(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
+
     let count = euclid();
     b.iter(|| assert_eq!(par_euclid(0.0, 0.0), count))
 }
@@ -57,7 +62,9 @@ fn euclid_faux_serial(b: &mut test::Bencher) {
 #[bench]
 /// Use the default weights (1.0)
 fn euclid_default(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
+
     let count = euclid();
     b.iter(|| assert_eq!(par_euclid(1.0, 1.0), count))
 }
@@ -65,7 +72,9 @@ fn euclid_default(b: &mut test::Bencher) {
 #[bench]
 /// Use infinite weight to force the outer loop parallelized.
 fn euclid_parallel_outer(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
+
     let count = euclid();
     b.iter(|| assert_eq!(par_euclid(INFINITY, 1.0), count))
 }
@@ -73,7 +82,9 @@ fn euclid_parallel_outer(b: &mut test::Bencher) {
 #[bench]
 /// Use infinite weights to force it fully parallelized.
 fn euclid_parallel_full(b: &mut test::Bencher) {
-    rayon::initialize();
+    rayon::initialize(Configuration::new())
+                     .expect(INIT_FAILED);
+
     let count = euclid();
     b.iter(|| assert_eq!(par_euclid(INFINITY, INFINITY), count))
 }


### PR DESCRIPTION
I wanted to benchmark the changes in #37, but the benchmarks were broken due to the latest changes to support a way to indicate a limit on the number of threads that rayon can use.

This adapts to the new changes.