### PR TITLE
Add a reduce version of nbody benchmark, some new combinators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ num = "0.1.30"
 
 [features]
 nightly = []
+
+# Unstable APIs that have not yet
+# proven their utility.
+unstable = []

--- a/demo/nbody/Cargo.toml
+++ b/demo/nbody/Cargo.toml
@@ -8,6 +8,6 @@ cgmath = { version = "0.7", features = ["unstable"] }
 docopt = "0.6"
 glium = "0.13"
 rand = "0.3"
-rayon = { path = "../../" }
+rayon = { path = "../../", features = ["unstable"] }
 rustc-serialize = "0.3"
 time = "0.1"

--- a/demo/nbody/src/main.rs
+++ b/demo/nbody/src/main.rs
@@ -18,7 +18,7 @@ use self::visualize::visualize_benchmarks;
 use self::nbody::NBodyBenchmark;
 
 const USAGE: &'static str = "
-Usage: nbody bench [--no-par | --no-seq] [--bodies N --ticks N]
+Usage: nbody bench [--mode MODE --bodies N --ticks N]
        nbody visualize [--mode MODE --bodies N]
        nbody --help
 
@@ -28,16 +28,15 @@ Commands:
 
 Options:
     -h, --help         Show this message.
-    --no-par           Skip parallel execution in the benchmark.
-    --no-seq           Skip sequential execution in the benchmark.
-    --mode MODE        Execution mode for the visualizer [default: par].
+    --mode MODE        Execution mode for the benchmark/visualizer.
     --bodies N         Use N bodies [default: 4000].
     --ticks N          Simulate for N ticks [default: 100].
 ";
 
-#[derive(Copy, Clone, RustcDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, RustcDecodable)]
 pub enum ExecutionMode {
     Par,
+    ParReduce,
     Seq,
 }
 
@@ -45,9 +44,7 @@ pub enum ExecutionMode {
 pub struct Args {
     cmd_bench: bool,
     cmd_visualize: bool,
-    flag_no_par: bool,
-    flag_no_seq: bool,
-    flag_mode: ExecutionMode,
+    flag_mode: Option<ExecutionMode>,
     flag_bodies: usize,
     flag_ticks: usize,
 }
@@ -59,16 +56,20 @@ fn main() {
             .unwrap_or_else(|e| e.exit());
 
     if args.cmd_bench {
-        run_benchmarks(!args.flag_no_par, !args.flag_no_seq,
-                       args.flag_bodies, args.flag_ticks);
+        run_benchmarks(args.flag_mode, args.flag_bodies, args.flag_ticks);
     }
 
     if args.cmd_visualize {
-        visualize_benchmarks(args.flag_bodies, args.flag_mode);
+        visualize_benchmarks(args.flag_bodies,
+                             args.flag_mode.unwrap_or(ExecutionMode::Par));
     }
 }
 
-fn run_benchmarks(run_par: bool, run_seq: bool, bodies: usize, ticks: usize) {
+fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
+    let run_par = mode.map(|m| m == ExecutionMode::Par).unwrap_or(true);
+    let run_par_reduce = mode.map(|m| m == ExecutionMode::ParReduce).unwrap_or(true);
+    let run_seq = mode.map(|m| m == ExecutionMode::Seq).unwrap_or(true);
+
     let par_time = if run_par {
         let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
         let mut benchmark = NBodyBenchmark::new(bodies, &mut rng);
@@ -80,6 +81,23 @@ fn run_benchmarks(run_par: bool, run_seq: bool, bodies: usize, ticks: usize) {
 
         let par_time = time::precise_time_ns() - par_start;
         println!("Parallel time   : {}", par_time);
+
+        Some(par_time)
+    } else {
+        None
+    };
+
+    let par_reduce_time = if run_par_reduce {
+        let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
+        let mut benchmark = NBodyBenchmark::new(bodies, &mut rng);
+        let par_start = time::precise_time_ns();
+
+        for _ in 0..ticks {
+            benchmark.tick_par_reduce();
+        }
+
+        let par_time = time::precise_time_ns() - par_start;
+        println!("ParReduce time  : {}", par_time);
 
         Some(par_time)
     } else {
@@ -105,5 +123,9 @@ fn run_benchmarks(run_par: bool, run_seq: bool, bodies: usize, ticks: usize) {
 
     if let (Some(pt), Some(st)) = (par_time, seq_time) {
         println!("Parallel speedup: {}", (st as f32) / (pt as f32));
+    }
+
+    if let (Some(pt), Some(st)) = (par_reduce_time, seq_time) {
+        println!("Parallel reduce speedup: {}", (st as f32) / (pt as f32));
     }
 }

--- a/demo/nbody/src/main.rs
+++ b/demo/nbody/src/main.rs
@@ -80,7 +80,7 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
         }
 
         let par_time = time::precise_time_ns() - par_start;
-        println!("Parallel time    : {}", par_time);
+        println!("Parallel time    : {} ns", par_time);
 
         Some(par_time)
     } else {
@@ -97,7 +97,7 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
         }
 
         let par_time = time::precise_time_ns() - par_start;
-        println!("ParReduce time   : {}", par_time);
+        println!("ParReduce time   : {} ns", par_time);
 
         Some(par_time)
     } else {
@@ -114,7 +114,7 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
         }
 
         let seq_time = time::precise_time_ns() - seq_start;
-        println!("Sequential time  : {}", seq_time);
+        println!("Sequential time  : {} ns", seq_time);
 
         Some(seq_time)
     } else {

--- a/demo/nbody/src/main.rs
+++ b/demo/nbody/src/main.rs
@@ -80,7 +80,7 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
         }
 
         let par_time = time::precise_time_ns() - par_start;
-        println!("Parallel time   : {}", par_time);
+        println!("Parallel time    : {}", par_time);
 
         Some(par_time)
     } else {
@@ -97,7 +97,7 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
         }
 
         let par_time = time::precise_time_ns() - par_start;
-        println!("ParReduce time  : {}", par_time);
+        println!("ParReduce time   : {}", par_time);
 
         Some(par_time)
     } else {
@@ -114,7 +114,7 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
         }
 
         let seq_time = time::precise_time_ns() - seq_start;
-        println!("Sequential time : {}", seq_time);
+        println!("Sequential time  : {}", seq_time);
 
         Some(seq_time)
     } else {
@@ -122,10 +122,10 @@ fn run_benchmarks(mode: Option<ExecutionMode>, bodies: usize, ticks: usize) {
     };
 
     if let (Some(pt), Some(st)) = (par_time, seq_time) {
-        println!("Parallel speedup: {}", (st as f32) / (pt as f32));
+        println!("Parallel speedup : {}", (st as f32) / (pt as f32));
     }
 
     if let (Some(pt), Some(st)) = (par_reduce_time, seq_time) {
-        println!("Parallel reduce speedup: {}", (st as f32) / (pt as f32));
+        println!("ParReduce speedup: {}", (st as f32) / (pt as f32));
     }
 }

--- a/demo/nbody/src/nbody.rs
+++ b/demo/nbody/src/nbody.rs
@@ -207,53 +207,63 @@ fn next_velocity(time: usize, prev: &Body, bodies: &[Body]) -> (Vector3<f64>, Ve
 
     // TODO -- parallelize this loop too? would be easy enough, it's just a reduction
     // Just have to factor things so that `tick_seq` doesn't do it in parallel.
-    for body in bodies {
-        let r = body.position - prev.position;
+    let zero: Vector3<f64> = Vector3::zero();
+    let (diff, diff2) = bodies
+        .iter()
+        .fold(
+            (zero, zero),
+            |(mut diff, mut diff2), body| {
+                let r = body.position - prev.position;
 
-        // make sure we are not testing the particle against its own position
-        let are_same = r == Vector3::zero();
+                // make sure we are not testing the particle against its own position
+                let are_same = r == Vector3::zero();
 
-        let dist_sqrd = r.length2();
+                let dist_sqrd = r.length2();
 
-        if dist_sqrd < zone_sqrd && !are_same {
-            let length = dist_sqrd.sqrt();
-            let percent = dist_sqrd / zone_sqrd;
+                if dist_sqrd < zone_sqrd && !are_same {
+                    let length = dist_sqrd.sqrt();
+                    let percent = dist_sqrd / zone_sqrd;
 
-            if dist_sqrd < repel {
-                let f = (repel / percent - 1.0) * 0.025;
-                let normal = (r / length) * f;
-                acc += normal;
-                acc2 += normal;
-            } else if dist_sqrd < align {
-                let thresh_delta = align - repel;
-                let adjusted_percent = (percent - repel) / thresh_delta;
-                let q = (0.5 - (adjusted_percent * PI * 2.0).cos() * 0.5 + 0.5) * 100.9;
+                    if dist_sqrd < repel {
+                        let f = (repel / percent - 1.0) * 0.025;
+                        let normal = (r / length) * f;
+                        diff += normal;
+                        diff2 += normal;
+                    } else if dist_sqrd < align {
+                        let thresh_delta = align - repel;
+                        let adjusted_percent = (percent - repel) / thresh_delta;
+                        let q = (0.5 - (adjusted_percent * PI * 2.0).cos() * 0.5 + 0.5) * 100.9;
 
-                // normalize vel2 and multiply by factor
-                let vel2_length = body.velocity2.length();
-                let vel2 = (body.velocity2 / vel2_length) * q;
+                        // normalize vel2 and multiply by factor
+                        let vel2_length = body.velocity2.length();
+                        let vel2 = (body.velocity2 / vel2_length) * q;
 
-                // normalize own velocity
-                let vel_length = prev.velocity.length();
-                let vel = (prev.velocity / vel_length) * q;
+                        // normalize own velocity
+                        let vel_length = prev.velocity.length();
+                        let vel = (prev.velocity / vel_length) * q;
 
-                acc += vel2;
-                acc2 += vel;
-            }
+                        diff += vel2;
+                        diff2 += vel;
+                    }
 
-            if dist_sqrd > attract { // attract
-                let thresh_delta2 = 1.0 - attract;
-                let adjusted_percent2 = (percent - attract) / thresh_delta2;
-                let c = (1.0 - ((adjusted_percent2 * PI * 2.0).cos() * 0.5 + 0.5)) * attract_power;
+                    if dist_sqrd > attract { // attract
+                        let thresh_delta2 = 1.0 - attract;
+                        let adjusted_percent2 = (percent - attract) / thresh_delta2;
+                        let c = (1.0 - ((adjusted_percent2 * PI * 2.0).cos() * 0.5 + 0.5)) * attract_power;
 
-                // normalize the distance vector
-                let d = (r / length) * c;
+                        // normalize the distance vector
+                        let d = (r / length) * c;
 
-                acc += d;
-                acc2 -= d;
-            }
-        }
-    }
+                        diff += d;
+                        diff2 -= d;
+                    }
+                }
+
+                (diff, diff2)
+            });
+
+    acc += diff;
+    acc2 += diff2;
 
     // Speed limits
     if time > 500.0 {

--- a/demo/nbody/src/nbody.rs
+++ b/demo/nbody/src/nbody.rs
@@ -109,7 +109,7 @@ impl NBodyBenchmark {
         out_bodies
     }
 
-    pub fn tick_reduce(&mut self) -> &[Body] {
+    pub fn tick_par_reduce(&mut self) -> &[Body] {
         let (in_bodies, out_bodies) = if (self.time & 1) == 0 {
             (&self.bodies.0, &mut self.bodies.1)
         } else {

--- a/demo/nbody/src/nbody.rs
+++ b/demo/nbody/src/nbody.rs
@@ -96,6 +96,31 @@ impl NBodyBenchmark {
                   .weight(200.0)
                   .zip(&in_bodies[..])
                   .for_each(|(out, prev)| {
+                      let (vel, vel2) = next_velocity(time, prev, in_bodies);
+                      out.velocity = vel;
+                      out.velocity2 = vel2;
+
+                      let next_velocity = vel - vel2;
+                      out.position = prev.position + next_velocity;
+                  });
+
+        self.time += 1;
+
+        out_bodies
+    }
+
+    pub fn tick_reduce(&mut self) -> &[Body] {
+        let (in_bodies, out_bodies) = if (self.time & 1) == 0 {
+            (&self.bodies.0, &mut self.bodies.1)
+        } else {
+            (&self.bodies.1, &mut self.bodies.0)
+        };
+
+        let time = self.time;
+        out_bodies.par_iter_mut()
+                  .weight(200.0)
+                  .zip(&in_bodies[..])
+                  .for_each(|(out, prev)| {
                       let (vel, vel2) = next_velocity_par(time, prev, in_bodies);
                       out.velocity = vel;
                       out.velocity2 = vel2;

--- a/demo/nbody/src/visualize.rs
+++ b/demo/nbody/src/visualize.rs
@@ -134,6 +134,7 @@ pub fn visualize_benchmarks(num_bodies: usize, mode: ExecutionMode) {
         {
             let bodies = match mode {
                 ExecutionMode::Par => benchmark.tick_par(),
+                ExecutionMode::ParReduce => benchmark.tick_par_reduce(),
                 ExecutionMode::Seq => benchmark.tick_seq(),
             };
 

--- a/demo/nbody/src/visualize.rs
+++ b/demo/nbody/src/visualize.rs
@@ -69,7 +69,7 @@ struct Instance {
 
 implement_vertex!(Instance, color, world_position);
 
-pub fn visualize_benchmarks(num_bodies: usize, mode: ExecutionMode) {
+pub fn visualize_benchmarks(num_bodies: usize, mut mode: ExecutionMode) {
     let display = WindowBuilder::new()
         .with_dimensions(800, 600)
         .with_title("nbody demo".to_string())
@@ -178,6 +178,15 @@ pub fn visualize_benchmarks(num_bodies: usize, mode: ExecutionMode) {
             match event {
                 Event::Closed => break 'main,
                 Event::KeyboardInput(ElementState::Pressed, _, Some(Key::Escape)) => break 'main,
+                Event::KeyboardInput(ElementState::Pressed, _, Some(Key::P)) => {
+                    mode = ExecutionMode::Par;
+                }
+                Event::KeyboardInput(ElementState::Pressed, _, Some(Key::S)) => {
+                    mode = ExecutionMode::Seq;
+                }
+                Event::KeyboardInput(ElementState::Pressed, _, Some(Key::R)) => {
+                    mode = ExecutionMode::ParReduce;
+                }
                 _ => ()
             }
         }

--- a/src/par_iter/fold.rs
+++ b/src/par_iter/fold.rs
@@ -1,0 +1,104 @@
+use super::ParallelIterator;
+use super::len::*;
+use super::internal::*;
+
+pub fn fold<PAR_ITER,I,FOLD_OP,REDUCE_OP>(pi: PAR_ITER,
+                                          identity: &I,
+                                          fold_op: &FOLD_OP,
+                                          reduce_op: &REDUCE_OP)
+                                          -> I
+    where PAR_ITER: ParallelIterator,
+          FOLD_OP: Fn(I, PAR_ITER::Item) -> I + Sync,
+          REDUCE_OP: Fn(I, I) -> I + Sync,
+          I: Clone + Send + Sync,
+{
+    let consumer = FoldConsumer { identity: identity,
+                                  fold_op: fold_op,
+                                  reduce_op: reduce_op };
+    pi.drive_unindexed(consumer)
+}
+
+struct FoldConsumer<'r, I:'r, FOLD_OP: 'r, REDUCE_OP: 'r> {
+    identity: &'r I,
+    fold_op: &'r FOLD_OP,
+    reduce_op: &'r REDUCE_OP,
+}
+
+impl<'r, I, FOLD_OP, REDUCE_OP> Copy for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP> {
+}
+
+impl<'r, I, FOLD_OP, REDUCE_OP> Clone for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP> {
+    fn clone(&self) -> Self { *self }
+}
+
+impl<'r, ITEM, I, FOLD_OP, REDUCE_OP> Consumer<ITEM>
+    for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP>
+    where FOLD_OP: Fn(I, ITEM) -> I + Sync,
+          REDUCE_OP: Fn(I, I) -> I + Sync,
+          I: Clone + Send + Sync,
+{
+    type Folder = FoldFolder<'r, I, FOLD_OP>;
+    type Reducer = Self;
+    type Result = I;
+
+    fn cost(&mut self, cost: f64) -> f64 {
+        // This isn't quite right, as we will do more than O(n) reductions, but whatever.
+        cost * FUNC_ADJUSTMENT
+    }
+
+    fn split_at(self, _index: usize) -> (Self, Self, Self) {
+        (self, self, self)
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        FoldFolder { item: self.identity.clone(),
+                     fold_op: self.fold_op }
+    }
+}
+
+impl<'r, ITEM, I, FOLD_OP, REDUCE_OP> UnindexedConsumer<ITEM>
+    for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP>
+    where FOLD_OP: Fn(I, ITEM) -> I + Sync,
+          REDUCE_OP: Fn(I, I) -> I + Sync,
+          I: Clone + Send + Sync,
+{
+    fn split_off(&self) -> Self {
+        *self
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        *self
+    }
+}
+
+impl<'r, I, FOLD_OP, REDUCE_OP> Reducer<I>
+    for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP>
+    where REDUCE_OP: Fn(I, I) -> I + Sync,
+          I: Clone + Send + Sync,
+{
+    fn reduce(self, left: I, right: I) -> I {
+        (self.reduce_op)(left, right)
+    }
+}
+
+pub struct FoldFolder<'r, I, FOLD_OP: 'r> {
+    fold_op: &'r FOLD_OP,
+    item: I,
+}
+
+impl<'r, I, FOLD_OP, ITEM> Folder<ITEM>
+    for FoldFolder<'r, I, FOLD_OP>
+    where FOLD_OP: Fn(I, ITEM) -> I + Sync,
+{
+    type Result = I;
+
+    fn consume(self, item: ITEM) -> Self {
+        let item = (self.fold_op)(self.item, item);
+        FoldFolder { fold_op: self.fold_op, item: item }
+    }
+
+    fn complete(self) -> I {
+        self.item
+    }
+}
+

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -33,6 +33,7 @@ pub mod flat_map;
 pub mod internal;
 pub mod len;
 pub mod for_each;
+#[cfg(feature = "unstable")]
 pub mod fold;
 pub mod reduce;
 pub mod slice;
@@ -168,6 +169,7 @@ pub trait ParallelIterator: Sized {
         reduce(self, &ReduceWithIdentityOp::new(&identity, &op))
     }
 
+    #[cfg(feature = "unstable")]
     fn fold<I,FOLD_OP,REDUCE_OP>(self,
                                  identity: I,
                                  fold_op: FOLD_OP,

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -33,6 +33,7 @@ pub mod flat_map;
 pub mod internal;
 pub mod len;
 pub mod for_each;
+pub mod fold;
 pub mod reduce;
 pub mod slice;
 pub mod slice_mut;
@@ -165,6 +166,18 @@ pub trait ParallelIterator: Sized {
               Self::Item: Clone + Sync,
     {
         reduce(self, &ReduceWithIdentityOp::new(&identity, &op))
+    }
+
+    fn fold<I,FOLD_OP,REDUCE_OP>(self,
+                                 identity: I,
+                                 fold_op: FOLD_OP,
+                                 reduce_op: REDUCE_OP)
+                                 -> I
+        where FOLD_OP: Fn(I, Self::Item) -> I + Sync,
+              REDUCE_OP: Fn(I, I) -> I + Sync,
+              I: Clone + Sync + Send,
+    {
+        fold::fold(self, &identity, &fold_op, &reduce_op)
     }
 
     /// Sums up the items in the iterator.

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -39,6 +39,7 @@ pub fn check_map_exact_and_bounded() {
 pub fn map_reduce() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
+              .weight_max()
               .map(|&i| i + 1)
               .sum();
     let r2 = a.iter()
@@ -51,12 +52,26 @@ pub fn map_reduce() {
 pub fn map_reduce_with() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
+              .weight_max()
               .map(|&i| i + 1)
               .reduce_with(|i, j| i + j);
     let r2 = a.iter()
               .map(|&i| i + 1)
               .fold(0, |a,b| a+b);
     assert_eq!(r1.unwrap(), r2);
+}
+
+#[test]
+pub fn map_reduce_with_identity() {
+    let a: Vec<i32> = (0..1024).collect();
+    let r1 = a.par_iter()
+              .weight_max()
+              .map(|&i| i + 1)
+              .reduce_with_identity(0, |i, j| i + j);
+    let r2 = a.iter()
+              .map(|&i| i + 1)
+              .fold(0, |a,b| a+b);
+    assert_eq!(r1, r2);
 }
 
 #[test]


### PR DESCRIPTION
This updates the nbody benchmark in two ways:

1. Adds a mode (par-reduce) that uses reduction internally. Right now this is kind of clumsily done, resulting in code duplication. This version runs more slowly than the original but exercises more of the parallel iterators API (and might provide a good target for optimization).
    - That said, I'd like to work on it a bit more to use parallel iterators better and remove DRY before we go too crazy.
2. Updates the visualizer to let you press `P`, `R`, or `S` during execution.
3. Updates the CLI to just use `--mode` universally.

cc @bjz 