### PR TITLE
remove unnecessary attribute: #[allow(dead_code)]

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -2,7 +2,6 @@
 
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum Event {
     StartWorking { index: usize },


### PR DESCRIPTION
Attribute: #[allow(dead_code)] in src/log.rs is unnecessary now and can be safely removed.