### PR TITLE
Steal while scope blocks

### DIFF
--- a/neg-tests-compile/scope_join_bad.rs
+++ b/neg-tests-compile/scope_join_bad.rs
@@ -1,0 +1,22 @@
+extern crate rayon;
+
+fn bad_scope<F>(f: F)
+    where F: FnOnce(&i32) + Send,
+{
+    rayon::scope(|s| {
+        let x = 22;
+        s.spawn(|_| f(&x)); //~ ERROR `x` does not live long enough
+    });
+}
+
+fn good_scope<F>(f: F)
+    where F: FnOnce(&i32) + Send,
+{
+    let x = 22;
+    rayon::scope(|s| {
+        s.spawn(|_| f(&x));
+    });
+}
+
+fn main() {
+}

--- a/pos-tests-run/scope_join.rs
+++ b/pos-tests-run/scope_join.rs
@@ -1,0 +1,45 @@
+extern crate rayon;
+
+/// Test that one can emulate join with `scope`:
+fn pseudo_join<F, G>(f: F, g: G)
+    where F: FnOnce() + Send,
+          G: FnOnce() + Send,
+{
+    rayon::scope(|s| {
+        s.spawn(|_| g());
+        f();
+    });
+}
+
+fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
+    if v.len() <= 1 {
+        return;
+    }
+
+    let mid = partition(v);
+    let (lo, hi) = v.split_at_mut(mid);
+    pseudo_join(|| quick_sort(lo), || quick_sort(hi));
+}
+
+fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
+    let pivot = v.len() - 1;
+    let mut i = 0;
+    for j in 0..pivot {
+        if v[j] <= v[pivot] {
+            v.swap(i, j);
+            i += 1;
+        }
+    }
+    v.swap(i, pivot);
+    i
+}
+
+pub fn is_sorted<T: Send + Ord>(v: &[T]) -> bool {
+    (1..v.len()).all(|i| v[i-1] <= v[i])
+}
+
+fn main() {
+    let mut v: Vec<i32> = (0 .. 1024).rev().collect();
+    quick_sort(&mut v);
+    assert!(is_sorted(&v));
+}

--- a/pos-tests-run/scope_join.rs
+++ b/pos-tests-run/scope_join.rs
@@ -39,7 +39,7 @@ pub fn is_sorted<T: Send + Ord>(v: &[T]) -> bool {
 }
 
 fn main() {
-    let mut v: Vec<i32> = (0 .. 1024).rev().collect();
+    let mut v: Vec<i32> = (0 .. 256).rev().collect();
     quick_sort(&mut v);
     assert!(is_sorted(&v));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(non_camel_case_types)] // I prefer to use ALL_CAPS for type parameters
+#![cfg_attr(test, feature(conservative_impl_trait))]
 
 extern crate deque;
 extern crate libc;

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -27,7 +27,9 @@ pub struct Scope<'scope> {
     /// latch to set when the counter drops to zero (and hence this scope is complete)
     job_completed_latch: SpinLatch,
 
-    marker: PhantomData<fn(&'scope ())>,
+    /// you can think of a scope as containing a list of closures to
+    /// execute, all of which outlive `'scope`
+    marker: PhantomData<Box<FnOnce(&Scope<'scope>) + 'scope>>,
 }
 
 /// Create a "fork-join" scope `s` and invokes the closure with a

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -67,6 +67,13 @@ pub struct Scope<'scope> {
 /// }
 /// ```
 ///
+/// ### A note on threading
+///
+/// The closure given to `scope()` executes in the Rayon thread-pool,
+/// as do those given to `spawn()`. This means that you can't access
+/// thread-local variables (well, you can, but they may have
+/// unexpected values).
+///
 /// ### Task execution
 ///
 /// Task execution potentially starts as soon as `spawn()` is called.

--- a/src/scope/test.rs
+++ b/src/scope/test.rs
@@ -1,5 +1,9 @@
+extern crate rand;
+
 use {scope, Scope};
 use prelude::*;
+use rand::{Rng, SeedableRng, XorShiftRng};
+use std::iter::once;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[test]
@@ -73,4 +77,68 @@ fn scope_mix() {
             assert_eq!(r1.unwrap(), r2);
         });
     });
+}
+
+struct Tree<T> {
+    value: T,
+    children: Vec<Tree<T>>,
+}
+
+impl<T> Tree<T> {
+    pub fn iter<'s>(&'s self) -> impl Iterator<Item=&'s T> + 's
+    {
+        once(&self.value)
+            .chain(self.children.iter().flat_map(|c| c.iter()))
+            .collect::<Vec<_>>() // seems like it shouldn't be needed... but prevents overflow
+            .into_iter()
+    }
+
+    pub fn update<OP>(&mut self, op: OP)
+        where OP: Fn(&mut T) + Sync, T: Send,
+    {
+        scope(|s| self.update_in_scope(&op, s));
+    }
+
+    fn update_in_scope<'scope, OP>(&'scope mut self, op: &'scope OP, scope: &Scope<'scope>)
+        where OP: Fn(&mut T) + Sync
+    {
+        let Tree { ref mut value, ref mut children } = *self;
+        scope.spawn(move |scope| {
+            for child in children {
+                scope.spawn(move |scope| child.update_in_scope(op, scope));
+            }
+        });
+
+        op(value);
+    }
+}
+
+fn random_tree(depth: usize) -> Tree<u32> {
+    assert!(depth > 0);
+    let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
+    random_tree1(depth, &mut rng)
+}
+
+fn random_tree1(depth: usize, rng: &mut XorShiftRng) -> Tree<u32> {
+    let children = if depth == 0 {
+        vec![]
+    } else {
+        (0..(rng.next_u32() % 3)) // somewhere between 0 and 3 children at each level
+            .map(|_| random_tree1(depth - 1, rng))
+            .collect()
+    };
+
+    Tree { value: rng.next_u32() % 1_000_000, children: children }
+}
+
+#[test]
+fn update_tree() {
+    let mut tree: Tree<u32> = random_tree(10);
+    let values: Vec<u32> = tree.iter().cloned().collect();
+    tree.update(|v| *v += 1);
+    let new_values: Vec<u32> = tree.iter().cloned().collect();
+    assert_eq!(values.len(), new_values.len());
+    for (&i, &j) in values.iter().zip(&new_values) {
+        assert_eq!(i + 1, j);
+    }
 }

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -278,6 +278,7 @@ impl WorkerThread {
         self.worker.pop()
     }
 
+    /// Keep stealing jobs until the latch is set.
     #[cold]
     pub unsafe fn steal_until(&mut self, latch: &SpinLatch) {
         // If another thread stole our job when we panic, we must halt unwinding
@@ -293,6 +294,7 @@ impl WorkerThread {
         mem::forget(guard);
     }
 
+    /// Steal a single job and return it.
     unsafe fn steal_work(&mut self) -> Option<JobRef> {
         if self.stealers.is_empty() { return None }
         let start = self.rng.next_u32() % self.stealers.len() as u32;


### PR DESCRIPTION
This branch causes us to shift to a worker thread as soon as you call `scope()`; individual calls to `scope.spawn()` are thus forced to execute in a worker thread, I believe. Since the scope is executing in a worker thread, we can then change to use a `SpinLatch` for when the workers are done, and then use `steal_until()` to steal until that completes.

I'm quite happy with these changes, but unhappy with not having tests. We need some bigger scope benchmarks. Something modeled on servo would be ideal (i.e., descending a tree, doing work (and maybe creating scopes too?) at each step).

Fixes #108

cc @emilio 

