### PR TITLE
Fixes for panic propagation

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -3,6 +3,8 @@ use latch::Latch;
 use std::any::Any;
 #[cfg(feature = "nightly")]
 use std::panic::{self, AssertRecoverSafe};
+use std::cell::UnsafeCell;
+use std::mem;
 
 enum JobResult<T> {
     None,
@@ -16,24 +18,20 @@ enum JobResult<T> {
 /// arranged in a deque, so that thieves can take from the top of the
 /// deque while the main worker manages the bottom of the deque. This
 /// deque is managed by the `thread_pool` module.
-///
-/// Note that we don't use a trait here due to `&mut` aliasing issues. A thief
-/// needs an `&mut` to access the func and result fields, while the original
-/// thread uses a `&` to access the latch. We solve this by simply using a raw
-/// pointer which allows us to get an &mut for func and result while getting a
-/// `&` for the latch.
-#[derive(Copy, Clone)]
-pub struct Job {
-    pub execute: unsafe fn(*mut ()),
-    pub data: *mut (),
+pub trait Job {
+    unsafe fn execute(&self);
+    unsafe fn abort(&self);
 }
-unsafe impl Send for Job { }
-unsafe impl Sync for Job { }
+
+#[derive(Copy, Clone)]
+pub struct JobRef(pub *const Job);
+unsafe impl Send for JobRef {}
+unsafe impl Sync for JobRef {}
 
 pub struct JobImpl<L:Latch,F,R> {
     pub latch: L,
-    func: Option<F>,
-    result: JobResult<R>,
+    func: UnsafeCell<Option<F>>,
+    result: UnsafeCell<JobResult<R>>,
 }
 
 impl<L:Latch,F,R> JobImpl<L,F,R>
@@ -42,51 +40,31 @@ impl<L:Latch,F,R> JobImpl<L,F,R>
     pub fn new(func: F, latch: L) -> JobImpl<L,F,R> {
         JobImpl {
             latch: latch,
-            func: Some(func),
-            result: JobResult::None,
+            func: UnsafeCell::new(Some(func)),
+            result: UnsafeCell::new(JobResult::None),
         }
     }
 
-    pub unsafe fn as_job(&mut self) -> Job {
-        unsafe fn execute<L:Latch,F,R>(data: *mut ())
-            where F: FnOnce() -> R
-        {
-            let job = data as *mut JobImpl<L,F,R>;
-
-            // Use a guard here to ensure that the latch is always set, even if
-            // the function panics.
-            struct PanicGuard<'a,L:Latch + 'a>(&'a L);
-            impl<'a,L:Latch> Drop for PanicGuard<'a,L> {
-                fn drop(&mut self) {
-                    self.0.set();
-                }
-            }
-            let _guard = PanicGuard(&(*job).latch);
-            let func = (*job).func.take().unwrap();
-            (*job).result = JobImpl::<L,F,R>::run_result(func);
-        }
-
-        Job {
-            execute: execute::<L,F,R>,
-            data: self as *mut _ as *mut (),
-        }
+    pub unsafe fn as_job_ref(&self) -> JobRef {
+        let job_ref: *const (Job + 'static) = mem::transmute(self as *const Job);
+        JobRef(job_ref)
     }
 
-    pub fn run_inline(self) -> R {
-        self.func.unwrap()()
+    pub unsafe fn run_inline(self) -> R {
+        self.func.into_inner().unwrap()()
     }
 
     #[cfg(not(feature = "nightly"))]
-    pub fn into_result(self) -> R {
-        match self.result {
+    pub unsafe fn into_result(self) -> R {
+        match self.result.into_inner() {
             JobResult::None => panic!("job function panicked"),
             JobResult::Ok(x) => x,
         }
     }
 
     #[cfg(feature = "nightly")]
-    pub fn into_result(self) -> R {
-        match self.result {
+    pub unsafe fn into_result(self) -> R {
+        match self.result.into_inner() {
             JobResult::None => unreachable!(),
             JobResult::Ok(x) => x,
             JobResult::Panic(x) => panic::propagate(x),
@@ -103,11 +81,34 @@ impl<L:Latch,F,R> JobImpl<L,F,R>
         // We assert that func is recover-safe since it doesn't touch any of
         // our data and we will be propagating the panic back to the user at
         // the join() call.
-        // FIXME(rust-lang/rust#31728) Use into_inner() instead
-        let mut wrapper = AssertRecoverSafe::new(Some(func));
-        match panic::recover(move || (*wrapper).take().unwrap()()) {
+        let wrapper = AssertRecoverSafe::new(func);
+        match panic::recover(move || wrapper.into_inner()()) {
             Ok(x) => JobResult::Ok(x),
             Err(x) => JobResult::Panic(x),
         }
+    }
+}
+
+impl<L:Latch,F,R> Job for JobImpl<L,F,R>
+    where F: FnOnce() -> R
+{
+    unsafe fn execute(&self) {
+        // Use a guard here to ensure that the latch is always set, even if
+        // the function panics.
+        struct PanicGuard<'a,L:Latch + 'a>(&'a L);
+        impl<'a,L:Latch> Drop for PanicGuard<'a,L> {
+            fn drop(&mut self) {
+                self.0.set();
+            }
+        }
+
+        let _guard = PanicGuard(&self.latch);
+        let func = (*self.func.get()).take().unwrap();
+        (*self.result.get()) = Self::run_result(func);
+    }
+
+    unsafe fn abort(&self) {
+        // Just set the latch and leave the result as None
+        self.latch.set();
     }
 }


### PR DESCRIPTION
The key part is the missing guard in `steal_until`, which was causing the crashes because unwinding would overwrite the job data.

Another issue was that some injected jobs could be left hanging after the thread pool was terminated. This is resolved by aborting all injected jobs on termination.

I also changed the code back to using a trait and just wrapped the mutable values in `UnsafeCell`.

Fixes #58