### PR TITLE
Add ParallelString with par_chars

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -43,6 +43,7 @@ pub mod fold;
 pub mod reduce;
 pub mod slice;
 pub mod slice_mut;
+pub mod string;
 pub mod map;
 pub mod weight;
 pub mod zip;
@@ -125,6 +126,14 @@ pub trait ToParallelChunksMut<'data> {
     /// implementation should strive to maximize chunk size when
     /// possible.
     fn par_chunks_mut(&'data mut self, size: usize) -> Self::Iter;
+}
+
+/// Parallel extensions for strings.
+pub trait ParallelString {
+    type Chars;
+
+    /// Returns a parallel iterator over the characters of a string.
+    fn par_chars(self) -> Self::Chars;
 }
 
 /// The `ParallelIterator` interface.

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -1,0 +1,66 @@
+use super::*;
+use super::internal::*;
+use std::str::Chars;
+
+/// Test if a byte is the start of a UTF-8 character.
+/// (extracted from `str::is_char_boundary`)
+fn is_char_boundary(b: u8) -> bool {
+    // This is bit magic equivalent to: b < 128 || b >= 192
+    (b as i8) >= -0x40
+}
+
+
+impl<'a> ParallelString for &'a str {
+    type Chars = ParChars<'a>;
+
+    fn par_chars(self) -> Self::Chars {
+        ParChars {
+            chars: self
+        }
+    }
+}
+
+
+pub struct ParChars<'a> {
+    chars: &'a str
+}
+
+impl<'a> ParallelIterator for ParChars<'a> {
+    type Item = char;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge_unindexed(self, consumer)
+    }
+}
+
+impl<'a> UnindexedProducer for ParChars<'a> {
+    fn can_split(&self) -> bool {
+        // This is pessimistic, as we only *know* there are multiple characters
+        // when it's longer than Unicode's maximum UTF-8 length of 4.  There
+        // could be smaller characters, but it's ok not to split maximally.
+        self.chars.len() > 4
+    }
+
+    fn split(self) -> (Self, Self) {
+        let mid = self.chars.len() / 2;
+        let (left, right) = self.chars.as_bytes().split_at(mid);
+        let index = right.iter().cloned().position(is_char_boundary).map(|i| mid + i)
+            .or_else(|| left.iter().cloned().rposition(is_char_boundary))
+            .unwrap_or(0);
+
+        let (left, right) = self.chars.split_at(index);
+        (ParChars { chars: left }, ParChars { chars: right })
+    }
+}
+
+impl<'a> IntoIterator for ParChars<'a>
+{
+    type Item = char;
+    type IntoIter = Chars<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.chars.chars()
+    }
+}

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -45,6 +45,10 @@ impl<'a> UnindexedProducer for ParChars<'a> {
 
     fn split(self) -> (Self, Self) {
         let mid = self.chars.len() / 2;
+
+        // We want to split near the midpoint, but we need to find an actual
+        // character boundary.  So we look at the raw bytes, first scanning
+        // forward from the midpoint for a boundary, then trying backward.
         let (left, right) = self.chars.as_bytes().split_at(mid);
         let index = right.iter().cloned().position(is_char_boundary).map(|i| mid + i)
             .or_else(|| left.iter().cloned().rposition(is_char_boundary))

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -55,6 +55,19 @@ pub fn execute_unindexed_range() {
 }
 
 #[test]
+pub fn execute_strings() {
+    let mut rng = XorShiftRng::from_seed([14159, 26535, 89793, 23846]);
+    let s: String = rng.gen_iter::<char>().take(1024).collect();
+
+    let par_chars: String = s.par_chars().collect();
+    assert_eq!(s, par_chars);
+
+    let par_even: String = s.par_chars().filter(|&c| (c as u32) & 1 == 0).collect();
+    let ser_even: String = s.chars().filter(|&c| (c as u32) & 1 == 0).collect();
+    assert_eq!(par_even, ser_even);
+}
+
+#[test]
 pub fn check_map_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().map(|x| x));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,4 +13,6 @@ pub use par_iter::IndexedParallelIterator;
 pub use par_iter::ToParallelChunks;
 pub use par_iter::ToParallelChunksMut;
 
+pub use par_iter::ParallelString;
+
 pub use par_iter::from_par_iter::FromParallelIterator;


### PR DESCRIPTION
This is a first step toward useful parallel operations on strings.  It
works as an `UnindexedProducer` to split on UTF-8 character boundaries.