### PR TITLE
Fixes issue #147

### DIFF
--- a/src/par_iter/collect/consumer.rs
+++ b/src/par_iter/collect/consumer.rs
@@ -1,5 +1,6 @@
 use super::super::len::*;
 use super::super::internal::*;
+use super::super::noop::*;
 use std::ptr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -1,6 +1,7 @@
 use super::ParallelIterator;
 use super::len::*;
 use super::internal::*;
+use super::noop::*;
 
 pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
     where PAR_ITER: ParallelIterator<Item=T>,

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -92,7 +92,7 @@ pub trait UnindexedProducer: IntoIterator + Send + Sized {
 
 /// A splitter controls the policy for splitting into smaller work items.
 #[derive(Clone, Copy)]
-pub enum Splitter {
+enum Splitter {
     /// Classic cost-splitting uses weights to split until below a threshold.
     Cost(f64),
 
@@ -159,47 +159,50 @@ pub fn bridge<PAR_ITER,C>(mut par_iter: PAR_ITER,
         where C: Consumer<ITEM>
     {
         type Output = C::Result;
-        fn callback<P>(mut self, mut producer: P) -> C::Result
+        fn callback<P>(self, producer: P) -> C::Result
             where P: Producer<Item=ITEM>
         {
-            let splitter = if producer.weighted() || self.consumer.weighted() {
-                let producer_cost = producer.cost(self.len);
-                let cost = self.consumer.cost(producer_cost);
-                Splitter::Cost(cost)
-            } else {
-                Splitter::new_thief()
-            };
-            bridge_producer_consumer(self.len, splitter, producer, self.consumer)
+            bridge_producer_consumer(self.len, producer, self.consumer)
         }
     }
 }
 
 pub fn bridge_producer_consumer<P,C>(len: usize,
-                                 mut splitter: Splitter,
-                                 producer: P,
-                                 consumer: C)
+                                 mut producer: P,
+                                 mut consumer: C)
                                  -> C::Result
     where P: Producer, C: Consumer<P::Item>
 {
-    if consumer.full() {
-        consumer.into_folder().complete()
-    } else if len > 1 && splitter.try() {
-        let mid = len / 2;
-        let (left_producer, right_producer) = producer.split_at(mid);
-        let (left_consumer, right_consumer, reducer) = consumer.split_at(mid);
-        let (left_result, right_result) =
-            join(|| bridge_producer_consumer(mid, splitter,
-                                             left_producer, left_consumer),
-                 || bridge_producer_consumer(len - mid, splitter,
-                                             right_producer, right_consumer));
-        reducer.reduce(left_result, right_result)
+    let splitter = if producer.weighted() || consumer.weighted() {
+        let producer_cost = producer.cost(len);
+        let cost = consumer.cost(producer_cost);
+        Splitter::Cost(cost)
     } else {
-        let mut folder = consumer.into_folder();
-        for item in producer {
-            folder = folder.consume(item);
-            if folder.full() { break }
+        Splitter::new_thief()
+    };
+    return helper(len, splitter, producer, consumer);
+
+    fn helper<P,C>(len: usize, mut splitter: Splitter, producer: P, consumer: C) -> C::Result
+        where P: Producer, C: Consumer<P::Item>
+    {
+        if consumer.full() {
+            consumer.into_folder().complete()
+        } else if len > 1 && splitter.try() {
+            let mid = len / 2;
+            let (left_producer, right_producer) = producer.split_at(mid);
+            let (left_consumer, right_consumer, reducer) = consumer.split_at(mid);
+            let (left_result, right_result) =
+                join(|| helper(mid, splitter, left_producer, left_consumer),
+                     || helper(len - mid, splitter, right_producer, right_consumer));
+            reducer.reduce(left_result, right_result)
+        } else {
+            let mut folder = consumer.into_folder();
+            for item in producer {
+                folder = folder.consume(item);
+                if folder.full() { break }
+            }
+            folder.complete()
         }
-        folder.complete()
     }
 }
 
@@ -238,12 +241,4 @@ fn bridge_unindexed_producer_consumer<P,C>(mut splitter: Splitter,
         }
         folder.complete()
     }
-}
-
-/// Utility type for consumers that don't need a "reduce" step. Just
-/// reduces unit to unit.
-pub struct NoopReducer;
-
-impl Reducer<()> for NoopReducer {
-    fn reduce(self, _left: (), _right: ()) { }
 }

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -92,7 +92,7 @@ pub trait UnindexedProducer: IntoIterator + Send + Sized {
 
 /// A splitter controls the policy for splitting into smaller work items.
 #[derive(Clone, Copy)]
-enum Splitter {
+pub enum Splitter {
     /// Classic cost-splitting uses weights to split until below a threshold.
     Cost(f64),
 
@@ -174,7 +174,7 @@ pub fn bridge<PAR_ITER,C>(mut par_iter: PAR_ITER,
     }
 }
 
-fn bridge_producer_consumer<P,C>(len: usize,
+pub fn bridge_producer_consumer<P,C>(len: usize,
                                  mut splitter: Splitter,
                                  producer: P,
                                  consumer: C)

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -25,6 +25,7 @@ use self::map::{Map, MapFn, MapCloned, MapInspect};
 use self::reduce::{reduce, ReduceOp, SumOp, ProductOp,
                    ReduceWithIdentityOp, SUM, PRODUCT};
 use self::skip::Skip;
+use self::take::Take;
 use self::internal::*;
 use self::weight::Weight;
 use self::zip::ZipIter;
@@ -43,6 +44,7 @@ pub mod for_each;
 pub mod fold;
 pub mod reduce;
 pub mod skip;
+pub mod take;
 pub mod slice;
 pub mod slice_mut;
 pub mod map;
@@ -690,6 +692,12 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
         use std::cmp::min;
         let n = min(n, self.len());
         Skip::new(self, n)
+    }
+
+    fn take(mut self, n: usize) -> Take<Self> {
+        use std::cmp::min;
+        let n = min(n, self.len());
+        Take::new(self, n)
     }
 
     /// Searches for **some** item in the parallel iterator that

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -688,15 +688,11 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
         Enumerate::new(self)
     }
 
-    fn skip(mut self, n: usize) -> Skip<Self> {
-        use std::cmp::min;
-        let n = min(n, self.len());
+    fn skip(self, n: usize) -> Skip<Self> {
         Skip::new(self, n)
     }
 
-    fn take(mut self, n: usize) -> Take<Self> {
-        use std::cmp::min;
-        let n = min(n, self.len());
+    fn take(self, n: usize) -> Take<Self> {
         Take::new(self, n)
     }
 

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -54,6 +54,7 @@ pub mod range;
 pub mod vec;
 pub mod option;
 pub mod collections;
+pub mod noop;
 
 #[cfg(test)]
 mod test;

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -688,10 +688,12 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
         Enumerate::new(self)
     }
 
+    /// Creates an iterator that skips the first `n` elements.
     fn skip(self, n: usize) -> Skip<Self> {
         Skip::new(self, n)
     }
 
+    /// Creates an iterator that yields the first `n` elements.
     fn take(self, n: usize) -> Take<Self> {
         Take::new(self, n)
     }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -24,6 +24,7 @@ use self::from_par_iter::FromParallelIterator;
 use self::map::{Map, MapFn, MapCloned, MapInspect};
 use self::reduce::{reduce, ReduceOp, SumOp, ProductOp,
                    ReduceWithIdentityOp, SUM, PRODUCT};
+use self::skip::Skip;
 use self::internal::*;
 use self::weight::Weight;
 use self::zip::ZipIter;
@@ -41,6 +42,7 @@ pub mod len;
 pub mod for_each;
 pub mod fold;
 pub mod reduce;
+pub mod skip;
 pub mod slice;
 pub mod slice_mut;
 pub mod map;
@@ -682,6 +684,12 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
     /// Yields an index along with each item.
     fn enumerate(self) -> Enumerate<Self> {
         Enumerate::new(self)
+    }
+
+    fn skip(mut self, n: usize) -> Skip<Self> {
+        use std::cmp::min;
+        let n = min(n, self.len());
+        Skip::new(self, n)
     }
 
     /// Searches for **some** item in the parallel iterator that

--- a/src/par_iter/noop.rs
+++ b/src/par_iter/noop.rs
@@ -47,3 +47,9 @@ impl<ITEM> UnindexedConsumer<ITEM> for NoopConsumer {
         NoopReducer
     }
 }
+
+pub struct NoopReducer;
+
+impl Reducer<()> for NoopReducer {
+    fn reduce(self, _left: (), _right: ()) { }
+}

--- a/src/par_iter/noop.rs
+++ b/src/par_iter/noop.rs
@@ -1,0 +1,49 @@
+use super::internal::*;
+
+pub struct NoopConsumer;
+
+impl NoopConsumer {
+    pub fn new() -> Self {
+        NoopConsumer
+    }
+}
+
+impl<ITEM> Consumer<ITEM> for NoopConsumer
+{
+    type Folder = NoopConsumer;
+    type Reducer = NoopReducer;
+    type Result = ();
+
+    fn cost(&mut self, cost: f64) -> f64 {
+        cost
+    }
+
+    fn split_at(self, _index: usize) -> (Self, Self, NoopReducer) {
+        (NoopConsumer, NoopConsumer, NoopReducer)
+    }
+
+    fn into_folder(self) -> Self {
+        self
+    }
+}
+
+impl<ITEM> Folder<ITEM> for NoopConsumer {
+    type Result = ();
+
+    fn consume(self, _item: ITEM) -> Self {
+        self
+    }
+
+    fn complete(self) {
+    }
+}
+
+impl<ITEM> UnindexedConsumer<ITEM> for NoopConsumer {
+    fn split_off(&self) -> Self {
+        NoopConsumer
+    }
+
+    fn to_reducer(&self) -> NoopReducer {
+        NoopReducer
+    }
+}

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -1,0 +1,74 @@
+use super::*;
+use super::internal::*;
+
+pub struct Skip<M> {
+    base: M,
+    n: usize,
+}
+
+impl<M> Skip<M> {
+    pub fn new(base: M, n: usize) -> Skip<M> {
+        Skip { base: base,
+               n: n }
+    }
+}
+
+impl<M> ParallelIterator for Skip<M>
+    where M: IndexedParallelIterator
+{
+    type Item = M::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<M> ExactParallelIterator for Skip<M>
+    where M: IndexedParallelIterator
+{
+    fn len(&mut self) -> usize {
+        self.base.len() - self.n
+    }
+}
+
+impl<M> BoundedParallelIterator for Skip<M>
+    where M: IndexedParallelIterator
+{
+    fn upper_bound(&mut self) -> usize {
+        self.len()
+    }
+
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+}
+
+impl<M> IndexedParallelIterator for Skip<M>
+    where M: IndexedParallelIterator
+{
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        return self.base.with_producer(Callback { callback: callback,
+                                                  n: self.n});
+
+        struct Callback<CB> {
+            callback: CB,
+            n: usize,
+        }
+
+        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
+            where CB: ProducerCallback<ITEM>
+        {
+            type Output = CB::Output;
+            fn callback<P>(self, base: P) -> CB::Output
+                where P: Producer<Item=ITEM>
+            {
+                let (_, producer) = base.split_at(self.n);
+                self.callback.callback(producer)
+            }
+        }
+    }
+}

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -7,7 +7,7 @@ pub struct Skip<M> {
     n: usize,
 }
 
-impl<M> Skip<M> 
+impl<M> Skip<M>
     where M: IndexedParallelIterator
 {
     pub fn new(mut base: M, n: usize) -> Skip<M> {
@@ -70,8 +70,10 @@ impl<M> IndexedParallelIterator for Skip<M>
             fn callback<P>(self, base: P) -> CB::Output
                 where P: Producer<Item=ITEM>
             {
-                let (_, producer) = base.split_at(self.n);
-                self.callback.callback(producer)
+                let (before_skip, after_skip) = base.split_at(self.n);
+                bridge_producer_consumer(self.n, Splitter::Cost(self.n as f64),
+                                         before_skip, noop::NoopConsumer::new());
+                self.callback.callback(after_skip)
             }
         }
     }

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -29,7 +29,11 @@ impl<M> ExactParallelIterator for Skip<M>
     where M: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
-        self.base.len() - self.n
+        let base_len = self.base.len();
+        if self.n > base_len {
+            self.n = base_len;
+        }
+        base_len - self.n
     }
 }
 

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -71,8 +71,7 @@ impl<M> IndexedParallelIterator for Skip<M>
                 where P: Producer<Item=ITEM>
             {
                 let (before_skip, after_skip) = base.split_at(self.n);
-                bridge_producer_consumer(self.n, Splitter::Cost(self.n as f64),
-                                         before_skip, noop::NoopConsumer::new());
+                bridge_producer_consumer(self.n, before_skip, noop::NoopConsumer::new());
                 self.callback.callback(after_skip)
             }
         }

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -1,13 +1,17 @@
 use super::*;
 use super::internal::*;
+use std::cmp::min;
 
 pub struct Skip<M> {
     base: M,
     n: usize,
 }
 
-impl<M> Skip<M> {
-    pub fn new(base: M, n: usize) -> Skip<M> {
+impl<M> Skip<M> 
+    where M: IndexedParallelIterator
+{
+    pub fn new(mut base: M, n: usize) -> Skip<M> {
+        let n = min(base.len(), n);
         Skip { base: base,
                n: n }
     }
@@ -29,11 +33,7 @@ impl<M> ExactParallelIterator for Skip<M>
     where M: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
-        let base_len = self.base.len();
-        if self.n > base_len {
-            self.n = base_len;
-        }
-        base_len - self.n
+        self.base.len() - self.n
     }
 }
 

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -1,0 +1,74 @@
+use super::*;
+use super::internal::*;
+
+pub struct Take<M> {
+    base: M,
+    n: usize,
+}
+
+impl<M> Take<M> {
+    pub fn new(base: M, n: usize) -> Take<M> {
+        Take { base: base,
+               n: n }
+    }
+}
+
+impl<M> ParallelIterator for Take<M>
+    where M: IndexedParallelIterator
+{
+    type Item = M::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+}
+
+impl<M> ExactParallelIterator for Take<M>
+    where M: IndexedParallelIterator
+{
+    fn len(&mut self) -> usize {
+        self.n
+    }
+}
+
+impl<M> BoundedParallelIterator for Take<M>
+    where M: IndexedParallelIterator
+{
+    fn upper_bound(&mut self) -> usize {
+        self.len()
+    }
+
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+}
+
+impl<M> IndexedParallelIterator for Take<M>
+    where M: IndexedParallelIterator
+{
+    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        return self.base.with_producer(Callback { callback: callback,
+                                                  n: self.n});
+
+        struct Callback<CB> {
+            callback: CB,
+            n: usize,
+        }
+
+        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
+            where CB: ProducerCallback<ITEM>
+        {
+            type Output = CB::Output;
+            fn callback<P>(self, base: P) -> CB::Output
+                where P: Producer<Item=ITEM>
+            {
+                let (producer, _) = base.split_at(self.n);
+                self.callback.callback(producer)
+            }
+        }
+    }
+}

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -29,6 +29,10 @@ impl<M> ExactParallelIterator for Take<M>
     where M: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
+        let base_len = self.base.len();
+        if self.n > base_len {
+            self.n = base_len
+        }
         self.n
     }
 }
@@ -48,7 +52,7 @@ impl<M> BoundedParallelIterator for Take<M>
 impl<M> IndexedParallelIterator for Take<M>
     where M: IndexedParallelIterator
 {
-    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
         return self.base.with_producer(Callback { callback: callback,

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -1,13 +1,17 @@
 use super::*;
 use super::internal::*;
+use std::cmp::min;
 
 pub struct Take<M> {
     base: M,
     n: usize,
 }
 
-impl<M> Take<M> {
-    pub fn new(base: M, n: usize) -> Take<M> {
+impl<M> Take<M> 
+    where M: IndexedParallelIterator
+{
+    pub fn new(mut base: M, n: usize) -> Take<M> {
+        let n = min(base.len(), n);
         Take { base: base,
                n: n }
     }
@@ -29,10 +33,6 @@ impl<M> ExactParallelIterator for Take<M>
     where M: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
-        let base_len = self.base.len();
-        if self.n > base_len {
-            self.n = base_len
-        }
         self.n
     }
 }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -180,6 +180,26 @@ pub fn check_increment() {
 }
 
 #[test]
+pub fn check_skip() {
+    let mut b = vec![];
+    let a: Vec<usize> = (0..10).collect();
+    a.into_par_iter()
+        .skip(5)
+        .collect_into(&mut b);
+    assert_eq!(b, vec![5, 6, 7, 8, 9]);
+}
+
+#[test]
+pub fn check_skip_overflow() {
+    let mut b = vec![];
+    let a: Vec<usize> = (0..10).collect();
+    a.into_par_iter()
+        .skip(15)
+        .collect_into(&mut b);
+    assert_eq!(b, vec![]);
+}
+
+#[test]
 pub fn check_inspect() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -181,40 +181,51 @@ pub fn check_increment() {
 
 #[test]
 pub fn check_skip() {
-    let mut b = vec![];
     let a: Vec<usize> = (0..10).collect();
-    a.into_par_iter()
+
+    let mut b = vec![];
+    a.par_iter()
         .skip(5)
+        .cloned()
         .collect_into(&mut b);
     assert_eq!(b, vec![5, 6, 7, 8, 9]);
-}
 
-#[test]
-pub fn check_skip_overflow() {
     let mut b = vec![];
-    let a: Vec<usize> = (0..10).collect();
-    a.into_par_iter()
+    a.par_iter()
+        .skip(0)
+        .cloned()
+        .collect_into(&mut b);
+    assert_eq!(b, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    let mut b = vec![];
+    a.par_iter()
         .skip(15)
+        .cloned()
         .collect_into(&mut b);
     assert_eq!(b, vec![]);
 }
 
 #[test]
 pub fn check_take() {
-    let mut b = vec![];
     let a: Vec<usize> = (0..10).collect();
-    a.into_par_iter()
+    let mut b = vec![];
+    a.par_iter()
         .take(5)
+        .cloned()
         .collect_into(&mut b);
     assert_eq!(b, vec![0, 1, 2, 3, 4]);
-}
 
-#[test]
-pub fn check_take_overflow() {
     let mut b = vec![];
-    let a: Vec<usize> = (0..10).collect();
-    a.into_par_iter()
+    a.par_iter()
+        .take(0)
+        .cloned()
+        .collect_into(&mut b);
+    assert_eq!(b, vec![]);
+
+    let mut b = vec![];
+    a.par_iter()
         .take(15)
+        .cloned()
         .collect_into(&mut b);
     assert_eq!(b, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -197,6 +197,13 @@ pub fn check_skip() {
     a.par_iter().skip(0).collect_into(&mut v1);
     let v2 = a.iter().skip(0).collect::<Vec<_>>();
     assert_eq!(v1, v2);
+
+    // Check that the skipped elements side effects are executed
+    use std::sync::{Arc, Mutex};
+    let num = Arc::new(Mutex::new(0usize));
+    a.par_iter().map(|&n| *num.lock().unwrap() += n).skip(512).count();
+    let n: usize = *num.lock().unwrap();
+    assert_eq!(n, a.iter().sum());
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -200,6 +200,26 @@ pub fn check_skip_overflow() {
 }
 
 #[test]
+pub fn check_take() {
+    let mut b = vec![];
+    let a: Vec<usize> = (0..10).collect();
+    a.into_par_iter()
+        .take(5)
+        .collect_into(&mut b);
+    assert_eq!(b, vec![0, 1, 2, 3, 4]);
+}
+
+#[test]
+pub fn check_take_overflow() {
+    let mut b = vec![];
+    let a: Vec<usize> = (0..10).collect();
+    a.into_par_iter()
+        .take(15)
+        .collect_into(&mut b);
+    assert_eq!(b, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+}
+
+#[test]
 pub fn check_inspect() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -199,11 +199,10 @@ pub fn check_skip() {
     assert_eq!(v1, v2);
 
     // Check that the skipped elements side effects are executed
-    use std::sync::{Arc, Mutex};
-    let num = Arc::new(Mutex::new(0usize));
-    a.par_iter().map(|&n| *num.lock().unwrap() += n).skip(512).count();
-    let n: usize = *num.lock().unwrap();
-    assert_eq!(n, a.iter().sum());
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let num = AtomicUsize::new(0);
+    a.par_iter().map(|&n| num.fetch_add(n, Ordering::Relaxed)).skip(512).count();
+    assert_eq!(num.load(Ordering::Relaxed), a.iter().sum());
 }
 
 #[test]

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -181,53 +181,42 @@ pub fn check_increment() {
 
 #[test]
 pub fn check_skip() {
-    let a: Vec<usize> = (0..10).collect();
+    let a: Vec<usize> = (0..1024).collect();
 
-    let mut b = vec![];
-    a.par_iter()
-        .skip(5)
-        .cloned()
-        .collect_into(&mut b);
-    assert_eq!(b, vec![5, 6, 7, 8, 9]);
+    let mut v1 = Vec::new();
+    a.par_iter().skip(16).collect_into(&mut v1);
+    let v2 = a.iter().skip(16).collect::<Vec<_>>();
+    assert_eq!(v1, v2);
 
-    let mut b = vec![];
-    a.par_iter()
-        .skip(0)
-        .cloned()
-        .collect_into(&mut b);
-    assert_eq!(b, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let mut v1 = Vec::new();
+    a.par_iter().skip(2048).collect_into(&mut v1);
+    let v2 = a.iter().skip(2048).collect::<Vec<_>>();
+    assert_eq!(v1, v2);
 
-    let mut b = vec![];
-    a.par_iter()
-        .skip(15)
-        .cloned()
-        .collect_into(&mut b);
-    assert_eq!(b, vec![]);
+    let mut v1 = Vec::new();
+    a.par_iter().skip(0).collect_into(&mut v1);
+    let v2 = a.iter().skip(0).collect::<Vec<_>>();
+    assert_eq!(v1, v2);
 }
 
 #[test]
 pub fn check_take() {
-    let a: Vec<usize> = (0..10).collect();
-    let mut b = vec![];
-    a.par_iter()
-        .take(5)
-        .cloned()
-        .collect_into(&mut b);
-    assert_eq!(b, vec![0, 1, 2, 3, 4]);
+    let a: Vec<usize> = (0..1024).collect();
 
-    let mut b = vec![];
-    a.par_iter()
-        .take(0)
-        .cloned()
-        .collect_into(&mut b);
-    assert_eq!(b, vec![]);
+    let mut v1 = Vec::new();
+    a.par_iter().take(16).collect_into(&mut v1);
+    let v2 = a.iter().take(16).collect::<Vec<_>>();
+    assert_eq!(v1, v2);
 
-    let mut b = vec![];
-    a.par_iter()
-        .take(15)
-        .cloned()
-        .collect_into(&mut b);
-    assert_eq!(b, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let mut v1 = Vec::new();
+    a.par_iter().take(2048).collect_into(&mut v1);
+    let v2 = a.iter().take(2048).collect::<Vec<_>>();
+    assert_eq!(v1, v2);
+
+    let mut v1 = Vec::new();
+    a.par_iter().take(0).collect_into(&mut v1);
+    let v2 = a.iter().take(0).collect::<Vec<_>>();
+    assert_eq!(v1, v2);
 }
 
 #[test]


### PR DESCRIPTION
These commits implements `skip` and `take` on exact parallel iterators.

I am very unsure if I have put the bounds checking in the right place; right now it is in `len()`, using the fact that it's `&mut self`. However, maybe there is no guarantee for `len()` to have been called before `with_producer`, in which case we will crash.

I'm a first time contributor (and almost first time user) of Rayon, and most of the code is taken from `enumerate.rs`, so I'm sorry if there are obvious errors here :)
