### PR TITLE
small readme doc fix saying f32 twice instead of f32 and f64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ serve a common purpose:
 1. A `Cell` offers a mutable slot with just two methods, `get` and
    `set`.  Cells can only be used for `Copy` types that are safe to
    memcpy around, such as `i32`, `f32`, or even something bigger like
-   `(usize, usize, f32)`.
+   `(usize, usize, f64)`.
 2. A `RefCell` is kind of like a "single-threaded read-write lock"; it
    can be used with any sort of type `T`. To gain access to the data
    inside, you call `borrow` or `borrow_mut`. Dynamic checks are done
@@ -364,5 +364,3 @@ fn search(path: &Path, cost_so_far: usize, best_cost: &Arc<AtomicUsize>) {
 
 Now in this case, we really WANT to see results from other threads
 interjected into our execution!
-
-

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ serve a common purpose:
 
 1. A `Cell` offers a mutable slot with just two methods, `get` and
    `set`.  Cells can only be used for `Copy` types that are safe to
-   memcpy around, such as `i32`, `f32`, or even something bigger like
-   `(usize, usize, f64)`.
+   memcpy around, such as `i32`, `f32`, or even something bigger like a tuple of
+   `(usize, usize, f32)`.
 2. A `RefCell` is kind of like a "single-threaded read-write lock"; it
    can be used with any sort of type `T`. To gain access to the data
    inside, you call `borrow` or `borrow_mut`. Dynamic checks are done


### PR DESCRIPTION
The README.md in the section  about atomicity metions:

A Cell offers a mutable slot with just two methods, get and set. Cells can only be used for Copy types that are safe to memcpy around, such as i32, **f32,** or even something **bigger** like (usize, usize, **f32**).

it mentions the f32 primitive and something bigger than that but again mentioning f32.

i'm assuming the intent was to say f64, this micro pr fixes that.

Liam Clark

