### PR TITLE
par_iter: require more Fn Sync

### DIFF
--- a/neg-tests-compile/cell_par_iter.rs
+++ b/neg-tests-compile/cell_par_iter.rs
@@ -1,0 +1,14 @@
+extern crate rayon;
+
+// Check that we can't use the par-iter API to access contents of an
+// `Rc`.
+
+use rayon::prelude::*;
+use std::cell::Cell;
+
+fn main() {
+    let c = Cell::new(42_i32);
+    (0_i32..1024).into_par_iter()
+             .map(|_| c.get()) //~ ERROR Sync` is not satisfied
+             .min(); //~ ERROR Sync` is not satisfied
+}

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -134,7 +134,7 @@ pub trait ParallelIterator: Sized {
     /// Applies `map_op` to each item of this iterator, producing a new
     /// iterator with the results.
     fn map<MAP_OP,R>(self, map_op: MAP_OP) -> Map<Self, MapFn<MAP_OP>>
-        where MAP_OP: Fn(Self::Item) -> R
+        where MAP_OP: Fn(Self::Item) -> R + Sync
     {
         Map::new(self, MapFn(map_op))
     }
@@ -151,7 +151,7 @@ pub trait ParallelIterator: Sized {
     /// producing a new iterator passing through the original items.  This is
     /// often useful for debugging to see what's happening in iterator stages.
     fn inspect<INSPECT_OP>(self, inspect_op: INSPECT_OP) -> Map<Self, MapInspect<INSPECT_OP>>
-        where INSPECT_OP: Fn(&Self::Item)
+        where INSPECT_OP: Fn(&Self::Item) + Sync
     {
         Map::new(self, MapInspect(inspect_op))
     }
@@ -159,7 +159,7 @@ pub trait ParallelIterator: Sized {
     /// Applies `filter_op` to each item of this iterator, producing a new
     /// iterator with only the items that gave `true` results.
     fn filter<FILTER_OP>(self, filter_op: FILTER_OP) -> Filter<Self, FILTER_OP>
-        where FILTER_OP: Fn(&Self::Item) -> bool
+        where FILTER_OP: Fn(&Self::Item) -> bool + Sync
     {
         Filter::new(self, filter_op)
     }
@@ -167,7 +167,7 @@ pub trait ParallelIterator: Sized {
     /// Applies `filter_op` to each item of this iterator to get an `Option`,
     /// producing a new iterator with only the items from `Some` results.
     fn filter_map<FILTER_OP,R>(self, filter_op: FILTER_OP) -> FilterMap<Self, FILTER_OP>
-        where FILTER_OP: Fn(Self::Item) -> Option<R>
+        where FILTER_OP: Fn(Self::Item) -> Option<R> + Sync
     {
         FilterMap::new(self, filter_op)
     }
@@ -175,7 +175,7 @@ pub trait ParallelIterator: Sized {
     /// Applies `map_op` to each item of this iterator to get nested iterators,
     /// producing a new iterator that flattens these back into one.
     fn flat_map<MAP_OP,PI>(self, map_op: MAP_OP) -> FlatMap<Self, MAP_OP>
-        where MAP_OP: Fn(Self::Item) -> PI, PI: IntoParallelIterator
+        where MAP_OP: Fn(Self::Item) -> PI + Sync, PI: IntoParallelIterator
     {
         FlatMap::new(self, map_op)
     }


### PR DESCRIPTION
A few of the mutators were accepting Fn without Sync, even though their
resulting objects required Sync to implement further ParallelIterator.
You'd still get an error in using it, but a bit removed from the actual
problem.  Requiring Sync right away puts an error message right on the
problematic closure, so it's clear what needs fixing.