### PR TITLE
Relax IntoParallelRefIterator and IntoParallelRefMutIterator

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -55,17 +55,39 @@ pub trait IntoParallelIterator {
 }
 
 pub trait IntoParallelRefIterator<'data> {
-    type Iter: ParallelIterator<Item=&'data Self::Item>;
-    type Item: Sync + 'data;
+    type Iter: ParallelIterator<Item=Self::Item>;
+    type Item: Send + 'data;
 
     fn par_iter(&'data self) -> Self::Iter;
 }
 
+impl<'data, I: 'data + ?Sized> IntoParallelRefIterator<'data> for I
+    where &'data I: IntoParallelIterator
+{
+    type Iter = <&'data I as IntoParallelIterator>::Iter;
+    type Item = <&'data I as IntoParallelIterator>::Item;
+
+    fn par_iter(&'data self) -> Self::Iter {
+        self.into_par_iter()
+    }
+}
+
 pub trait IntoParallelRefMutIterator<'data> {
-    type Iter: ParallelIterator<Item=&'data mut Self::Item>;
+    type Iter: ParallelIterator<Item=Self::Item>;
     type Item: Send + 'data;
 
     fn par_iter_mut(&'data mut self) -> Self::Iter;
+}
+
+impl<'data, I: 'data + ?Sized> IntoParallelRefMutIterator<'data> for I
+    where &'data mut I: IntoParallelIterator
+{
+    type Iter = <&'data mut I as IntoParallelIterator>::Iter;
+    type Item = <&'data mut I as IntoParallelIterator>::Item;
+
+    fn par_iter_mut(&'data mut self) -> Self::Iter {
+        self.into_par_iter()
+    }
 }
 
 pub trait ToParallelChunks<'data> {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -23,15 +23,6 @@ impl<'data, T: Sync + 'data> IntoParallelIterator for &'data Vec<T> {
     }
 }
 
-impl<'data, T: Sync + 'data> IntoParallelRefIterator<'data> for [T] {
-    type Item = T;
-    type Iter = SliceIter<'data, T>;
-
-    fn par_iter(&'data self) -> Self::Iter {
-        self.into_par_iter()
-    }
-}
-
 impl<'data, T: Sync + 'data> ToParallelChunks<'data> for [T] {
     type Item = T;
     type Iter = ChunksIter<'data, T>;

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -23,15 +23,6 @@ impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut Vec<T> {
     }
 }
 
-impl<'data, T: Send + 'data> IntoParallelRefMutIterator<'data> for [T] {
-    type Item = T;
-    type Iter = SliceIterMut<'data, T>;
-
-    fn par_iter_mut(&'data mut self) -> Self::Iter {
-        self.into_par_iter()
-    }
-}
-
 impl<'data, T: Send + 'data> ToParallelChunksMut<'data> for [T] {
     type Item = T;
     type Iter = ChunksMutIter<'data, T>;


### PR DESCRIPTION
The constraints on their `Iter` no longer require them to have simple
references.  Their `Item` now represents the complete type that is
produced, which could be something like `(&K, &mut V)` on a map, for
instance.

There are also now blanket implementations for types whose references
already implement `IntoParallelIterator`, which wasn't possible before.

[breaking-change] Implementers of these traits may have to adapt to the
changed constraints, and may be forced out by the blanket impl.  Users
of the traits may be affected by the changed `Item` semantics.

Closes #90.