### PR TITLE
Additions for parallel collect

### DIFF
--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -3,6 +3,7 @@ use super::{ParallelIterator, ExactParallelIterator};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
 use std::collections::LinkedList;
+use std::collections::{BinaryHeap, VecDeque};
 
 pub trait FromParallelIterator<PAR_ITER> {
     fn from_par_iter(par_iter: PAR_ITER) -> Self;
@@ -29,6 +30,27 @@ impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for Vec<T>
         let mut vec = vec![];
         par_iter.collect_into(&mut vec);
         vec
+    }
+}
+
+/// Collect items from a parallel iterator into a vecdeque.
+impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for VecDeque<T>
+    where Vec<T>: FromParallelIterator<PAR_ITER>,
+          T: Send,
+{
+    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+        Vec::from_par_iter(par_iter).into()
+    }
+}
+
+/// Collect items from a parallel iterator into a binaryheap.
+/// The heap-ordering is calculated serially after all items are collected.
+impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for BinaryHeap<T>
+    where Vec<T>: FromParallelIterator<PAR_ITER>,
+          T: Ord + Send,
+{
+    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+        Vec::from_par_iter(par_iter).into()
     }
 }
 

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -88,6 +88,7 @@ impl<PAR_ITER, K, V, S> FromParallelIterator<PAR_ITER> for HashMap<K, V, S>
           S: BuildHasher + Default + Send,
 {
     fn from_par_iter(par_iter: PAR_ITER) -> Self {
+        // See the map_collect benchmarks in rayon-demo for different strategies.
         combine(par_iter, |list| {
             let len = combined_len(list);
             HashMap::with_capacity_and_hasher(len, Default::default())

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -667,9 +667,13 @@ pub fn par_iter_collect_vecdeque() {
 #[test]
 pub fn par_iter_collect_binaryheap() {
     let a: Vec<i32> = (0..1024).collect();
-    let b: BinaryHeap<i32> = a.par_iter().cloned().collect();
+    let mut b: BinaryHeap<i32> = a.par_iter().cloned().collect();
     assert_eq!(b.peek(), Some(&1023));
     assert_eq!(b.len(), 1024);
+    for n in (0..1024).rev() {
+        assert_eq!(b.pop(), Some(n));
+        assert_eq!(b.len() as i32, n);
+    }
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -5,6 +5,7 @@ use super::internal::*;
 
 use std::collections::LinkedList;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BinaryHeap, VecDeque};
 
 fn is_bounded<T: ExactParallelIterator>(_: T) { }
 fn is_exact<T: ExactParallelIterator>(_: T) { }
@@ -653,6 +654,22 @@ pub fn par_iter_collect() {
     let b: Vec<i32> = a.par_iter().map(|&i| i + 1).collect();
     let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
     assert_eq!(b, c);
+}
+
+#[test]
+pub fn par_iter_collect_vecdeque() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: VecDeque<i32> = a.par_iter().cloned().collect();
+    let c: VecDeque<i32> = a.iter().cloned().collect();
+    assert_eq!(b, c);
+}
+
+#[test]
+pub fn par_iter_collect_binaryheap() {
+    let a: Vec<i32> = (0..1024).collect();
+    let b: BinaryHeap<i32> = a.par_iter().cloned().collect();
+    assert_eq!(b.peek(), Some(&1023));
+    assert_eq!(b.len(), 1024);
 }
 
 #[test]


### PR DESCRIPTION
- Re-add the extra benchmarks from #135 
- Change the general collect to use `LinkedList<Vec<_>>`
- Add `BinaryHeap` and `VecDeque` for symmetry with `IntoParallelIterator` collections.