### PR TITLE
Update compiletest_rs dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ num_cpus = "0.2.10"
 deque = "0.3.1"
 
 [dev-dependencies]
-compiletest_rs = "0.0.11"
+compiletest_rs = "0.1.1"
 num = "0.1.30"
 
 [features]


### PR DESCRIPTION
I'm extremely new in this project, and just try to do 'cargo test', but I have got problem with it: crate "compiletest_rs" was not built with errors like "/compiletest_rs-0.0.11/src/procsrv.rs:16:5: 16:37 error: unresolved import `std::dynamic_lib::DynamicLibrary`. Could not find `dynamic_lib` in `std` ". I'm looking to the "compiletest_rs" repository and find in commit with "Cargo.toml", with a comment "Bump 0.1.1" about "3 days ago". Looks like "compiletest_rs" change version numbering.