### PR TITLE
[RFC] [breaking-change] Simplify `reduce` and `fold`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,12 @@
+# Release 0.5 (pending)
+
+- **Breaking change:** The `reduce` method has been vastly
+  simplified, and `reduce_with_identity` has been deprecated.
+- **Breaking change:** The `fold` method has been changed. It used to
+  always reduce the values, but now instead it is a combinator that
+  returns a parallel iterator which can itself be reduced. See the
+  docs for more information.
+
 # Release 0.4.3
 
 - Parallel iterators now offer an adaptive weight scheme,

--- a/rayon-demo/src/nbody/nbody.rs
+++ b/rayon-demo/src/nbody/nbody.rs
@@ -342,12 +342,10 @@ fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body])
         acc += diff;
     }
 
-    let zero: Vector3<f64> = Vector3::zero();
     let (diff, diff2) = bodies
         .par_iter()
-        .fold(
-            (zero, zero),
-            |(mut diff, mut diff2), body| {
+        .fold(|| (Vector3::zero(), Vector3::zero()),
+              |(mut diff, mut diff2), body| {
                 let r = body.position - prev.position;
 
                 // make sure we are not testing the particle against its own position
@@ -395,8 +393,9 @@ fn next_velocity_par(time: usize, prev: &Body, bodies: &[Body])
                 }
 
                 (diff, diff2)
-            },
-            |(diffa, diff2a), (diffb, diff2b)| (diffa + diffb, diff2a + diff2b));
+              })
+        .reduce(|| (Vector3::zero(), Vector3::zero()),
+                |(diffa, diff2a), (diffb, diff2b)| (diffa + diffb, diff2a + diff2b));
 
     acc += diff;
     acc2 += diff2;

--- a/src/par_iter/fold.rs
+++ b/src/par_iter/fold.rs
@@ -4,37 +4,31 @@ use super::internal::*;
 
 pub fn fold<PAR_ITER,I,FOLD_OP,REDUCE_OP>(pi: PAR_ITER,
                                           identity: &I,
-                                          fold_op: &FOLD_OP,
-                                          reduce_op: &REDUCE_OP)
+                                          fold_op: &FOLD_OP)
                                           -> I
     where PAR_ITER: ParallelIterator,
           FOLD_OP: Fn(I, PAR_ITER::Item) -> I + Sync,
-          REDUCE_OP: Fn(I, I) -> I + Sync,
           I: Clone + Send + Sync,
 {
     let consumer = FoldConsumer { identity: identity,
-                                  fold_op: fold_op,
-                                  reduce_op: reduce_op };
+                                  fold_op: fold_op };
     pi.drive_unindexed(consumer)
 }
 
-struct FoldConsumer<'r, I:'r, FOLD_OP: 'r, REDUCE_OP: 'r> {
+struct FoldConsumer<'r, I:'r, FOLD_OP: 'r> {
     identity: &'r I,
     fold_op: &'r FOLD_OP,
-    reduce_op: &'r REDUCE_OP,
 }
 
-impl<'r, I, FOLD_OP, REDUCE_OP> Copy for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP> {
+impl<'r, I, FOLD_OP> Copy for FoldConsumer<'r, I, FOLD_OP> {
 }
 
-impl<'r, I, FOLD_OP, REDUCE_OP> Clone for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP> {
+impl<'r, I, FOLD_OP> Clone for FoldConsumer<'r, I, FOLD_OP> {
     fn clone(&self) -> Self { *self }
 }
 
-impl<'r, ITEM, I, FOLD_OP, REDUCE_OP> Consumer<ITEM>
-    for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP>
+impl<'r, ITEM, I, FOLD_OP> Consumer<ITEM> for FoldConsumer<'r, I, FOLD_OP>
     where FOLD_OP: Fn(I, ITEM) -> I + Sync,
-          REDUCE_OP: Fn(I, I) -> I + Sync,
           I: Clone + Send + Sync,
 {
     type Folder = FoldFolder<'r, I, FOLD_OP>;
@@ -56,10 +50,8 @@ impl<'r, ITEM, I, FOLD_OP, REDUCE_OP> Consumer<ITEM>
     }
 }
 
-impl<'r, ITEM, I, FOLD_OP, REDUCE_OP> UnindexedConsumer<ITEM>
-    for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP>
+impl<'r, ITEM, I, FOLD_OP> UnindexedConsumer<ITEM> for FoldConsumer<'r, I, FOLD_OP>
     where FOLD_OP: Fn(I, ITEM) -> I + Sync,
-          REDUCE_OP: Fn(I, I) -> I + Sync,
           I: Clone + Send + Sync,
 {
     fn split_off(&self) -> Self {
@@ -71,10 +63,8 @@ impl<'r, ITEM, I, FOLD_OP, REDUCE_OP> UnindexedConsumer<ITEM>
     }
 }
 
-impl<'r, I, FOLD_OP, REDUCE_OP> Reducer<I>
-    for FoldConsumer<'r, I, FOLD_OP, REDUCE_OP>
-    where REDUCE_OP: Fn(I, I) -> I + Sync,
-          I: Clone + Send + Sync,
+impl<'r, I, FOLD_OP> Reducer<I> for FoldConsumer<'r, I, FOLD_OP>
+    where I: Clone + Send + Sync,
 {
     fn reduce(self, left: I, right: I) -> I {
         (self.reduce_op)(left, right)

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -35,7 +35,6 @@ pub mod flat_map;
 pub mod internal;
 pub mod len;
 pub mod for_each;
-#[cfg(feature = "unstable")]
 pub mod fold;
 pub mod reduce;
 pub mod slice;
@@ -403,15 +402,6 @@ pub trait ParallelIterator: Sized {
     ///                .sum();
     /// assert_eq!(sum, (0..22).sum()); // compare to sequential
     /// ```
-    ///
-    /// ### Stability
-    ///
-    /// **This method is marked as unstable** because it is
-    /// particularly likely to change its name and/or signature, or go
-    /// away entirely.
-    ///
-    /// The concern is whether it holds its weight in comparison to map/reduce.
-    #[cfg(feature = "unstable")]
     fn fold<IDENTITY_ITEM,IDENTITY,FOLD_OP>(self,
                                             identity: IDENTITY,
                                             fold_op: FOLD_OP)

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -229,7 +229,7 @@ pub trait ParallelIterator: Sized {
     /// ```
     ///
     /// **Note:** unlike a sequential `fold` operation, the order in
-    /// which `op` will be applied to reduce the result is not
+    /// which `op` will be applied to reduce the result is not fully
     /// specified. So `op` should be [associative] or else the results
     /// will be non-deterministic. And of course `identity()` should
     /// produce a true identity.
@@ -251,9 +251,11 @@ pub trait ParallelIterator: Sized {
     /// requires an identity element.
     ///
     /// **Note:** unlike a sequential `fold` operation, the order in
-    /// which `op` will be applied to reduce the result is not
-    /// specified. So `op` should be [commutative] and associative or
-    /// else the results will be non-deterministic.
+    /// which `op` will be applied to reduce the result is not fully
+    /// specified. So `op` should be [associative] or else the results
+    /// will be non-deterministic.
+    ///
+    /// [associative]: https://en.wikipedia.org/wiki/Associative_property
     fn reduce_with<OP>(self, op: OP) -> Option<Self::Item>
         where OP: Fn(Self::Item, Self::Item) -> Self::Item + Sync,
     {
@@ -416,9 +418,11 @@ pub trait ParallelIterator: Sized {
     /// Sums up the items in the iterator.
     ///
     /// Note that the order in items will be reduced is not specified,
-    /// so if the `+` operator is not truly commutative and
-    /// associative (as is the case for floating point numbers), then
-    /// the results are not fully deterministic.
+    /// so if the `+` operator is not truly [associative] (as is the
+    /// case for floating point numbers), then the results are not
+    /// fully deterministic.
+    ///
+    /// [associative]: https://en.wikipedia.org/wiki/Associative_property
     ///
     /// Basically equivalent to `self.reduce(|| 0, |a, b| a + b)`,
     /// except that the type of `0` and the `+` operation may vary
@@ -432,9 +436,11 @@ pub trait ParallelIterator: Sized {
     /// Multiplies all the items in the iterator.
     ///
     /// Note that the order in items will be reduced is not specified,
-    /// so if the `*` operator is not truly commutative and
-    /// associative (as is the case for floating point numbers), then
-    /// the results are not fully deterministic.
+    /// so if the `*` operator is not truly [associative] (as is the
+    /// case for floating point numbers), then the results are not
+    /// fully deterministic.
+    ///
+    /// [associative]: https://en.wikipedia.org/wiki/Associative_property
     ///
     /// Basically equivalent to `self.reduce(|| 1, |a, b| a * b)`,
     /// except that the type of `1` and the `*` operation may vary
@@ -448,9 +454,8 @@ pub trait ParallelIterator: Sized {
     /// Computes the minimum of all the items in the iterator.
     ///
     /// Note that the order in items will be reduced is not specified,
-    /// so if the `Ord` impl is not truly commutative and associative
-    /// (as is the case for floating point numbers), then the results
-    /// are not deterministic.
+    /// so if the `Ord` impl is not truly associative, then the
+    /// results are not deterministic.
     ///
     /// Basically equivalent to `self.reduce(|| MAX, |a, b| cmp::min(a, b))`
     /// except that the type of `MAX` and the `min` operation may vary
@@ -464,8 +469,8 @@ pub trait ParallelIterator: Sized {
     /// Computes the maximum of all the items in the iterator.
     ///
     /// Note that the order in items will be reduced is not specified,
-    /// so if the `Ord` impl is not truly commutative and associative
-    /// (as is the case for floating point numbers), then the results
+    /// so if the `Ord` impl is not truly associative, then the
+    /// results are not deterministic.
     ///
     /// Basically equivalent to `self.reduce(|| MIN, |a, b| cmp::max(a, b))`
     /// except that the type of `MIN` and the `max` operation may vary

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -215,15 +215,26 @@ pub trait ParallelIterator: Sized {
     /// (but consider just calling `sum()` in that case).
     ///
     /// Example:
-    /// - `vectors.par_iter().reduce(|| Vector::zero(), Vector::add)`
+    ///
+    /// ```
+    /// // Iterate over a sequence of pairs `(x0, y0), ..., (xN, yN)`
+    /// // and use reduce to compute one pair `(x0 + ... + xN, y0 + ... + yN)`
+    /// // where the first/second elements are summed separately.
+    /// use rayon::prelude::*;
+    /// let sums = [(0, 1), (5, 6), (16, 2), (8, 9)]
+    ///            .par_iter()        // iterating over &(i32, i32)
+    ///            .cloned()          // iterating over (i32, i32)
+    ///            .reduce(|| (0, 0), // the "identity" is 0 in both columns
+    ///                    |a, b| (a.0 + b.0, a.1 + b.1));
+    /// assert_eq!(sums, (0 + 5 + 16 + 8, 1 + 6 + 2 + 9));
+    /// ```
     ///
     /// **Note:** unlike a sequential `fold` operation, the order in
     /// which `op` will be applied to reduce the result is not
-    /// specified. So `op` should be [commutative] and associative or
-    /// else the results will be non-deterministic. And of course
-    /// `identity()` should produce a true identity.
+    /// specified. So `op` should be [associative] or else the results
+    /// will be non-deterministic. And of course `identity()` should
+    /// produce a true identity.
     ///
-    /// [commutative]: https://en.wikipedia.org/wiki/Commutative_property
     /// [associative]: https://en.wikipedia.org/wiki/Associative_property
     fn reduce<OP,IDENTITY>(self, identity: IDENTITY, op: OP) -> Self::Item
         where OP: Fn(Self::Item, Self::Item) -> Self::Item + Sync,
@@ -265,67 +276,151 @@ pub trait ParallelIterator: Sized {
         self.reduce(|| identity.clone(), op)
     }
 
-    /// A variant on the typical `map/reduce` pattern. Parallel fold
-    /// is similar to sequential fold except that the sequence of
-    /// items may be subdivided before it is folded. The resulting
-    /// values are then reduced together using `reduce_op`.  Typically
-    /// `fold_op` and `reduce_op` will be doing the same conceptual
-    /// operation, but on different types, or with a different twist.
+    /// Parallel fold is similar to sequential fold except that the
+    /// sequence of items may be subdivided before it is
+    /// folded. Consider a list of numbers like `22 3 77 89 46`. If
+    /// you used sequential fold to add them (`fold(0, |a,b| a+b)`,
+    /// you would wind up first adding 0 + 22, then 22 + 3, then 25 +
+    /// 77, and so forth. The **parallel fold** works similarly except
+    /// that it first breaks up your list into sublists, and hence
+    /// instead of yielding up a single sum at the end, it yields up
+    /// multiple sums. The number of results is nondeterministic, as
+    /// is the point where the breaks occur.
     ///
-    /// Here is how to visualize what is happening. Imagine an input
-    /// sequence with 7 values as shown:
+    /// So if did the same parallel fold (`fold(0, |a,b| a+b)`) on
+    /// our example list, we might wind up with a sequence of two numbers,
+    /// like so:
     ///
     /// ```notrust
-    /// [ 0 1 2 3 4 5 6 ]
-    ///   |     | |   |
-    ///   +--X--+ +-Y-+ // <-- fold_op
-    ///      |      |
-    ///      +---Z--+   // <-- reduce_op
+    /// 22 3 77 89 46
+    ///       |     |
+    ///     102   135
     /// ```
     ///
-    /// These values will be first divided into contiguous chunks of
-    /// some size (the precise sizes will depend on how many cores are
-    /// present and how active they are). These are folded using
-    /// `fold_op`. Here, the chunk `[0, 1, 2, 3]` was folded into `X`
-    /// and the chunk `[4, 5, 6]` was folded into `Y`. Note that `X`
-    /// and `Y` may, in general, have different types than the
-    /// original input sequence. Now the results from these folds are
-    /// themselves *reduced* using `reduce_op` (again, in some
-    /// unspecified order). So now `X` and `Y` are reduced to `Z`,
-    /// which is the final result. Note that `reduce_op` must consume
-    /// and produce values of the same type.
+    /// Or perhaps these three numbers:
     ///
-    /// Note that `fold` can always be expressed using map/reduce. For
-    /// example, a call `self.fold(identity, fold_op, reduce_op)` could
-    /// also be expressed as follows:
-    ///
-    /// ```notest
-    /// self.map(|elem| fold_op(identity.clone(), elem))
-    ///     .reduce_with_identity(identity, reduce_op)
+    /// ```notrust
+    /// 22 3 77 89 46
+    ///       |  |  |
+    ///     102 89 46
     /// ```
     ///
-    /// This is equivalent to an execution of `fold` where the
-    /// subsequences that were folded sequentially would up being of
-    /// length 1.  However, this would rarely happen in practice,
-    /// typically the subsequences would be larger, and hence a call
-    /// to `fold` *can* be more efficient than map/reduce,
-    /// particularly if the `fold_op` is more efficient when applied
-    /// to a large sequence.
+    /// In general, Rayon will attempt to find good breaking points
+    /// that keep all of your cores busy.
+    ///
+    /// ### Fold versus reduce
+    ///
+    /// The `fold()` and `reduce()` methods each take an identity element
+    /// and a combining function, but they operate rather differently.
+    ///
+    /// `reduce()` requires that the identity function has the same
+    /// type as the things you are iterating over, and it fully
+    /// reduces the list of items into a single item. So, for example,
+    /// imagine we are iterating over a list of bytes `bytes: [128_u8,
+    /// 64_u8, 64_u8]`. If we used `bytes.reduce(|| 0_u8, |a: u8, b:
+    /// u8| a + b)`, we would get an overflow. This is because `0`,
+    /// `a`, and `b` here are all bytes, just like the numbers in the
+    /// list (I wrote the types explicitly above, but those are the
+    /// only types you can use). To avoid the overflow, we would need
+    /// to do something like `bytes.map(|b| b as u32).reduce(|| 0, |a,
+    /// b| a + b)`, in which case our result would be `256`.
+    ///
+    /// In contrast, with `fold()`, the identity function does not
+    /// have to have the same type as the things you are iterating
+    /// over, and you potentially get back many results. So, if we
+    /// continue with the `bytes` example from the previous paragraph,
+    /// we could do `bytes.fold(|| 0_u32, |a, b| a + (b as u32))` to
+    /// convert our bytes into `u32`. And of course we might not get
+    /// back a single sum.
+    ///
+    /// There is a more subtle distinction as well, though it's
+    /// actually implied by the above points. When you use `reduce()`,
+    /// your reduction function is sometimes called with values that
+    /// were never part of your original parallel iterator (for
+    /// example, both the left and right might be a partial sum). With
+    /// `fold()`, in contrast, the left value in the fold function is
+    /// always the accumulator, and the right value is always from
+    /// your original sequence.
+    ///
+    /// ### Fold vs Map/Reduce
+    ///
+    /// Fold makes sense if you have some operation where it is
+    /// cheaper to groups of elements at a time. For example, imagine
+    /// collecting characters into a string. If you were going to use
+    /// map/reduce, you might try this:
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// let s =
+    ///     ['a', 'b', 'c', 'd', 'e']
+    ///     .par_iter()
+    ///     .map(|c: &char| format!("{}", c))
+    ///     .reduce(|| String::new(),
+    ///             |mut a: String, b: String| { a.push_str(&b); a });
+    /// assert_eq!(s, "abcde");
+    /// ```
+    ///
+    /// Because reduce produces the same type of element as its input,
+    /// you have to first map each character into a string, and then
+    /// you can reduce them. This means we create one string per
+    /// element in ou iterator -- not so great. Using `fold`, we can
+    /// do this instead:
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// let s =
+    ///     ['a', 'b', 'c', 'd', 'e']
+    ///     .par_iter()
+    ///     .fold(|| String::new(),
+    ///             |mut s: String, c: &char| { s.push(*c); s })
+    ///     .reduce(|| String::new(),
+    ///             |mut a: String, b: String| { a.push_str(&b); a });
+    /// assert_eq!(s, "abcde");
+    /// ```
+    ///
+    /// Now `fold` will process groups of our characters at a time,
+    /// and we only make one string per group. We should wind up with
+    /// some small-ish number of strings roughly proportional to the
+    /// number of CPUs you have (it will ultimately depend on how busy
+    /// your processors are). Note that we still need to do a reduce
+    /// afterwards to combine those groups of strings into a single
+    /// string.
+    ///
+    /// You could use a similar trick to save partial results (e.g., a
+    /// cache) or something similar.
+    ///
+    /// ### Combining fold with other operations
+    ///
+    /// You can combine `fold` with `reduce` if you want to produce a
+    /// single value. This is then roughly equivalent to a map/reduce
+    /// combination in effect:
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// let bytes = 0..22_u8; // series of u8 bytes
+    /// let sum = bytes.into_par_iter()
+    ///                .fold(|| 0_u32, |a: u32, b: u8| a + (b as u32))
+    ///                .sum();
+    /// assert_eq!(sum, (0..22).sum()); // compare to sequential
+    /// ```
+    ///
+    /// ### Stability
     ///
     /// **This method is marked as unstable** because it is
     /// particularly likely to change its name and/or signature, or go
     /// away entirely.
+    ///
+    /// The concern is whether it holds its weight in comparison to map/reduce.
     #[cfg(feature = "unstable")]
-    fn fold<I,FOLD_OP,REDUCE_OP>(self,
-                                 identity: I,
-                                 fold_op: FOLD_OP,
-                                 reduce_op: REDUCE_OP)
-                                 -> I
-        where FOLD_OP: Fn(I, Self::Item) -> I + Sync,
-              REDUCE_OP: Fn(I, I) -> I + Sync,
-              I: Clone + Sync + Send,
+    fn fold<IDENTITY_ITEM,IDENTITY,FOLD_OP>(self,
+                                            identity: IDENTITY,
+                                            fold_op: FOLD_OP)
+                                            -> fold::Fold<Self, IDENTITY, FOLD_OP>
+        where FOLD_OP: Fn(IDENTITY_ITEM, Self::Item) -> IDENTITY_ITEM + Sync,
+              IDENTITY: Fn() -> IDENTITY_ITEM + Sync,
+              IDENTITY_ITEM: Send,
     {
-        fold::fold(self, &identity, &fold_op, &reduce_op)
+        fold::fold(self, identity, fold_op)
     }
 
     /// Sums up the items in the iterator.
@@ -334,6 +429,10 @@ pub trait ParallelIterator: Sized {
     /// so if the `+` operator is not truly commutative and
     /// associative (as is the case for floating point numbers), then
     /// the results are not fully deterministic.
+    ///
+    /// Basically equivalent to `self.reduce(|| 0, |a, b| a + b)`,
+    /// except that the type of `0` and the `+` operation may vary
+    /// depending on the type of value being produced.
     fn sum(self) -> Self::Item
         where SumOp: ReduceOp<Self::Item>
     {
@@ -346,6 +445,10 @@ pub trait ParallelIterator: Sized {
     /// so if the `*` operator is not truly commutative and
     /// associative (as is the case for floating point numbers), then
     /// the results are not fully deterministic.
+    ///
+    /// Basically equivalent to `self.reduce(|| 1, |a, b| a * b)`,
+    /// except that the type of `1` and the `*` operation may vary
+    /// depending on the type of value being produced.
     fn mul(self) -> Self::Item
         where MulOp: ReduceOp<Self::Item>
     {
@@ -358,6 +461,10 @@ pub trait ParallelIterator: Sized {
     /// so if the `Ord` impl is not truly commutative and associative
     /// (as is the case for floating point numbers), then the results
     /// are not deterministic.
+    ///
+    /// Basically equivalent to `self.reduce(|| MAX, |a, b| cmp::min(a, b))`
+    /// except that the type of `MAX` and the `min` operation may vary
+    /// depending on the type of value being produced.
     fn min(self) -> Self::Item
         where MinOp: ReduceOp<Self::Item>
     {
@@ -369,6 +476,10 @@ pub trait ParallelIterator: Sized {
     /// Note that the order in items will be reduced is not specified,
     /// so if the `Ord` impl is not truly commutative and associative
     /// (as is the case for floating point numbers), then the results
+    ///
+    /// Basically equivalent to `self.reduce(|| MIN, |a, b| cmp::max(a, b))`
+    /// except that the type of `MIN` and the `max` operation may vary
+    /// depending on the type of value being produced.
     /// are not deterministic.
     fn max(self) -> Self::Item
         where MaxOp: ReduceOp<Self::Item>

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -66,11 +66,11 @@ pub fn map_reduce_with() {
     let r1 = a.par_iter()
               .weight_max()
               .map(|&i| i + 1)
-              .reduce_with(|i, j| i + j);
+              .reduce(|| 0, |i, j| i + j);
     let r2 = a.iter()
               .map(|&i| i + 1)
               .fold(0, |a,b| a+b);
-    assert_eq!(r1.unwrap(), r2);
+    assert_eq!(r1, r2);
 }
 
 #[test]
@@ -79,7 +79,7 @@ pub fn map_reduce_with_identity() {
     let r1 = a.par_iter()
               .weight_max()
               .map(|&i| i + 1)
-              .reduce_with_identity(0, |i, j| i + j);
+              .reduce(|| 0, |i, j| i + j);
     let r2 = a.iter()
               .map(|&i| i + 1)
               .fold(0, |a,b| a+b);
@@ -92,11 +92,11 @@ pub fn map_reduce_weighted() {
     let r1 = a.par_iter()
               .map(|&i| i + 1)
               .weight(2.0)
-              .reduce_with(|i, j| i + j);
+              .reduce(|| 0, |i, j| i + j);
     let r2 = a.iter()
               .map(|&i| i + 1)
               .fold(0, |a,b| a+b);
-    assert_eq!(r1.unwrap(), r2);
+    assert_eq!(r1, r2);
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -48,7 +48,7 @@ pub fn check_map_exact_and_bounded() {
 }
 
 #[test]
-pub fn map_reduce() {
+pub fn map_sum() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
               .weight_max()
@@ -61,42 +61,54 @@ pub fn map_reduce() {
 }
 
 #[test]
+pub fn map_reduce() {
+    let a: Vec<i32> = (0..1024).collect();
+    let r1 = a.par_iter()
+              .weight_max()
+              .map(|&i| i + 1)
+              .reduce(|| 0, |i, j| i + j);
+    let r2 = a.iter()
+              .map(|&i| i + 1)
+              .fold(0, |a,b| a+b);
+    assert_eq!(r1, r2);
+}
+
+#[test]
 pub fn map_reduce_with() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
               .weight_max()
               .map(|&i| i + 1)
-              .reduce(|| 0, |i, j| i + j);
+              .reduce_with(|i, j| i + j);
     let r2 = a.iter()
               .map(|&i| i + 1)
               .fold(0, |a,b| a+b);
-    assert_eq!(r1, r2);
+    assert_eq!(r1, Some(r2));
 }
 
 #[test]
-pub fn map_reduce_with_identity() {
-    let a: Vec<i32> = (0..1024).collect();
-    let r1 = a.par_iter()
-              .weight_max()
-              .map(|&i| i + 1)
-              .reduce(|| 0, |i, j| i + j);
-    let r2 = a.iter()
-              .map(|&i| i + 1)
-              .fold(0, |a,b| a+b);
-    assert_eq!(r1, r2);
-}
-
-#[test]
-pub fn map_reduce_weighted() {
-    let a: Vec<i32> = (0..1024).collect();
-    let r1 = a.par_iter()
-              .map(|&i| i + 1)
-              .weight(2.0)
-              .reduce(|| 0, |i, j| i + j);
-    let r2 = a.iter()
-              .map(|&i| i + 1)
-              .fold(0, |a,b| a+b);
-    assert_eq!(r1, r2);
+pub fn fold_map_reduce() {
+    // Kind of a weird test, but it demonstrates various
+    // transformations that are taking place. Relies on
+    // `weight_max().fold()` being equivalent to `map()`.
+    //
+    // Take each number from 0 to 32 and fold them by appending to a
+    // vector.  Because of `weight_max`, this will produce 32 vectors,
+    // each with one item.  We then collect all of these into an
+    // individual vector by mapping each into their own vector (so we
+    // have Vec<Vec<i32>>) and then reducing those into a single
+    // vector.
+    let r1 = (0_i32..32).into_par_iter()
+                        .weight_max()
+                        .fold(|| vec![], |mut v, e| { v.push(e); v })
+                        .map(|v| vec![v])
+                        .reduce_with(|mut v_a, v_b| { v_a.extend(v_b); v_a });
+    assert_eq!(r1,
+               Some(vec![vec![0], vec![1], vec![2], vec![3], vec![4], vec![5], vec![6], vec![7],
+                         vec![8], vec![9], vec![10], vec![11], vec![12], vec![13], vec![14],
+                         vec![15], vec![16], vec![17], vec![18], vec![19], vec![20], vec![21],
+                         vec![22], vec![23], vec![24], vec![25], vec![26], vec![27], vec![28],
+                         vec![29], vec![30], vec![31]]));
 }
 
 #[test]


### PR DESCRIPTION
We currently have too many variants of `reduce`. This brings us down to two:
- `reduce(identity, combine)`, which will combine elements in your iterator by calling `combine(l, r)`, and using `identity()` to produce an identity value when it needs to
  - by taking a closure, we can remove the `Clone` bound on `reduce`
  - by taking an identity, we can make the return value `T` and be maximally efficient
- `reduce_with(combine)`, which will combine elements in your iterator by calling `combine(l, r)`
  - it does not take an identity, so it returns `None` if your iterator is empty

I've also stabilized and modified `fold` -- it might make sense to give it another name, though, like `partial_fold`. The new `fold` is kind of like sequential fold except that it operates only on subsequences (determined dynamically), so it produces a series of values instead of folding the entire sequence into one value. It is cool because the value you are producing does not have to be the same type as your inputs (unlike `reduce`), so you can do things like this:

``` rust
use rayon::prelude::*;
let s =
    ['a', 'b', 'c', 'd', 'e']
    .par_iter()
    .fold(|| String::new(), |mut s, &c| { s.push(*c); s })
    .reduce_with(|mut a: String, b: String| { a.push_str(&b); a });
```

Here, the `fold` is pushing characters onto strings, and the reduce then combines the resulting strings. This should produce some number of strings roughly proportional to the number of CPUs you have, instead of being proportional to the size of your input (as it would be with just `reduce`).

Fixes #94 

cc @jorendorff
cc @cuviper 
