### PR TITLE
add a `collect()` method to parallel iterators

### DIFF
--- a/rayon-demo/src/main.rs
+++ b/rayon-demo/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(conservative_impl_trait))]
 
 use std::env;
 use std::io;
@@ -12,6 +13,7 @@ mod sieve;
 
 // these are not "full-fledged" benchmarks yet,
 // they only run with cargo bench
+#[cfg(test)] mod map_collect;
 #[cfg(test)] mod factorial;
 #[cfg(test)] mod pythagoras;
 #[cfg(test)] mod fibonacci;

--- a/rayon-demo/src/map_collect.rs
+++ b/rayon-demo/src/map_collect.rs
@@ -65,9 +65,14 @@ mod util {
                     map
                 })
           .reduce(|| HashMap::new(),
-                  |mut map1, map2| {
-                      map1.extend(map2);
-                      map1
+                  |mut map1, mut map2| {
+                      if map1.len() > map2.len() {
+                          map1.extend(map2);
+                          map1
+                      } else {
+                          map2.extend(map1);
+                          map2
+                      }
                   })
     }
 }

--- a/rayon-demo/src/map_collect.rs
+++ b/rayon-demo/src/map_collect.rs
@@ -1,0 +1,168 @@
+//! Some benchmarks stress-testing various ways to build the standard
+//! `HashMap` data structures from the standard library.
+
+mod util {
+    use rayon::prelude::*;
+    use std::collections::{LinkedList, HashMap};
+    use std::hash::Hash;
+    use std::sync::Mutex;
+
+    /// Do whatever `collect` does by default.
+    pub fn collect<K, V, PI>(pi: PI) -> HashMap<K, V>
+        where K: Send + Hash + Eq,
+              V: Send,
+              PI: ParallelIterator<Item = (K, V)> + Send
+    {
+        pi.collect()
+    }
+
+    /// Use a system mutex.
+    pub fn mutex<K, V, PI>(pi: PI) -> HashMap<K, V>
+        where K: Send + Hash + Eq,
+              V: Send,
+              PI: ParallelIterator<Item = (K, V)> + Send
+    {
+        let mutex = Mutex::new(HashMap::new());
+        pi.for_each(|(k, v)| {
+            let mut guard = mutex.lock().unwrap();
+            guard.insert(k, v);
+        });
+        mutex.into_inner().unwrap()
+    }
+
+    /// Use a linked list intermediary.
+    pub fn linked_list<K, V, PI>(pi: PI) -> HashMap<K, V>
+        where K: Send + Hash + Eq,
+              V: Send,
+              PI: ParallelIterator<Item = (K, V)> + Send
+    {
+        let list: LinkedList<(_, _)> = pi.collect();
+        list.into_iter().collect()
+    }
+
+    /// Use a linked list of vectors intermediary.
+    pub fn linked_list_vec<K, V, PI>(pi: PI) -> HashMap<K, V>
+        where K: Send + Hash + Eq,
+              V: Send,
+              PI: ParallelIterator<Item = (K, V)> + Send
+    {
+        let list: LinkedList<Vec<(_, _)>> = pi
+            .fold(|| Vec::new(),
+                  |mut vec, elem| { vec.push(elem); vec })
+            .collect();
+        list.into_iter().flat_map(Vec::into_iter).collect()
+    }
+
+    /// Fold into hashmaps and then reduce them together.
+    pub fn fold<K, V, PI>(pi: PI) -> HashMap<K, V>
+        where K: Send + Hash + Eq,
+              V: Send,
+              PI: ParallelIterator<Item = (K, V)> + Send
+    {
+        pi.fold(|| HashMap::new(),
+                |mut map, (k, v)| {
+                    map.insert(k, v);
+                    map
+                })
+          .reduce(|| HashMap::new(),
+                  |mut map1, map2| {
+                      map1.extend(map2);
+                      map1
+                  })
+    }
+}
+
+
+macro_rules! make_bench {
+    ($generate:ident, $check:ident) => {
+        #[bench]
+        fn with_collect(b: &mut ::test::Bencher) {
+            use map_collect::util;
+            let mut map = None;
+            b.iter(|| map = Some(util::collect($generate())));
+            $check(&map.unwrap());
+        }
+
+        #[bench]
+        fn with_mutex(b: &mut ::test::Bencher) {
+            use map_collect::util;
+            let mut map = None;
+            b.iter(|| map = Some(util::mutex($generate())));
+            $check(&map.unwrap());
+        }
+
+        #[bench]
+        fn with_linked_list(b: &mut ::test::Bencher) {
+            use map_collect::util;
+            let mut map = None;
+            b.iter(|| map = Some(util::linked_list($generate())));
+            $check(&map.unwrap());
+        }
+
+        #[bench]
+        fn with_linked_list_vec(b: &mut ::test::Bencher) {
+            use map_collect::util;
+            let mut map = None;
+            b.iter(|| map = Some(util::linked_list_vec($generate())));
+            $check(&map.unwrap());
+        }
+
+        #[bench]
+        fn with_fold(b: &mut ::test::Bencher) {
+            use map_collect::util;
+            let mut map = None;
+            b.iter(|| map = Some(util::fold($generate())));
+            $check(&map.unwrap());
+        }
+    }
+}
+
+/// Tests a big map mapping `i -> i` forall i in 0 to N. This map is
+/// interesting because it has no conflicts, so each parallel
+/// iteration adds a distinct entry into the map.
+mod i_to_i {
+    use rayon::prelude::*;
+    use std::collections::HashMap;
+
+    const N: u32 = 256 * 1024;
+
+    fn generate() -> impl ParallelIterator<Item=(u32, u32)> {
+        (0_u32..N)
+            .into_par_iter()
+            .map(|i| (i, i))
+    }
+
+    fn check(hm: &HashMap<u32, u32>) {
+        assert_eq!(hm.len(), N as usize);
+        for i in 0..N {
+            assert_eq!(hm[&i], i);
+        }
+    }
+
+    make_bench!(generate, check);
+}
+
+/// Tests a big map mapping `i % 10 -> i` forall i in 0 to N. This map
+/// is interesting because it has lots of conflicts, so parallel
+/// iterations sometimes overwrite entries.
+mod i_mod_10_to_i {
+    use rayon::prelude::*;
+    use std::collections::HashMap;
+
+    const N: u32 = 256 * 1024;
+
+    fn generate() -> impl ParallelIterator<Item=(u32, u32)> {
+        (0_u32..N)
+            .into_par_iter()
+            .map(|i| (i % 10, i))
+    }
+
+    fn check(hm: &HashMap<u32, u32>) {
+        assert_eq!(hm.len(), 10);
+        for (&k, &v) in hm {
+            assert_eq!(k, v % 10);
+        }
+    }
+
+    make_bench!(generate, check);
+}

--- a/src/par_iter/collect/mod.rs
+++ b/src/par_iter/collect/mod.rs
@@ -35,4 +35,3 @@ pub fn collect_into<PAR_ITER,T>(mut pi: PAR_ITER, v: &mut Vec<T>)
         v.set_len(len);
     }
 }
-

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -1,0 +1,35 @@
+use super::ExactParallelIterator;
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+pub trait FromParIter<PAR_ITER> {
+    fn from_par_iter(par_iter: PAR_ITER) -> Self;
+}
+
+/// Collect items from a parallel iterator into a freshly allocated
+/// vector. This is very efficient, but requires precise knowledge of
+/// the number of items being iterated.
+impl<PAR_ITER, T> FromParIter<PAR_ITER> for Vec<T>
+    where PAR_ITER: ExactParallelIterator<Item=T>,
+          T: Send,
+{
+    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+        let mut vec = vec![];
+        par_iter.collect_into(&mut vec);
+        vec
+    }
+}
+
+/// Collect items from a parallel iterator into a hashmap. To some
+/// extent, a proof of concept, since it requires an intermediate
+/// allocation into a vector at the moment.
+impl<PAR_ITER, K: Eq + Hash, V> FromParIter<PAR_ITER> for HashMap<K, V>
+    where PAR_ITER: ExactParallelIterator<Item=(K, V)>,
+          (K, V): Send,
+{
+    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+        let vec: Vec<(K, V)> = par_iter.collect();
+        vec.into_iter().collect()
+    }
+}

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -35,15 +35,16 @@ impl<PAR_ITER, T> FromParIter<PAR_ITER> for LinkedList<T>
     }
 }
 
-/// Collect items from a parallel iterator into a hashmap. To some
-/// extent, a proof of concept, since it requires an intermediate
-/// allocation into a vector at the moment.
+/// Collect (key, value) pairs from a parallel iterator into a
+/// hashmap.  If multiple pairs correspond to the same key, then the
+/// ones produced earlier in the parallel iterator will be
+/// overwritten, just as with a sequential iterator.
 impl<PAR_ITER, K: Eq + Hash, V> FromParIter<PAR_ITER> for HashMap<K, V>
-    where PAR_ITER: ExactParallelIterator<Item=(K, V)>,
+    where PAR_ITER: ParallelIterator<Item=(K, V)>,
           (K, V): Send,
 {
     fn from_par_iter(par_iter: PAR_ITER) -> Self {
-        let vec: Vec<(K, V)> = par_iter.collect();
+        let vec: LinkedList<(K, V)> = par_iter.collect();
         vec.into_iter().collect()
     }
 }

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -1,7 +1,8 @@
-use super::ExactParallelIterator;
+use super::{ParallelIterator, ExactParallelIterator};
 
 use std::collections::HashMap;
 use std::hash::Hash;
+use std::collections::LinkedList;
 
 pub trait FromParIter<PAR_ITER> {
     fn from_par_iter(par_iter: PAR_ITER) -> Self;
@@ -18,6 +19,19 @@ impl<PAR_ITER, T> FromParIter<PAR_ITER> for Vec<T>
         let mut vec = vec![];
         par_iter.collect_into(&mut vec);
         vec
+    }
+}
+
+/// Collect items from a parallel iterator into a freshly allocated
+/// linked list.
+impl<PAR_ITER, T> FromParIter<PAR_ITER> for LinkedList<T>
+    where PAR_ITER: ParallelIterator<Item=T>,
+          T: Send,
+{
+    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+        par_iter.map(|elem| { let mut list = LinkedList::new(); list.push_back(elem); list })
+                .reduce_with(|mut list1, mut list2| { list1.append(&mut list2); list1 })
+                .unwrap_or_else(|| LinkedList::new())
     }
 }
 

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -4,14 +4,14 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::collections::LinkedList;
 
-pub trait FromParIter<PAR_ITER> {
+pub trait FromParallelIterator<PAR_ITER> {
     fn from_par_iter(par_iter: PAR_ITER) -> Self;
 }
 
 /// Collect items from a parallel iterator into a freshly allocated
 /// vector. This is very efficient, but requires precise knowledge of
 /// the number of items being iterated.
-impl<PAR_ITER, T> FromParIter<PAR_ITER> for Vec<T>
+impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for Vec<T>
     where PAR_ITER: ExactParallelIterator<Item=T>,
           T: Send,
 {
@@ -24,7 +24,7 @@ impl<PAR_ITER, T> FromParIter<PAR_ITER> for Vec<T>
 
 /// Collect items from a parallel iterator into a freshly allocated
 /// linked list.
-impl<PAR_ITER, T> FromParIter<PAR_ITER> for LinkedList<T>
+impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for LinkedList<T>
     where PAR_ITER: ParallelIterator<Item=T>,
           T: Send,
 {
@@ -39,7 +39,7 @@ impl<PAR_ITER, T> FromParIter<PAR_ITER> for LinkedList<T>
 /// hashmap.  If multiple pairs correspond to the same key, then the
 /// ones produced earlier in the parallel iterator will be
 /// overwritten, just as with a sequential iterator.
-impl<PAR_ITER, K: Eq + Hash, V> FromParIter<PAR_ITER> for HashMap<K, V>
+impl<PAR_ITER, K: Eq + Hash, V> FromParallelIterator<PAR_ITER> for HashMap<K, V>
     where PAR_ITER: ParallelIterator<Item=(K, V)>,
           (K, V): Send,
 {

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -19,6 +19,7 @@ use self::enumerate::Enumerate;
 use self::filter::Filter;
 use self::filter_map::FilterMap;
 use self::flat_map::FlatMap;
+use self::from_par_iter::FromParIter;
 use self::map::{Map, MapFn, MapCloned, MapInspect};
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp,
                    ReduceWithIdentityOp, SUM, MUL, MIN, MAX};
@@ -33,6 +34,7 @@ pub mod enumerate;
 pub mod filter;
 pub mod filter_map;
 pub mod flat_map;
+pub mod from_par_iter;
 pub mod internal;
 pub mod len;
 pub mod for_each;
@@ -545,6 +547,12 @@ pub trait ParallelIterator: Sized {
     #[doc(hidden)]
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>;
+
+    fn collect<C>(self) -> C
+        where C: FromParIter<Self>
+    {
+        C::from_par_iter(self)
+    }
 }
 
 impl<T: ParallelIterator> IntoParallelIterator for T {

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -19,7 +19,7 @@ use self::enumerate::Enumerate;
 use self::filter::Filter;
 use self::filter_map::FilterMap;
 use self::flat_map::FlatMap;
-use self::from_par_iter::FromParIter;
+use self::from_par_iter::FromParallelIterator;
 use self::map::{Map, MapFn, MapCloned, MapInspect};
 use self::reduce::{reduce, ReduceOp, SumOp, MulOp, MinOp, MaxOp,
                    ReduceWithIdentityOp, SUM, MUL, MIN, MAX};
@@ -559,7 +559,7 @@ pub trait ParallelIterator: Sized {
     /// to reuse the vector's backing store rather than allocating a
     /// fresh vector.
     fn collect<C>(self) -> C
-        where C: FromParIter<Self>
+        where C: FromParallelIterator<Self>
     {
         C::from_par_iter(self)
     }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -548,6 +548,16 @@ pub trait ParallelIterator: Sized {
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>;
 
+    /// Create a fresh collection containing all the element produced
+    /// by this parallel iterator. Note that some kinds of collections
+    /// have stricter requirements in terms of the kinds of iterators
+    /// that you can collect from (e.g., a `Vec` currently requires an
+    /// iterator that has precise knowledge of how many elements it
+    /// contains).
+    ///
+    /// You may also prefer to use `collect_into()`, which allows you
+    /// to reuse the vector's backing store rather than allocating a
+    /// fresh vector.
     fn collect<C>(self) -> C
         where C: FromParIter<Self>
     {

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -4,7 +4,7 @@ use super::*;
 use super::internal::*;
 
 use std::collections::LinkedList;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
 fn is_exact<T: ExactParallelIterator>(_: T) { }
@@ -656,10 +656,33 @@ pub fn par_iter_collect() {
 }
 
 #[test]
-pub fn par_iter_collect_map() {
+pub fn par_iter_collect_hashmap() {
     let a: Vec<i32> = (0..1024).collect();
     let b: HashMap<i32, String> = a.par_iter().map(|&i| (i, format!("{}", i))).collect();
     assert_eq!(&b[&3], "3");
+    assert_eq!(b.len(), 1024);
+}
+
+#[test]
+pub fn par_iter_collect_hashset() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: HashSet<i32> = a.par_iter().cloned().collect();
+    assert_eq!(b.len(), 1024);
+}
+
+#[test]
+pub fn par_iter_collect_btreemap() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: BTreeMap<i32, String> = a.par_iter().map(|&i| (i, format!("{}", i))).collect();
+    assert_eq!(&b[&3], "3");
+    assert_eq!(b.len(), 1024);
+}
+
+#[test]
+pub fn par_iter_collect_btreeset() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: BTreeSet<i32> = a.par_iter().cloned().collect();
+    assert_eq!(b.len(), 1024);
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use super::*;
 use super::internal::*;
 
+use std::collections::LinkedList;
 use std::collections::HashMap;
 
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
@@ -659,5 +660,20 @@ pub fn par_iter_collect_map() {
     let a: Vec<i32> = (0..1024).collect();
     let b: HashMap<i32, String> = a.par_iter().map(|&i| (i, format!("{}", i))).collect();
     assert_eq!(&b[&3], "3");
+}
+
+#[test]
+pub fn par_iter_collect_linked_list() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: LinkedList<_> = a.par_iter().map(|&i| (i, format!("{}", i))).collect();
+    let c: LinkedList<_> = a.iter().map(|&i| (i, format!("{}", i))).collect();
+    assert_eq!(b, c);
+}
+
+#[test]
+pub fn par_iter_collect_linked_list_flat_map_filter() {
+    let b: LinkedList<i32> = (0_i32..1024).into_par_iter().weight_max().flat_map(|i| (0..i)).filter(|&i| i % 2 == 0).collect();
+    let c: LinkedList<i32> = (0_i32..1024).flat_map(|i| (0..i)).filter(|&i| i % 2 == 0).collect();
+    assert_eq!(b, c);
 }
 

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use super::*;
 use super::internal::*;
 
+use std::collections::HashMap;
+
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
 fn is_exact<T: ExactParallelIterator>(_: T) { }
 fn is_indexed<T: IndexedParallelIterator>(_: T) { }
@@ -643,3 +645,19 @@ pub fn check_find_is_present() {
     assert!(q >= 1024 && q < 1096);
     assert!(counter.load(Ordering::SeqCst) < 2048); // should not have visited every single one
 }
+
+#[test]
+pub fn par_iter_collect() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: Vec<i32> = a.par_iter().map(|&i| i + 1).collect();
+    let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
+    assert_eq!(b, c);
+}
+
+#[test]
+pub fn par_iter_collect_map() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: HashMap<i32, String> = a.par_iter().map(|&i| (i, format!("{}", i))).collect();
+    assert_eq!(&b[&3], "3");
+}
+

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,3 +12,5 @@ pub use par_iter::IndexedParallelIterator;
 
 pub use par_iter::ToParallelChunks;
 pub use par_iter::ToParallelChunksMut;
+
+pub use par_iter::from_par_iter::FromParIter;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,4 +13,4 @@ pub use par_iter::IndexedParallelIterator;
 pub use par_iter::ToParallelChunks;
 pub use par_iter::ToParallelChunksMut;
 
-pub use par_iter::from_par_iter::FromParIter;
+pub use par_iter::from_par_iter::FromParallelIterator;


### PR DESCRIPTION
Implement it for `Vec<T>` and `HashMap<K, V>`. The latter one is mildly
dubious, though I think it's functionality we will want to support (and
probably optimize over time). I included it in part to force type
inference hints.

cc #123
