### PR TITLE
Added `fn par_chunks` and `fn par_chunks_mut` methods.

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -68,6 +68,36 @@ pub trait IntoParallelRefMutIterator<'data> {
     fn par_iter_mut(&'data mut self) -> Self::Iter;
 }
 
+pub trait ToParallelChunks<'data> {
+    type Iter: ParallelIterator<Item=&'data [Self::Item]>;
+    type Item: Sync + 'data;
+
+    /// Returns a parallel iterator over at most `size` elements of
+    /// `self` at a time. The chunks do not overlap.
+    ///
+    /// The policy for how a collection is divided into chunks is not
+    /// dictated here (e.g. a B-tree-like collection may by necessity
+    /// produce many chunks with fewer than `size` elements), but an
+    /// implementation should strive to maximize chunk size when
+    /// possible.
+    fn par_chunks(&'data self, size: usize) -> Self::Iter;
+}
+
+pub trait ToParallelChunksMut<'data> {
+    type Iter: ParallelIterator<Item=&'data mut [Self::Item]>;
+    type Item: Send + 'data;
+
+    /// Returns a parallel iterator over at most `size` elements of
+    /// `self` at a time. The chunks are mutable and do not overlap.
+    ///
+    /// The policy for how a collection is divided into chunks is not
+    /// dictated here (e.g. a B-tree-like collection may by necessity
+    /// produce many chunks with fewer than `size` elements), but an
+    /// implementation should strive to maximize chunk size when
+    /// possible.
+    fn par_chunks_mut(&'data mut self, size: usize) -> Self::Iter;
+}
+
 /// The `ParallelIterator` interface.
 pub trait ParallelIterator: Sized {
     type Item: Send;

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -32,6 +32,15 @@ impl<'data, T: Sync + 'data> IntoParallelRefIterator<'data> for [T] {
     }
 }
 
+impl<'data, T: Sync + 'data> ToParallelChunks<'data> for [T] {
+    type Item = T;
+    type Iter = ChunksIter<'data, T>;
+
+    fn par_chunks(&'data self, chunk_size: usize) -> Self::Iter {
+        ChunksIter { chunk_size: chunk_size, slice: self }
+    }
+}
+
 impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
     type Item = &'data T;
 
@@ -68,6 +77,47 @@ impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
     }
 }
 
+pub struct ChunksIter<'data, T: 'data + Sync> {
+    chunk_size: usize,
+    slice: &'data [T],
+}
+
+impl<'data, T: Sync + 'data> ParallelIterator for ChunksIter<'data, T> {
+    type Item = &'data [T];
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<'data, T: Sync + 'data> BoundedParallelIterator for ChunksIter<'data, T> {
+    fn upper_bound(&mut self) -> usize {
+        ExactParallelIterator::len(self)
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<'data, T: Sync + 'data> ExactParallelIterator for ChunksIter<'data, T> {
+    fn len(&mut self) -> usize {
+        self.slice.len()
+    }
+}
+
+impl<'data, T: Sync + 'data> IndexedParallelIterator for ChunksIter<'data, T> {
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        callback.callback(SliceChunksProducer { chunk_size: self.chunk_size, slice: self.slice })
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 
 pub struct SliceProducer<'data, T: 'data + Sync> {
@@ -91,5 +141,32 @@ impl<'data, T: 'data + Sync> IntoIterator for SliceProducer<'data, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.slice.into_iter()
+    }
+}
+
+pub struct SliceChunksProducer<'data, T: 'data + Sync> {
+    chunk_size: usize,
+    slice: &'data [T]
+}
+
+impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
+    fn cost(&mut self, len: usize) -> f64 {
+        len as f64
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let elem_index = (index + self.chunk_size - 1) / self.chunk_size;
+        let (left, right) = self.slice.split_at(elem_index);
+        (SliceChunksProducer { chunk_size: self.chunk_size, slice: left },
+         SliceChunksProducer { chunk_size: self.chunk_size, slice: right })
+    }
+}
+
+impl<'data, T: 'data + Sync> IntoIterator for SliceChunksProducer<'data, T> {
+    type Item = &'data [T];
+    type IntoIter = ::std::slice::Chunks<'data, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slice.chunks(self.chunk_size)
     }
 }

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -106,7 +106,7 @@ impl<'data, T: Sync + 'data> BoundedParallelIterator for ChunksIter<'data, T> {
 
 impl<'data, T: Sync + 'data> ExactParallelIterator for ChunksIter<'data, T> {
     fn len(&mut self) -> usize {
-        self.slice.len()
+        (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
 }
 
@@ -155,7 +155,7 @@ impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        let elem_index = (index + self.chunk_size - 1) / self.chunk_size;
+        let elem_index = index * self.chunk_size;
         let (left, right) = self.slice.split_at(elem_index);
         (SliceChunksProducer { chunk_size: self.chunk_size, slice: left },
          SliceChunksProducer { chunk_size: self.chunk_size, slice: right })

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -32,6 +32,15 @@ impl<'data, T: Send + 'data> IntoParallelRefMutIterator<'data> for [T] {
     }
 }
 
+impl<'data, T: Send + 'data> ToParallelChunksMut<'data> for [T] {
+    type Item = T;
+    type Iter = ChunksMutIter<'data, T>;
+
+    fn par_chunks_mut(&'data mut self, chunk_size: usize) -> Self::Iter {
+        ChunksMutIter { chunk_size: chunk_size, slice: self }
+    }
+}
+
 impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
     type Item = &'data mut T;
 
@@ -68,6 +77,47 @@ impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> 
     }
 }
 
+pub struct ChunksMutIter<'data, T: 'data + Send> {
+    chunk_size: usize,
+    slice: &'data mut [T],
+}
+
+impl<'data, T: Send + 'data> ParallelIterator for ChunksMutIter<'data, T> {
+    type Item = &'data mut [T];
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMutIter<'data, T> {
+    fn upper_bound(&mut self) -> usize {
+        ExactParallelIterator::len(self)
+    }
+
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<'data, T: Send + 'data> ExactParallelIterator for ChunksMutIter<'data, T> {
+    fn len(&mut self) -> usize {
+        self.slice.len()
+    }
+}
+
+impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMutIter<'data, T> {
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        callback.callback(SliceChunksMutProducer { chunk_size: self.chunk_size, slice: self.slice })
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 
 pub struct SliceMutProducer<'data, T: 'data + Send> {
@@ -92,5 +142,32 @@ impl<'data, T: 'data + Send> IntoIterator for SliceMutProducer<'data, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.slice.into_iter()
+    }
+}
+
+pub struct SliceChunksMutProducer<'data, T: 'data + Send> {
+    chunk_size: usize,
+    slice: &'data mut [T]
+}
+
+impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
+    fn cost(&mut self, len: usize) -> f64 {
+        len as f64
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let elem_index = (index + self.chunk_size - 1) / self.chunk_size;
+        let (left, right) = self.slice.split_at_mut(elem_index);
+        (SliceChunksMutProducer { chunk_size: self.chunk_size, slice: left },
+         SliceChunksMutProducer { chunk_size: self.chunk_size, slice: right })
+    }
+}
+
+impl<'data, T: 'data + Send> IntoIterator for SliceChunksMutProducer<'data, T> {
+    type Item = &'data mut [T];
+    type IntoIter = ::std::slice::ChunksMut<'data, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slice.chunks_mut(self.chunk_size)
     }
 }

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -106,7 +106,7 @@ impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMutIter<'data, T>
 
 impl<'data, T: Send + 'data> ExactParallelIterator for ChunksMutIter<'data, T> {
     fn len(&mut self) -> usize {
-        self.slice.len()
+        (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
 }
 
@@ -156,7 +156,7 @@ impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        let elem_index = (index + self.chunk_size - 1) / self.chunk_size;
+        let elem_index = index * self.chunk_size;
         let (left, right) = self.slice.split_at_mut(elem_index);
         (SliceChunksMutProducer { chunk_size: self.chunk_size, slice: left },
          SliceChunksMutProducer { chunk_size: self.chunk_size, slice: right })

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -323,3 +323,51 @@ pub fn check_flat_map_nested_ranges() {
     assert_eq!(v, w);
 }
 
+#[test]
+pub fn check_chunks() {
+    let a: Vec<i32> = vec![1, 5, 10, 4, 100, 3, 1000, 2, 10000, 1];
+    let par_sum_product_pairs =
+         a.par_chunks(2)
+          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
+          .sum();
+    let seq_sum_product_pairs =
+         a.chunks(2)
+          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
+          .fold(0, |i, j| i+j);
+    assert_eq!(par_sum_product_pairs, 12345);
+    assert_eq!(par_sum_product_pairs, seq_sum_product_pairs);
+
+    let par_sum_product_triples: i32 =
+         a.par_chunks(3)
+          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
+          .sum();
+    let seq_sum_product_triples =
+         a.chunks(3)
+          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
+          .fold(0, |i, j| i+j);
+    assert_eq!(par_sum_product_triples, 5_0 + 12_00 + 2_000_0000 + 1);
+    assert_eq!(par_sum_product_triples, seq_sum_product_triples);
+}
+
+#[test]
+pub fn check_chunks_mut() {
+    let mut a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let mut b: Vec<i32> = a.clone();
+    a.par_chunks_mut(2)
+        .for_each(|c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j));
+    b.chunks_mut(2)
+        .map(     |c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j))
+        .count();
+    assert_eq!(a, &[3, 2, 7, 4, 11, 6, 15, 8, 19, 10]);
+    assert_eq!(a, b);
+
+    let mut a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    let mut b: Vec<i32> = a.clone();
+    a.par_chunks_mut(3)
+        .for_each(|c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j));
+    b.chunks_mut(3)
+        .map(     |c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j))
+        .count();
+    assert_eq!(a, &[6, 2, 3, 15, 5, 6, 24, 8, 9, 10]);
+    assert_eq!(a, b);
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -328,6 +328,7 @@ pub fn check_chunks() {
     let a: Vec<i32> = vec![1, 5, 10, 4, 100, 3, 1000, 2, 10000, 1];
     let par_sum_product_pairs =
          a.par_chunks(2)
+          .weight_max()
           .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
           .sum();
     let seq_sum_product_pairs =
@@ -339,6 +340,7 @@ pub fn check_chunks() {
 
     let par_sum_product_triples: i32 =
          a.par_chunks(3)
+          .weight_max()
           .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
           .sum();
     let seq_sum_product_triples =
@@ -354,6 +356,7 @@ pub fn check_chunks_mut() {
     let mut a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let mut b: Vec<i32> = a.clone();
     a.par_chunks_mut(2)
+        .weight_max()
         .for_each(|c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j));
     b.chunks_mut(2)
         .map(     |c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j))
@@ -364,6 +367,7 @@ pub fn check_chunks_mut() {
     let mut a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     let mut b: Vec<i32> = a.clone();
     a.par_chunks_mut(3)
+        .weight_max()
         .for_each(|c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j));
     b.chunks_mut(3)
         .map(     |c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j))

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,3 +9,6 @@ pub use par_iter::ParallelIterator;
 pub use par_iter::BoundedParallelIterator;
 pub use par_iter::ExactParallelIterator;
 pub use par_iter::IndexedParallelIterator;
+
+pub use par_iter::ToParallelChunks;
+pub use par_iter::ToParallelChunksMut;


### PR DESCRIPTION
Added `fn par_chunks` and `fn par_chunks_mut` methods.

These for iteration over chunks of slice in parallel. (The particular use case I am thinking of are things like processing the rows of a matrix that uses a slice in row-major order for its representation.)