### PR TITLE
Make FromParallelIterator look more like FromIterator

### DIFF
--- a/rayon-demo/src/main.rs
+++ b/rayon-demo/src/main.rs
@@ -16,6 +16,7 @@ mod tsp;
 // these are not "full-fledged" benchmarks yet,
 // they only run with cargo bench
 #[cfg(test)] mod map_collect;
+#[cfg(test)] mod vec_collect;
 #[cfg(test)] mod factorial;
 #[cfg(test)] mod pythagoras;
 #[cfg(test)] mod fibonacci;

--- a/rayon-demo/src/vec_collect.rs
+++ b/rayon-demo/src/vec_collect.rs
@@ -1,0 +1,151 @@
+//! Some benchmarks stress-testing various ways to build a standard `Vec`.
+
+mod util {
+    use rayon::prelude::*;
+    use std::collections::LinkedList;
+
+    /// Do whatever `collect` does by default.
+    pub fn collect<T, PI>(pi: PI) -> Vec<T>
+        where T: Send,
+              PI: ParallelIterator<Item = T> + Send
+    {
+        pi.collect()
+    }
+
+    /// Use a linked list of vectors intermediary.
+    pub fn linked_list_vec<T, PI>(pi: PI) -> Vec<T>
+        where T: Send,
+              PI: ParallelIterator<Item = T> + Send
+    {
+        let list: LinkedList<Vec<_>> = pi
+            .fold(|| Vec::new(),
+                  |mut vec, elem| { vec.push(elem); vec })
+            .collect();
+        list.into_iter()
+            .fold(Vec::new(),
+                  |mut vec, mut sub| { vec.append(&mut sub); vec })
+    }
+
+    /// Use a linked list of vectors intermediary, with a size hint.
+    pub fn linked_list_vec_sized<T, PI>(pi: PI) -> Vec<T>
+        where T: Send,
+              PI: ParallelIterator<Item = T> + Send
+    {
+        let list: LinkedList<Vec<_>> = pi
+            .fold(|| Vec::new(),
+                  |mut vec, elem| { vec.push(elem); vec })
+            .collect();
+
+        let len = list.iter().map(Vec::len).sum();
+        list.into_iter()
+            .fold(Vec::with_capacity(len),
+                  |mut vec, mut sub| { vec.append(&mut sub); vec })
+    }
+
+    /// Fold into vectors and then reduce them together.
+    pub fn fold<T, PI>(pi: PI) -> Vec<T>
+        where T: Send,
+              PI: ParallelIterator<Item = T> + Send
+    {
+        pi.fold(|| Vec::new(),
+                |mut vec, x| {
+                    vec.push(x);
+                    vec
+                })
+          .reduce(|| Vec::new(),
+                  |mut vec1, mut vec2| { vec1.append(&mut vec2); vec1 })
+    }
+}
+
+
+macro_rules! make_bench {
+    ($generate:ident, $check:ident) => {
+        #[bench]
+        fn with_collect(b: &mut ::test::Bencher) {
+            use vec_collect::util;
+            let mut vec = None;
+            b.iter(|| vec = Some(util::collect($generate())));
+            $check(&vec.unwrap());
+        }
+
+        #[bench]
+        fn with_linked_list_vec(b: &mut ::test::Bencher) {
+            use vec_collect::util;
+            let mut vec = None;
+            b.iter(|| vec = Some(util::linked_list_vec($generate())));
+            $check(&vec.unwrap());
+        }
+
+        #[bench]
+        fn with_linked_list_vec_sized(b: &mut ::test::Bencher) {
+            use vec_collect::util;
+            let mut vec = None;
+            b.iter(|| vec = Some(util::linked_list_vec_sized($generate())));
+            $check(&vec.unwrap());
+        }
+
+        #[bench]
+        fn with_fold(b: &mut ::test::Bencher) {
+            use vec_collect::util;
+            let mut vec = None;
+            b.iter(|| vec = Some(util::fold($generate())));
+            $check(&vec.unwrap());
+        }
+    }
+}
+
+/// Tests a big vector of i forall i in 0 to N.
+mod vec_i {
+    use rayon::prelude::*;
+
+    const N: u32 = 4 * 1024 * 1024;
+
+    fn generate() -> impl ExactParallelIterator<Item=u32> {
+        (0_u32..N)
+            .into_par_iter()
+    }
+
+    fn check(v: &Vec<u32>) {
+        assert!(v.iter().cloned().eq(0..N));
+    }
+
+    #[bench]
+    fn with_collect_into(b: &mut ::test::Bencher) {
+        let mut vec = None;
+        b.iter(|| {
+            let mut v = vec![];
+            generate().collect_into(&mut v);
+            vec = Some(v);
+        });
+        check(&vec.unwrap());
+    }
+
+    #[bench]
+    fn with_collect_into_reused(b: &mut ::test::Bencher) {
+        let mut vec = vec![];
+        b.iter(|| generate().collect_into(&mut vec));
+        check(&vec);
+    }
+
+    make_bench!(generate, check);
+}
+
+/// Tests a big vector of i forall i in 0 to N, with a no-op
+/// filter just to make sure it's not an exact iterator.
+mod vec_i_filtered {
+    use rayon::prelude::*;
+
+    const N: u32 = 4 * 1024 * 1024;
+
+    fn generate() -> impl ParallelIterator<Item=u32> {
+        (0_u32..N)
+            .into_par_iter()
+            .filter(|_| true)
+    }
+
+    fn check(v: &Vec<u32>) {
+        assert!(v.iter().cloned().eq(0..N));
+    }
+
+    make_bench!(generate, check);
+}

--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -33,6 +33,13 @@ impl<A, B> ParallelIterator for ChainIter<A, B>
         let b = self.b.drive_unindexed(consumer.split_off());
         consumer.to_reducer().reduce(a, b)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        match (self.a.opt_len(), self.b.opt_len()) {
+            (Some(a_len), Some(b_len)) => a_len.checked_add(b_len),
+            _ => None,
+        }
+    }
 }
 
 impl<A, B> BoundedParallelIterator for ChainIter<A, B>

--- a/src/par_iter/collect/consumer.rs
+++ b/src/par_iter/collect/consumer.rs
@@ -110,3 +110,14 @@ impl<'c, ITEM: Send> Folder<ITEM> for CollectFolder<'c, ITEM> {
         self.consumer.writes.fetch_add(self.consumer.len, Ordering::SeqCst);
     }
 }
+
+/// Pretend to be unindexed for `special_collect_into`,
+/// but we should never actually get used that way...
+impl<'c, ITEM: Send> UnindexedConsumer<ITEM> for CollectConsumer<'c, ITEM> {
+    fn split_off(&self) -> Self {
+        unreachable!("CollectConsumer must be indexed!")
+    }
+    fn to_reducer(&self) -> Self::Reducer {
+        NoopReducer
+    }
+}

--- a/src/par_iter/collect/mod.rs
+++ b/src/par_iter/collect/mod.rs
@@ -1,16 +1,35 @@
-use super::ExactParallelIterator;
+use super::{ParallelIterator, ExactParallelIterator};
 use std::isize;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 mod consumer;
 use self::consumer::CollectConsumer;
 
+/// Collects the results of the exact iterator into the specified vector.
 pub fn collect_into<PAR_ITER, T>(mut pi: PAR_ITER, v: &mut Vec<T>)
     where PAR_ITER: ExactParallelIterator<Item = T>,
-          PAR_ITER: ExactParallelIterator,
           T: Send
 {
     let len = pi.len();
+    special_collect_into(pi, len, v);
+}
+
+/// Collects the results of the iterator into the specified vector.
+///
+/// Technically, this only works for `ExactParallelIterator`, but we're faking a
+/// bit of specialization here until Rust can do that natively.  Callers are
+/// using `opt_len` to find the length before calling this, and only exact
+/// iterators will return anything but `None` there.
+///
+/// Since the type system doesn't understand that contract, we have to allow
+/// *any* `ParallelIterator` here, and `CollectConsumer` has to also implement
+/// `UnindexedConsumer`.  That implementation panics `unreachable!` in case
+/// there's a bug where we actually do try to use this unindexed.
+#[doc(hidden)]
+pub fn special_collect_into<PAR_ITER, T>(pi: PAR_ITER, len: usize, v: &mut Vec<T>)
+    where PAR_ITER: ParallelIterator<Item = T>,
+          T: Send
+{
     assert!(len < isize::MAX as usize);
 
     v.truncate(0); // clear any old data
@@ -21,7 +40,7 @@ pub fn collect_into<PAR_ITER, T>(mut pi: PAR_ITER, v: &mut Vec<T>)
         // assert that target..target+len is unique and writable
         CollectConsumer::new(&writes, target, len)
     };
-    pi.drive(consumer);
+    pi.drive_unindexed(consumer);
 
     unsafe {
         // Here, we assert that `v` is fully initialized. This is

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -23,6 +23,10 @@ impl<M> ParallelIterator for Enumerate<M>
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<M> BoundedParallelIterator for Enumerate<M>

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -1,21 +1,25 @@
-use super::{ParallelIterator, ExactParallelIterator};
+use super::{IntoParallelIterator, ParallelIterator};
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
 use std::collections::LinkedList;
 use std::collections::{BinaryHeap, VecDeque};
 
-pub trait FromParallelIterator<PAR_ITER> {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self;
+pub trait FromParallelIterator<ITEM>
+    where ITEM: Send
+{
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = ITEM>;
 }
 
 
 fn combine<PAR_ITER, START, COLL>(par_iter: PAR_ITER, make_start: START) -> COLL
-    where PAR_ITER: ParallelIterator,
+    where PAR_ITER: IntoParallelIterator,
           START: FnOnce(&LinkedList<Vec<PAR_ITER::Item>>) -> COLL,
           COLL: Extend<PAR_ITER::Item>
 {
-    let list = par_iter.fold(Vec::new, |mut vec, elem| {
+    let list = par_iter.into_par_iter()
+        .fold(Vec::new, |mut vec, elem| {
             vec.push(elem);
             vec
         })
@@ -34,49 +38,64 @@ fn combined_len<T>(list: &LinkedList<Vec<T>>) -> usize {
 }
 
 
-/// Collect items from a parallel iterator into a freshly allocated
-/// vector. This is very efficient, but requires precise knowledge of
-/// the number of items being iterated.
-impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for Vec<T>
-    where PAR_ITER: ExactParallelIterator<Item = T>,
-          T: Send
+/// Collect items from a parallel iterator into a freshly allocated vector.
+impl<T> FromParallelIterator<T> for Vec<T>
+    where T: Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
-        let mut vec = vec![];
-        par_iter.collect_into(&mut vec);
-        vec
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = T>
+    {
+        // When Rust gets specialization, we can use `collect_into` for exact iterators.
+        // This works like `combine`, but `Vec::append` is more efficient than `extend`.
+        let list = par_iter.into_par_iter()
+            .fold(Vec::new, |mut vec, elem| {
+                vec.push(elem);
+                vec
+            })
+            .collect();
+
+        let start = Vec::with_capacity(combined_len(&list));
+        list.into_iter()
+            .fold(start, |mut vec, mut sub| {
+                vec.append(&mut sub);
+                vec
+            })
     }
 }
 
 /// Collect items from a parallel iterator into a vecdeque.
-impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for VecDeque<T>
-    where Vec<T>: FromParallelIterator<PAR_ITER>,
-          T: Send
+impl<T> FromParallelIterator<T> for VecDeque<T>
+    where T: Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = T>
+    {
         Vec::from_par_iter(par_iter).into()
     }
 }
 
 /// Collect items from a parallel iterator into a binaryheap.
 /// The heap-ordering is calculated serially after all items are collected.
-impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for BinaryHeap<T>
-    where Vec<T>: FromParallelIterator<PAR_ITER>,
-          T: Ord + Send
+impl<T> FromParallelIterator<T> for BinaryHeap<T>
+    where T: Ord + Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = T>
+    {
         Vec::from_par_iter(par_iter).into()
     }
 }
 
 /// Collect items from a parallel iterator into a freshly allocated
 /// linked list.
-impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for LinkedList<T>
-    where PAR_ITER: ParallelIterator<Item = T>,
-          T: Send
+impl<T> FromParallelIterator<T> for LinkedList<T>
+    where T: Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
-        par_iter.map(|elem| {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = T>
+    {
+        par_iter.into_par_iter()
+            .map(|elem| {
                 let mut list = LinkedList::new();
                 list.push_back(elem);
                 list
@@ -93,13 +112,14 @@ impl<PAR_ITER, T> FromParallelIterator<PAR_ITER> for LinkedList<T>
 /// hashmap. If multiple pairs correspond to the same key, then the
 /// ones produced earlier in the parallel iterator will be
 /// overwritten, just as with a sequential iterator.
-impl<PAR_ITER, K, V, S> FromParallelIterator<PAR_ITER> for HashMap<K, V, S>
-    where PAR_ITER: ParallelIterator<Item = (K, V)>,
-          K: Eq + Hash + Send,
+impl<K, V, S> FromParallelIterator<(K, V)> for HashMap<K, V, S>
+    where K: Eq + Hash + Send,
           V: Send,
           S: BuildHasher + Default + Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = (K, V)>
+    {
         // See the map_collect benchmarks in rayon-demo for different strategies.
         combine(par_iter, |list| {
             let len = combined_len(list);
@@ -112,23 +132,25 @@ impl<PAR_ITER, K, V, S> FromParallelIterator<PAR_ITER> for HashMap<K, V, S>
 /// btreemap. If multiple pairs correspond to the same key, then the
 /// ones produced earlier in the parallel iterator will be
 /// overwritten, just as with a sequential iterator.
-impl<PAR_ITER, K, V> FromParallelIterator<PAR_ITER> for BTreeMap<K, V>
-    where PAR_ITER: ParallelIterator<Item = (K, V)>,
-          K: Ord + Send,
+impl<K, V> FromParallelIterator<(K, V)> for BTreeMap<K, V>
+    where K: Ord + Send,
           V: Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = (K, V)>
+    {
         combine(par_iter, |_| BTreeMap::new())
     }
 }
 
 /// Collect values from a parallel iterator into a hashset.
-impl<PAR_ITER, V, S> FromParallelIterator<PAR_ITER> for HashSet<V, S>
-    where PAR_ITER: ParallelIterator<Item = V>,
-          V: Eq + Hash + Send,
+impl<V, S> FromParallelIterator<V> for HashSet<V, S>
+    where V: Eq + Hash + Send,
           S: BuildHasher + Default + Send
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = V>
+    {
         combine(par_iter, |list| {
             let len = combined_len(list);
             HashSet::with_capacity_and_hasher(len, Default::default())
@@ -137,31 +159,64 @@ impl<PAR_ITER, V, S> FromParallelIterator<PAR_ITER> for HashSet<V, S>
 }
 
 /// Collect values from a parallel iterator into a btreeset.
-impl<PAR_ITER, V> FromParallelIterator<PAR_ITER> for BTreeSet<V>
-    where PAR_ITER: ParallelIterator<Item = V>,
-          V: Send + Ord
+impl<V> FromParallelIterator<V> for BTreeSet<V>
+    where V: Send + Ord
 {
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = V>
+    {
         combine(par_iter, |_| BTreeSet::new())
     }
 }
 
 /// Collect characters from a parallel iterator into a string.
-impl<PAR_ITER> FromParallelIterator<PAR_ITER> for String
-    where PAR_ITER: ParallelIterator<Item=char>,
-{
-    fn from_par_iter(par_iter: PAR_ITER) -> Self {
+impl FromParallelIterator<char> for String {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = char>
+    {
         // This is like `combine`, but `Vec<char>` is less efficient to deal
         // with than `String`, so instead collect to `LinkedList<String>`.
-        let list: LinkedList<_> = par_iter
-            .fold(String::new, |mut string, ch| { string.push(ch); string })
+        let list: LinkedList<_> = par_iter.into_par_iter()
+            .fold(String::new, |mut string, ch| {
+                string.push(ch);
+                string
+            })
             .collect();
 
         let len = list.iter().map(String::len).sum();
         let start = String::with_capacity(len);
         list.into_iter()
-            .fold(start, |mut string, sub| { string.push_str(&sub); string })
+            .fold(start, |mut string, sub| {
+                string.push_str(&sub);
+                string
+            })
     }
 }
-// Note, `String` also has `FromIterator<&'a str>` and `FromIterator<String>`,
-// but that's not possible with the current signature of `FromParallelIterator`.
+
+/// Collect string slices from a parallel iterator into a string.
+impl<'a> FromParallelIterator<&'a str> for String {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = &'a str>
+    {
+        combine(par_iter, |list| {
+            let len = list.iter()
+                .map(|vec| -> usize { vec.iter().cloned().map(str::len).sum() })
+                .sum();
+            String::with_capacity(len)
+        })
+    }
+}
+
+/// Collect strings from a parallel iterator into one large string.
+impl FromParallelIterator<String> for String {
+    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
+        where PAR_ITER: IntoParallelIterator<Item = String>
+    {
+        combine(par_iter, |list| {
+            let len = list.iter()
+                .map(|vec| -> usize { vec.iter().map(String::len).sum() })
+                .sum();
+            String::with_capacity(len)
+        })
+    }
+}

--- a/src/par_iter/from_par_iter.rs
+++ b/src/par_iter/from_par_iter.rs
@@ -45,21 +45,34 @@ impl<T> FromParallelIterator<T> for Vec<T>
     fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
         where PAR_ITER: IntoParallelIterator<Item = T>
     {
-        // When Rust gets specialization, we can use `collect_into` for exact iterators.
-        // This works like `combine`, but `Vec::append` is more efficient than `extend`.
-        let list = par_iter.into_par_iter()
-            .fold(Vec::new, |mut vec, elem| {
-                vec.push(elem);
+        // See the vec_collect benchmarks in rayon-demo for different strategies.
+        let mut par_iter = par_iter.into_par_iter();
+        match par_iter.opt_len() {
+            Some(len) => {
+                // When Rust gets specialization, call `par_iter.collect_into()`
+                // for exact iterators.  Until then, `special_collect_into()` fakes
+                // the same thing on the promise that `opt_len()` is accurate.
+                let mut vec = vec![];
+                super::collect::special_collect_into(par_iter, len, &mut vec);
                 vec
-            })
-            .collect();
+            }
+            None => {
+                // This works like `combine`, but `Vec::append` is more efficient than `extend`.
+                let list = par_iter.fold(Vec::new, |mut vec, elem| {
+                        vec.push(elem);
+                        vec
+                    })
+                    .collect();
 
-        let start = Vec::with_capacity(combined_len(&list));
-        list.into_iter()
-            .fold(start, |mut vec, mut sub| {
-                vec.append(&mut sub);
-                vec
-            })
+                let len = combined_len(&list);
+                let start = Vec::with_capacity(len);
+                list.into_iter()
+                    .fold(start, |mut vec, mut sub| {
+                        vec.append(&mut sub);
+                        vec
+                    })
+            }
+        }
     }
 }
 
@@ -104,7 +117,7 @@ impl<T> FromParallelIterator<T> for LinkedList<T>
                 list1.append(&mut list2);
                 list1
             })
-            .unwrap_or_else(|| LinkedList::new())
+            .unwrap_or_else(LinkedList::new)
     }
 }
 

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -71,6 +71,10 @@ impl<M, MAP_OP> ParallelIterator for Map<M, MAP_OP>
         let consumer1 = MapConsumer::new(consumer, &self.map_op);
         self.base.drive_unindexed(consumer1)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        self.base.opt_len()
+    }
 }
 
 impl<M, MAP_OP> BoundedParallelIterator for Map<M, MAP_OP>

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -608,7 +608,17 @@ pub trait ParallelIterator: Sized {
     #[doc(hidden)]
     fn drive_unindexed<C>(self, consumer: C) -> C::Result where C: UnindexedConsumer<Self::Item>;
 
-    /// Internal method used to fake specialization for indexed collect.
+    /// Returns the number of items produced by this iterator, if known
+    /// statically. This can be used by consumers to trigger special fast
+    /// paths. Therefore, if `Some(_)` is returned, this iterator must only
+    /// use the (indexed) `Consumer` methods when driving a consumer, such
+    /// as `split_at()`. Calling `UnindexedConsumer::split_off()` or other
+    /// `UnindexedConsumer` methods -- or returning an inaccurate value --
+    /// may result in panics.
+    ///
+    /// This is hidden & considered internal for now, until we decide
+    /// whether it makes sense for a public API.  Right now it is only used
+    /// to optimize `collect`  for want of true Rust specialization.
     #[doc(hidden)]
     fn opt_len(&mut self) -> Option<usize> {
         None

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -609,17 +609,14 @@ pub trait ParallelIterator: Sized {
     fn drive_unindexed<C>(self, consumer: C) -> C::Result where C: UnindexedConsumer<Self::Item>;
 
     /// Create a fresh collection containing all the element produced
-    /// by this parallel iterator. Note that some kinds of collections
-    /// have stricter requirements in terms of the kinds of iterators
-    /// that you can collect from (e.g., a `Vec` currently requires an
-    /// iterator that has precise knowledge of how many elements it
-    /// contains).
+    /// by this parallel iterator.
     ///
-    /// You may also prefer to use `collect_into()`, which allows you
-    /// to reuse the vector's backing store rather than allocating a
-    /// fresh vector.
+    /// You may prefer to use `collect_into()`, which allocates more
+    /// efficiently with precise knowledge of how many elements the
+    /// iterator contains, and even allows you to reuse an existing
+    /// vector's backing store rather than allocating a fresh vector.
     fn collect<C>(self) -> C
-        where C: FromParallelIterator<Self>
+        where C: FromParallelIterator<Self::Item>
     {
         C::from_par_iter(self)
     }

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -608,6 +608,12 @@ pub trait ParallelIterator: Sized {
     #[doc(hidden)]
     fn drive_unindexed<C>(self, consumer: C) -> C::Result where C: UnindexedConsumer<Self::Item>;
 
+    /// Internal method used to fake specialization for indexed collect.
+    #[doc(hidden)]
+    fn opt_len(&mut self) -> Option<usize> {
+        None
+    }
+
     /// Create a fresh collection containing all the element produced
     /// by this parallel iterator.
     ///
@@ -650,11 +656,6 @@ pub trait BoundedParallelIterator: ParallelIterator {
 pub trait ExactParallelIterator: BoundedParallelIterator {
     /// Produces an exact count of how many items this iterator will
     /// produce, presuming no panic occurs.
-    ///
-    /// # Safety note
-    ///
-    /// Returning an incorrect value here could lead to **undefined
-    /// behavior**.
     fn len(&mut self) -> usize;
 
     /// Collects the results of the iterator into the specified

--- a/src/par_iter/option.rs
+++ b/src/par_iter/option.rs
@@ -70,6 +70,10 @@ impl<T: Send> ParallelIterator for OptionIter<T> {
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<T: Send> BoundedParallelIterator for OptionIter<T> {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -38,6 +38,10 @@ macro_rules! indexed_range_impl {
             {
                 bridge(self, consumer)
             }
+
+            fn opt_len(&mut self) -> Option<usize> {
+                Some(self.len())
+            }
         }
 
         impl BoundedParallelIterator for RangeIter<$t> {

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -26,6 +26,10 @@ impl<M> ParallelIterator for Skip<M>
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<M> ExactParallelIterator for Skip<M>

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -43,6 +43,10 @@ impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<'data, T: Sync + 'data> BoundedParallelIterator for SliceIter<'data, T> {
@@ -83,6 +87,10 @@ impl<'data, T: Sync + 'data> ParallelIterator for ChunksIter<'data, T> {
         where C: UnindexedConsumer<Self::Item>
     {
         bridge(self, consumer)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
     }
 }
 

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -43,6 +43,10 @@ impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<'data, T: Send + 'data> BoundedParallelIterator for SliceIterMut<'data, T> {
@@ -83,6 +87,10 @@ impl<'data, T: Send + 'data> ParallelIterator for ChunksMutIter<'data, T> {
         where C: UnindexedConsumer<Self::Item>
     {
         bridge(self, consumer)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
     }
 }
 

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -14,15 +14,13 @@ impl<'a> ParallelString for &'a str {
     type Chars = ParChars<'a>;
 
     fn par_chars(self) -> Self::Chars {
-        ParChars {
-            chars: self
-        }
+        ParChars { chars: self }
     }
 }
 
 
 pub struct ParChars<'a> {
-    chars: &'a str
+    chars: &'a str,
 }
 
 impl<'a> ParallelIterator for ParChars<'a> {
@@ -50,7 +48,10 @@ impl<'a> UnindexedProducer for ParChars<'a> {
         // character boundary.  So we look at the raw bytes, first scanning
         // forward from the midpoint for a boundary, then trying backward.
         let (left, right) = self.chars.as_bytes().split_at(mid);
-        let index = right.iter().cloned().position(is_char_boundary).map(|i| mid + i)
+        let index = right.iter()
+            .cloned()
+            .position(is_char_boundary)
+            .map(|i| mid + i)
             .or_else(|| left.iter().cloned().rposition(is_char_boundary))
             .unwrap_or(0);
 
@@ -59,8 +60,7 @@ impl<'a> UnindexedProducer for ParChars<'a> {
     }
 }
 
-impl<'a> IntoIterator for ParChars<'a>
-{
+impl<'a> IntoIterator for ParChars<'a> {
     type Item = char;
     type IntoIter = Chars<'a>;
 

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -26,6 +26,10 @@ impl<M> ParallelIterator for Take<M>
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<M> ExactParallelIterator for Take<M>

--- a/src/par_iter/vec.rs
+++ b/src/par_iter/vec.rs
@@ -23,6 +23,10 @@ impl<T: Send> ParallelIterator for VecIter<T> {
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<T: Send> BoundedParallelIterator for VecIter<T> {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -26,6 +26,10 @@ impl<M> ParallelIterator for Weight<M>
         let consumer1 = WeightConsumer::new(consumer, self.weight);
         self.base.drive_unindexed(consumer1)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        self.base.opt_len()
+    }
 }
 
 impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> {

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -25,6 +25,10 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     {
         bridge(self, consumer)
     }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
 }
 
 impl<A, B> BoundedParallelIterator for ZipIter<A, B>


### PR DESCRIPTION
It's now parameterized on the item type, which allows collecting
different things, e.g. `String` (#164) might collect `char` or `&str`.

The `from_par_iter` method is parameterized on `IntoParallelIterator`,
which means `Vec` has to be generalized too, not just exact.  There's
always `collect_into`, and we can eventually do better when Rust gets
specialization.