### PR TITLE
RFC: adaptive "thief splitting" algorithm for par_iter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
     cargo test --features nightly
   - |
     [ $TRAVIS_RUST_VERSION != nightly ] ||
-    ( cd rayon-demo && cargo bench && cd ../../ )
+    ( cd rayon-demo && cargo test && cd ../../ )

--- a/rayon-demo/src/nbody/nbody.rs
+++ b/rayon-demo/src/nbody/nbody.rs
@@ -92,7 +92,6 @@ impl NBodyBenchmark {
 
         let time = self.time;
         out_bodies.par_iter_mut()
-                  .weight(200.0)
                   .zip(&in_bodies[..])
                   .for_each(|(out, prev)| {
                       let (vel, vel2) = next_velocity(time, prev, in_bodies);
@@ -117,7 +116,6 @@ impl NBodyBenchmark {
 
         let time = self.time;
         out_bodies.par_iter_mut()
-                  .weight(200.0)
                   .zip(&in_bodies[..])
                   .for_each(|(out, prev)| {
                       let (vel, vel2) = next_velocity_par(time, prev, in_bodies);

--- a/rayon-demo/src/pythagoras/mod.rs
+++ b/rayon-demo/src/pythagoras/mod.rs
@@ -18,20 +18,30 @@ use test;
 ///
 /// This is a coprime triple.  Multiplying by factors k covers all triples.
 fn par_euclid(m_weight: f64, n_weight: f64) -> u32 {
-    (1u32 .. 1000).into_par_iter().weight(m_weight).map(|m| {
+    (1u32 .. 2000).into_par_iter().weight(m_weight).map(|m| {
         (1 .. m).into_par_iter().weight(n_weight)
             .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
-            .map(|n| 1000000 / (m*m + n*n))
+            .map(|n| 4000000 / (m*m + n*n))
+            .sum()
+    }).sum()
+}
+
+/// Same as par_euclid, without explicit weights.
+fn par_euclid_weightless() -> u32 {
+    (1u32 .. 2000).into_par_iter().map(|m| {
+        (1 .. m).into_par_iter()
+            .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
+            .map(|n| 4000000 / (m*m + n*n))
             .sum()
     }).sum()
 }
 
 /// Same as par_euclid, without using rayon.
 fn euclid() -> u32 {
-    (1u32 .. 1000).map(|m| {
+    (1u32 .. 2000).map(|m| {
         (1 .. m)
             .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
-            .map(|n| 1000000 / (m*m + n*n))
+            .map(|n| 4000000 / (m*m + n*n))
             .fold(0, Add::add)
     }).fold(0, Add::add)
 }
@@ -51,8 +61,15 @@ fn euclid_faux_serial(b: &mut test::Bencher) {
 }
 
 #[bench]
+/// Use the default without any weights
+fn euclid_parallel_weightless(b: &mut test::Bencher) {
+    let count = euclid();
+    b.iter(|| assert_eq!(par_euclid_weightless(), count))
+}
+
+#[bench]
 /// Use the default weights (1.0)
-fn euclid_default(b: &mut test::Bencher) {
+fn euclid_parallel_one(b: &mut test::Bencher) {
     let count = euclid();
     b.iter(|| assert_eq!(par_euclid(1.0, 1.0), count))
 }

--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -139,6 +139,10 @@ impl<A, B> ChainProducer<A, B>
 impl<A, B> Producer for ChainProducer<A, B>
     where A: Producer, B: Producer<Item=A::Item>
 {
+    fn weighted(&self) -> bool {
+        self.a.weighted() || self.b.weighted()
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         let a_len = min(self.a_len, len);
         let b_len = len - a_len;

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -83,6 +83,10 @@ pub struct EnumerateProducer<P> {
 impl<P> Producer for EnumerateProducer<P>
     where P: Producer
 {
+    fn weighted(&self) -> bool {
+        self.base.weighted()
+    }
+
     fn cost(&mut self, items: usize) -> f64 {
         self.base.cost(items) // enumerating is basically free
     }

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -64,6 +64,10 @@ impl<'f, ITEM, C, FILTER_OP: 'f> Consumer<ITEM> for FilterConsumer<'f, C, FILTER
     type Reducer = C::Reducer;
     type Result = C::Result;
 
+    fn weighted(&self) -> bool {
+        self.base.weighted()
+    }
+
     /// Cost to process `items` number of items.
     fn cost(&mut self, cost: f64) -> f64 {
         self.base.cost(cost) * FUNC_ADJUSTMENT

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -69,6 +69,10 @@ impl<'f, ITEM, MAPPED_ITEM, C, FILTER_OP> Consumer<ITEM>
     type Reducer = C::Reducer;
     type Result = C::Result;
 
+    fn weighted(&self) -> bool {
+        self.base.weighted()
+    }
+
     /// Cost to process `items` number of items.
     fn cost(&mut self, cost: f64) -> f64 {
         self.base.cost(cost) * FUNC_ADJUSTMENT

--- a/src/par_iter/flat_map.rs
+++ b/src/par_iter/flat_map.rs
@@ -53,6 +53,10 @@ impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Consumer<ITEM>
     type Reducer = C::Reducer;
     type Result = C::Result;
 
+    fn weighted(&self) -> bool {
+        true
+    }
+
     fn cost(&mut self, _cost: f64) -> f64 {
         // We have no idea how many items we will produce, so ramp up
         // the cost, so as to encourage the producer to do a

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -137,6 +137,10 @@ impl<'m, P, MAP_OP> Producer for MapProducer<'m, P, MAP_OP>
     where P: Producer,
           MAP_OP: MapOp<P::Item>,
 {
+    fn weighted(&self) -> bool {
+        self.base.weighted()
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         self.base.cost(len) * FUNC_ADJUSTMENT
     }
@@ -202,6 +206,10 @@ impl<'m, ITEM, C, MAP_OP> Consumer<ITEM> for MapConsumer<'m, C, MAP_OP>
     type Folder = MapFolder<'m, C::Folder, MAP_OP>;
     type Reducer = C::Reducer;
     type Result = C::Result;
+
+    fn weighted(&self) -> bool {
+        self.base.weighted()
+    }
 
     fn cost(&mut self, cost: f64) -> f64 {
         self.base.cost(cost) * FUNC_ADJUSTMENT

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -78,6 +78,10 @@ pub struct WeightProducer<P> {
 }
 
 impl<P: Producer> Producer for WeightProducer<P> {
+    fn weighted(&self) -> bool {
+        true
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         self.base.cost(len) * self.weight
     }
@@ -118,6 +122,10 @@ impl<C, ITEM> Consumer<ITEM> for WeightConsumer<C>
     type Folder = C::Folder;
     type Reducer = C::Reducer;
     type Result = C::Result;
+
+    fn weighted(&self) -> bool {
+        true
+    }
 
     fn cost(&mut self, cost: f64) -> f64 {
         self.base.cost(cost) * self.weight

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -109,6 +109,10 @@ pub struct ZipProducer<A: Producer, B: Producer> {
 }
 
 impl<A: Producer, B: Producer> Producer for ZipProducer<A, B> {
+    fn weighted(&self) -> bool {
+        self.a.weighted() || self.b.weighted()
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         // Rather unclear that this should be `+`. It might be that max is better?
         self.a.cost(len) + self.b.cost(len)


### PR DESCRIPTION
This introduces an adaptive algorithm for splitting par_iter jobs, used
only as a default case when no weights are specified.  Initially, it
will split into enough jobs to fill every thread.  Then whenever a job
is stolen, that job will again be split enough for every thread.

This is roughly based on @Amanieu's description in the users forum of
the algorithm used by Async++ and TBB.