### PR TITLE
Add Vec::into_par_iter

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -40,6 +40,7 @@ pub mod map;
 pub mod weight;
 pub mod zip;
 pub mod range;
+pub mod vec;
 
 #[cfg(test)]
 mod test;

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -126,6 +126,54 @@ pub fn check_increment() {
 }
 
 #[test]
+pub fn check_move() {
+    let a = vec![vec![1, 2, 3]];
+    let ptr = a[0].as_ptr();
+
+    let mut b = vec![];
+    a.into_par_iter().collect_into(&mut b);
+
+    // a simple move means the inner vec will be completely unchanged
+    assert_eq!(ptr, b[0].as_ptr());
+}
+
+#[test]
+pub fn check_drops() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let c = AtomicUsize::new(0);
+    let a = vec![DropCounter(&c); 10];
+
+    let mut b = vec![];
+    a.clone().into_par_iter().collect_into(&mut b);
+    assert_eq!(c.load(Ordering::Relaxed), 0);
+
+    b.into_par_iter();
+    assert_eq!(c.load(Ordering::Relaxed), 10);
+
+    a.into_par_iter().with_producer(Partial);
+    assert_eq!(c.load(Ordering::Relaxed), 20);
+
+
+    #[derive(Clone)]
+    struct DropCounter<'a>(&'a AtomicUsize);
+    impl<'a> Drop for DropCounter<'a> {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    struct Partial;
+    impl<'a> ProducerCallback<DropCounter<'a>> for Partial {
+        type Output = ();
+        fn callback<P>(self, producer: P) where P: Producer<Item=DropCounter<'a>> {
+            let (a, _) = producer.split_at(5);
+            a.into_iter().next();
+        }
+    }
+}
+
+#[test]
 pub fn check_slice_exact_and_bounded() {
     let a = vec![1, 2, 3];
     is_bounded(a.par_iter());
@@ -139,6 +187,14 @@ pub fn check_slice_mut_exact_and_bounded() {
     is_bounded(a.par_iter_mut());
     is_exact(a.par_iter_mut());
     is_indexed(a.par_iter_mut());
+}
+
+#[test]
+pub fn check_vec_exact_and_bounded() {
+    let a = vec![1, 2, 3];
+    is_bounded(a.clone().into_par_iter());
+    is_exact(a.clone().into_par_iter());
+    is_indexed(a.clone().into_par_iter());
 }
 
 #[test]

--- a/src/par_iter/vec.rs
+++ b/src/par_iter/vec.rs
@@ -1,0 +1,126 @@
+use super::*;
+use super::internal::*;
+use std;
+
+pub struct VecIter<T: Send> {
+    vec: Vec<T>,
+    consumed: bool,
+}
+
+impl<T: Send> IntoParallelIterator for Vec<T> {
+    type Item = T;
+    type Iter = VecIter<T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        VecIter { vec: self, consumed: false }
+    }
+}
+
+impl<T: Send> ParallelIterator for VecIter<T> {
+    type Item = T;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<T: Send> BoundedParallelIterator for VecIter<T> {
+    fn upper_bound(&mut self) -> usize {
+        ExactParallelIterator::len(self)
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<T: Send> ExactParallelIterator for VecIter<T> {
+    fn len(&mut self) -> usize {
+        self.vec.len()
+    }
+}
+
+impl<T: Send> IndexedParallelIterator for VecIter<T> {
+    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        // The producer will move or drop each item from the slice.
+        let producer = VecProducer { slice: &mut self.vec };
+        self.consumed = true;
+        callback.callback(producer)
+    }
+}
+
+impl<T: Send> Drop for VecIter<T> {
+    fn drop(&mut self) {
+        if self.consumed {
+            // only need vec to free its buffer now
+            unsafe { self.vec.set_len(0) };
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+pub struct VecProducer<'data, T: 'data + Send> {
+    slice: &'data mut [T]
+}
+
+impl<'data, T: 'data + Send> Producer for VecProducer<'data, T> {
+    fn cost(&mut self, len: usize) -> f64 {
+        len as f64
+    }
+
+    fn split_at(mut self, index: usize) -> (Self, Self) {
+        // replace the slice so we don't drop it twice
+        let slice = std::mem::replace(&mut self.slice, &mut []);
+        let (left, right) = slice.split_at_mut(index);
+        (VecProducer { slice: left }, VecProducer { slice: right })
+    }
+}
+
+impl<'data, T: 'data + Send> IntoIterator for VecProducer<'data, T> {
+    type Item = T;
+    type IntoIter = SliceDrain<'data, T>;
+
+    fn into_iter(mut self) -> Self::IntoIter {
+        // replace the slice so we don't drop it twice
+        let slice = std::mem::replace(&mut self.slice, &mut []);
+        SliceDrain { iter: slice.iter_mut() }
+    }
+}
+
+impl<'data, T: 'data + Send> Drop for VecProducer<'data, T> {
+    fn drop(&mut self) {
+        SliceDrain { iter: self.slice.iter_mut() };
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+// like std::vec::Drain, without updating a source Vec
+pub struct SliceDrain<'data, T: 'data> {
+    iter: std::slice::IterMut<'data, T>
+}
+
+impl<'data, T: 'data> Iterator for SliceDrain<'data, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        self.iter.next()
+            .map(|ptr| unsafe { std::ptr::read(ptr) })
+    }
+}
+
+impl<'data, T: 'data> Drop for SliceDrain<'data, T> {
+    fn drop(&mut self) {
+        for ptr in &mut self.iter {
+            // use drop_in_place once stable
+            unsafe { std::ptr::read(ptr); }
+        }
+    }
+}


### PR DESCRIPTION
This is modeled similarly to what &mut[] does, except that values are
moved out with ptr::read, and any remains are dropped.

Fixes #17.