### PR TITLE
fix(thread_local): Removes unnecessary semicolon

### DIFF
--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -93,7 +93,7 @@ impl Splitter {
     fn thief_id() -> usize {
         // The actual `ID` value is irrelevant.  We're just using its TLS
         // address as a unique thread key, faster than a real thread-id call.
-        thread_local!{ static ID: bool = false; }
+        thread_local!{ static ID: bool = false }
         ID.with(|id| id as *const bool as usize )
     }
 


### PR DESCRIPTION
Not sure if this is explicitly a rust `1.9.0` thing or not