### PR TITLE
Match sequential iterator API for comparison-based reducers

### DIFF
--- a/src/par_iter/reduce.rs
+++ b/src/par_iter/reduce.rs
@@ -185,66 +185,6 @@ product_rule!(usize, 1);
 product_rule!(f32, 1.0);
 product_rule!(f64, 1.0);
 
-pub struct MinOp;
-
-pub const MIN: &'static MinOp = &MinOp;
-
-macro_rules! min_rule {
-    ($i:ty, $z:expr, $f:expr) => {
-        impl ReduceOp<$i> for MinOp {
-            fn start_value(&self) -> $i {
-                $z
-            }
-            fn reduce(&self, value1: $i, value2: $i) -> $i {
-                $f(value1, value2)
-            }
-        }
-    }
-}
-
-min_rule!(i8, std::i8::MAX, std::cmp::min);
-min_rule!(i16, std::i16::MAX, std::cmp::min);
-min_rule!(i32, std::i32::MAX, std::cmp::min);
-min_rule!(i64, std::i64::MAX, std::cmp::min);
-min_rule!(isize, std::isize::MAX, std::cmp::min);
-min_rule!(u8, std::u8::MAX, std::cmp::min);
-min_rule!(u16, std::u16::MAX, std::cmp::min);
-min_rule!(u32, std::u32::MAX, std::cmp::min);
-min_rule!(u64, std::u64::MAX, std::cmp::min);
-min_rule!(usize, std::usize::MAX, std::cmp::min);
-min_rule!(f32, std::f32::INFINITY, f32::min);
-min_rule!(f64, std::f64::INFINITY, f64::min);
-
-pub struct MaxOp;
-
-pub const MAX: &'static MaxOp = &MaxOp;
-
-macro_rules! max_rule {
-    ($i:ty, $z:expr, $f:expr) => {
-        impl ReduceOp<$i> for MaxOp {
-            fn start_value(&self) -> $i {
-                $z
-            }
-            fn reduce(&self, value1: $i, value2: $i) -> $i {
-                $f(value1, value2)
-            }
-        }
-    }
-}
-
-max_rule!(i8, std::i8::MIN, std::cmp::max);
-max_rule!(i16, std::i16::MIN, std::cmp::max);
-max_rule!(i32, std::i32::MIN, std::cmp::max);
-max_rule!(i64, std::i64::MIN, std::cmp::max);
-max_rule!(isize, std::isize::MIN, std::cmp::max);
-max_rule!(u8, std::u8::MIN, std::cmp::max);
-max_rule!(u16, std::u16::MIN, std::cmp::max);
-max_rule!(u32, std::u32::MIN, std::cmp::max);
-max_rule!(u64, std::u64::MIN, std::cmp::max);
-max_rule!(usize, std::usize::MIN, std::cmp::max);
-max_rule!(f32, std::f32::NEG_INFINITY, f32::max);
-max_rule!(f64, std::f64::NEG_INFINITY, f64::max);
-
 pub struct ReduceWithIdentityOp<'r, IDENTITY: 'r, OP: 'r> {
     identity: &'r IDENTITY,
     op: &'r OP,

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -741,3 +741,12 @@ fn min_max() {
     }
 }
 
+fn min_max_by() {
+    let mut rng = XorShiftRng::from_seed([14159, 26535, 89793, 23846]);
+    let a: Vec<(i32, u16)> = rng.gen_iter().take(1024).zip(0 .. 1024).collect();
+    for i in 0 .. a.len() + 1 {
+        let slice = &a[..i];
+        assert_eq!(slice.par_iter().min_by_key(|x| x.0), slice.iter().min_by_key(|x| x.0));
+        assert_eq!(slice.par_iter().max_by_key(|x| x.0), slice.iter().max_by_key(|x| x.0));
+    }
+}

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use super::*;
 use super::internal::*;
 
+use rand::{Rng, SeedableRng, XorShiftRng};
 use std::collections::LinkedList;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
@@ -727,5 +728,16 @@ pub fn par_iter_collect_linked_list_flat_map_filter() {
     let b: LinkedList<i32> = (0_i32..1024).into_par_iter().weight_max().flat_map(|i| (0..i)).filter(|&i| i % 2 == 0).collect();
     let c: LinkedList<i32> = (0_i32..1024).flat_map(|i| (0..i)).filter(|&i| i % 2 == 0).collect();
     assert_eq!(b, c);
+}
+
+#[test]
+fn min_max() {
+    let mut rng = XorShiftRng::from_seed([14159, 26535, 89793, 23846]);
+    let a: Vec<i32> = rng.gen_iter().take(1024).collect();
+    for i in 0 .. a.len() + 1 {
+        let slice = &a[..i];
+        assert_eq!(slice.par_iter().min(), slice.iter().min());
+        assert_eq!(slice.par_iter().max(), slice.iter().max());
+    }
 }
 


### PR DESCRIPTION
Closes #148.

(The failing tests should be unrelated; they fail on master as well.)