### PR TITLE
Miscellaneous fixes

### DIFF
--- a/neg-tests-compile/quicksort_race1.rs
+++ b/neg-tests-compile/quicksort_race1.rs
@@ -7,7 +7,7 @@ fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
 
     let mid = partition(v);
     let (lo, hi) = v.split_at_mut(mid);
-    rayon::join(|| quick_sort(lo), || quick_sort(lo)); //~ ERROR E0500
+    rayon::join(|| quick_sort(lo), || quick_sort(lo)); //~ ERROR E0524
 }
 
 fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {

--- a/neg-tests-compile/quicksort_race3.rs
+++ b/neg-tests-compile/quicksort_race3.rs
@@ -7,7 +7,7 @@ fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
 
     let mid = partition(v);
     let (lo, hi) = v.split_at_mut(mid);
-    rayon::join(|| quick_sort(hi), || quick_sort(hi)); //~ ERROR E0500
+    rayon::join(|| quick_sort(hi), || quick_sort(hi)); //~ ERROR E0524
 }
 
 fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {

--- a/neg-tests-compile/rc_par_iter.rs
+++ b/neg-tests-compile/rc_par_iter.rs
@@ -10,6 +10,6 @@ fn main() {
     let x = vec![Rc::new(22), Rc::new(23)];
     let mut y = vec![];
     x.into_par_iter() //~ ERROR no method named `into_par_iter`
-     .map(|rc| *rc) //~ ERROR type of this value must be known in this context
+     .map(|rc| *rc)
      .collect_into(&mut y);
 }

--- a/neg-tests-compile/rc_upvar.rs
+++ b/neg-tests-compile/rc_upvar.rs
@@ -6,5 +6,4 @@ fn main() {
     let r = Rc::new(22);
     rayon::join(|| r.clone(), || r.clone());
     //~^ ERROR E0277
-    //~| ERROR E0277
 }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -226,7 +226,7 @@ pub trait ParallelIterator: Sized {
     /// Here is how to visualize what is happening. Imagine an input
     /// sequence with 7 values as shown:
     ///
-    /// ```
+    /// ```notest
     /// [ 0 1 2 3 4 5 6 ]
     ///   |     | |   |
     ///   +--X--+ +-Y-+ // <-- fold_op
@@ -250,7 +250,7 @@ pub trait ParallelIterator: Sized {
     /// example, a call `self.fold(identity, fold_op, reduce_op)` could
     /// also be expressed as follows:
     ///
-    /// ```
+    /// ```notest
     /// self.map(|elem| fold_op(identity.clone(), elem))
     ///     .reduce_with_identity(identity, reduce_op)
     /// ```

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -18,7 +18,7 @@ use self::enumerate::Enumerate;
 use self::filter::Filter;
 use self::filter_map::FilterMap;
 use self::flat_map::FlatMap;
-use self::map::{Map, MapOp, MapFn, MapCloned, MapInspect};
+use self::map::{Map, MapFn, MapCloned, MapInspect};
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp, ReduceWithOp,
                    ReduceWithIdentityOp, SUM, MUL, MIN, MAX};
 use self::internal::*;


### PR DESCRIPTION
Correcting some minor drift so that tests pass again.

Note that you cannot use RUST_NEW_ERROR_FORMAT due to compiletest still not having been updated lately.