### PR TITLE
Run rustfmt Across Entire Project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 target
 *~
 TAGS
+*.bk

--- a/src/api.rs
+++ b/src/api.rs
@@ -23,11 +23,15 @@ pub enum InitError {
 impl fmt::Display for InitError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            InitError::NumberOfThreadsZero =>
-                write!(f, "The number of threads was set to zero but must be greater than zero."),
-            InitError::GlobalPoolAlreadyInitialized =>
-                write!(f, "The gobal thread pool has already been initialized with a different \
-                           configuration. Only one valid configuration is allowed.")
+            InitError::NumberOfThreadsZero => {
+                write!(f,
+                       "The number of threads was set to zero but must be greater than zero.")
+            }
+            InitError::GlobalPoolAlreadyInitialized => {
+                write!(f,
+                       "The gobal thread pool has already been initialized with a different \
+                        configuration. Only one valid configuration is allowed.")
+            }
         }
     }
 }
@@ -35,10 +39,10 @@ impl fmt::Display for InitError {
 impl Error for InitError {
     fn description(&self) -> &str {
         match *self {
-            InitError::NumberOfThreadsZero =>
-                "number of threads set to zero",
-            InitError::GlobalPoolAlreadyInitialized =>
+            InitError::NumberOfThreadsZero => "number of threads set to zero",
+            InitError::GlobalPoolAlreadyInitialized => {
                 "global thread pool has already been initialized"
+            }
         }
     }
 }
@@ -47,7 +51,7 @@ impl Error for InitError {
 #[derive(Clone, Debug)]
 pub struct Configuration {
     /// The number of threads in the rayon thread pool. Must not be zero.
-    num_threads: Option<usize>
+    num_threads: Option<usize>,
 }
 
 impl Configuration {
@@ -127,13 +131,11 @@ pub fn dump_stats() {
     dump_stats!();
 }
 
-pub fn join<A,B,RA,RB>(oper_a: A,
-                       oper_b: B)
-                       -> (RA, RB)
+pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where A: FnOnce() -> RA + Send,
           B: FnOnce() -> RB + Send,
           RA: Send,
-          RB: Send,
+          RB: Send
 {
     unsafe {
         let worker_thread = WorkerThread::current();
@@ -190,13 +192,11 @@ pub fn join<A,B,RA,RB>(oper_a: A,
 }
 
 #[cold] // cold path
-unsafe fn join_inject<A,B,RA,RB>(oper_a: A,
-                                 oper_b: B)
-                                 -> (RA, RB)
+unsafe fn join_inject<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
     where A: FnOnce() -> RA + Send,
           B: FnOnce() -> RB + Send,
           RA: Send,
-          RB: Send,
+          RB: Send
 {
     let job_a = StackJob::new(oper_a, LockLatch::new());
     let job_b = StackJob::new(oper_b, LockLatch::new());
@@ -210,23 +210,21 @@ unsafe fn join_inject<A,B,RA,RB>(oper_a: A,
 }
 
 pub struct ThreadPool {
-    registry: Arc<Registry>
+    registry: Arc<Registry>,
 }
 
 impl ThreadPool {
     /// Constructs a new thread pool with the given configuration. If
     /// the configuration is not valid, returns a suitable `Err`
     /// result.  See `InitError` for more details.
-    pub fn new(configuration: Configuration) -> Result<ThreadPool,InitError> {
+    pub fn new(configuration: Configuration) -> Result<ThreadPool, InitError> {
         try!(configuration.validate());
-        Ok(ThreadPool {
-            registry: Registry::new(configuration.num_threads)
-        })
+        Ok(ThreadPool { registry: Registry::new(configuration.num_threads) })
     }
 
     /// Executes `op` within the threadpool. Any attempts to `join`
     /// which occur there will then operate within that threadpool.
-    pub fn install<OP,R>(&self, op: OP) -> R
+    pub fn install<OP, R>(&self, op: OP) -> R
         where OP: FnOnce() -> R + Send
     {
         unsafe {

--- a/src/job.rs
+++ b/src/job.rs
@@ -49,7 +49,10 @@ impl JobRef {
         let fn_ptr: unsafe fn(*const (), JobMode) = mem::transmute(fn_ptr);
         let pointer = data as *const ();
 
-        JobRef { pointer: pointer, execute_fn: fn_ptr }
+        JobRef {
+            pointer: pointer,
+            execute_fn: fn_ptr,
+        }
     }
 
     #[inline]
@@ -155,4 +158,3 @@ impl<BODY> Job for HeapJob<BODY>
         job(mode);
     }
 }
-

--- a/src/latch.rs
+++ b/src/latch.rs
@@ -9,15 +9,13 @@ pub trait Latch {
 /// A Latch starts as false and eventually becomes true. You can block
 /// until it becomes true.
 pub struct SpinLatch {
-    b: AtomicBool
+    b: AtomicBool,
 }
 
 impl SpinLatch {
     #[inline]
     pub fn new() -> SpinLatch {
-        SpinLatch {
-            b: AtomicBool::new(false)
-        }
+        SpinLatch { b: AtomicBool::new(false) }
     }
 
     /// Test if latch is set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@ mod latch;
 mod job;
 pub mod par_iter;
 pub mod prelude;
-#[cfg(test)] mod test;
+#[cfg(test)]
+mod test;
 #[cfg(feature = "unstable")]
 mod scope;
 mod thread_pool;

--- a/src/par_iter/collect/mod.rs
+++ b/src/par_iter/collect/mod.rs
@@ -5,10 +5,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 mod consumer;
 use self::consumer::CollectConsumer;
 
-pub fn collect_into<PAR_ITER,T>(mut pi: PAR_ITER, v: &mut Vec<T>)
-    where PAR_ITER: ExactParallelIterator<Item=T>,
+pub fn collect_into<PAR_ITER, T>(mut pi: PAR_ITER, v: &mut Vec<T>)
+    where PAR_ITER: ExactParallelIterator<Item = T>,
           PAR_ITER: ExactParallelIterator,
-          T: Send,
+          T: Send
 {
     let len = pi.len();
     assert!(len < isize::MAX as usize);
@@ -17,7 +17,8 @@ pub fn collect_into<PAR_ITER,T>(mut pi: PAR_ITER, v: &mut Vec<T>)
     v.reserve(len); // reserve enough space
     let target = v.as_mut_ptr(); // get a raw ptr
     let writes = AtomicUsize::new(0);
-    let consumer = unsafe { // assert that target..target+len is unique and writable
+    let consumer = unsafe {
+        // assert that target..target+len is unique and writable
         CollectConsumer::new(&writes, target, len)
     };
     pi.drive(consumer);
@@ -31,7 +32,10 @@ pub fn collect_into<PAR_ITER,T>(mut pi: PAR_ITER, v: &mut Vec<T>)
         // have happened. Unless some code is buggy, that means we
         // should have seen `len` total writes.
         let actual_writes = writes.load(Ordering::Relaxed);
-        assert!(actual_writes == len, "expected {} total writes, but got {}", len, actual_writes);
+        assert!(actual_writes == len,
+                "expected {} total writes, but got {}",
+                len,
+                actual_writes);
         v.set_len(len);
     }
 }

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -14,7 +14,7 @@ impl<M> Enumerate<M> {
 }
 
 impl<M> ParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator,
+    where M: IndexedParallelIterator
 {
     type Item = (usize, M::Item);
 
@@ -26,7 +26,7 @@ impl<M> ParallelIterator for Enumerate<M>
 }
 
 impl<M> BoundedParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator,
+    where M: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -38,7 +38,7 @@ impl<M> BoundedParallelIterator for Enumerate<M>
 }
 
 impl<M> ExactParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator,
+    where M: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.base.len()
@@ -46,7 +46,7 @@ impl<M> ExactParallelIterator for Enumerate<M>
 }
 
 impl<M> IndexedParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator,
+    where M: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -62,18 +62,20 @@ impl<M> IndexedParallelIterator for Enumerate<M>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item=ITEM>
+                where P: Producer<Item = ITEM>
             {
-                let producer = EnumerateProducer { base: base,
-                                                   offset: 0 };
+                let producer = EnumerateProducer {
+                    base: base,
+                    offset: 0,
+                };
                 self.callback.callback(producer)
             }
         }
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
-// Producer implementation
+/// ////////////////////////////////////////////////////////////////////////
+/// Producer implementation
 
 pub struct EnumerateProducer<P> {
     base: P,
@@ -93,14 +95,20 @@ impl<P> Producer for EnumerateProducer<P>
 
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.base.split_at(index);
-        (EnumerateProducer { base: left,
-                             offset: self.offset },
-         EnumerateProducer { base: right,
-                             offset: self.offset + index })
+        (EnumerateProducer {
+             base: left,
+             offset: self.offset,
+         },
+         EnumerateProducer {
+             base: right,
+             offset: self.offset + index,
+         })
     }
 }
 
-impl<P> IntoIterator for EnumerateProducer<P> where P: Producer {
+impl<P> IntoIterator for EnumerateProducer<P>
+    where P: Producer
+{
     type Item = (usize, P::Item);
     type IntoIter = iter::Zip<RangeFrom<usize>, P::IntoIter>;
 

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -9,13 +9,16 @@ pub struct Filter<M, FILTER_OP> {
 
 impl<M, FILTER_OP> Filter<M, FILTER_OP> {
     pub fn new(base: M, filter_op: FILTER_OP) -> Filter<M, FILTER_OP> {
-        Filter { base: base, filter_op: filter_op }
+        Filter {
+            base: base,
+            filter_op: filter_op,
+        }
     }
 }
 
 impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
     where M: ParallelIterator,
-          FILTER_OP: Fn(&M::Item) -> bool + Sync,
+          FILTER_OP: Fn(&M::Item) -> bool + Sync
 {
     type Item = M::Item;
 
@@ -43,8 +46,8 @@ impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
-// Consumer implementation
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
 
 struct FilterConsumer<'f, C, FILTER_OP: 'f> {
     base: C,
@@ -53,12 +56,16 @@ struct FilterConsumer<'f, C, FILTER_OP: 'f> {
 
 impl<'f, C, FILTER_OP> FilterConsumer<'f, C, FILTER_OP> {
     fn new(base: C, filter_op: &'f FILTER_OP) -> Self {
-        FilterConsumer { base: base, filter_op: filter_op }
+        FilterConsumer {
+            base: base,
+            filter_op: filter_op,
+        }
     }
 }
 
 impl<'f, ITEM, C, FILTER_OP: 'f> Consumer<ITEM> for FilterConsumer<'f, C, FILTER_OP>
-    where C: Consumer<ITEM>, FILTER_OP: Fn(&ITEM) -> bool + Sync,
+    where C: Consumer<ITEM>,
+          FILTER_OP: Fn(&ITEM) -> bool + Sync
 {
     type Folder = FilterFolder<'f, C::Folder, FILTER_OP>;
     type Reducer = C::Reducer;
@@ -81,7 +88,10 @@ impl<'f, ITEM, C, FILTER_OP: 'f> Consumer<ITEM> for FilterConsumer<'f, C, FILTER
     }
 
     fn into_folder(self) -> Self::Folder {
-        FilterFolder { base: self.base.into_folder(), filter_op: self.filter_op, }
+        FilterFolder {
+            base: self.base.into_folder(),
+            filter_op: self.filter_op,
+        }
     }
 
     fn full(&self) -> bool {
@@ -90,9 +100,9 @@ impl<'f, ITEM, C, FILTER_OP: 'f> Consumer<ITEM> for FilterConsumer<'f, C, FILTER
 }
 
 
-impl<'f, ITEM, C, FILTER_OP: 'f> UnindexedConsumer<ITEM>
-    for FilterConsumer<'f, C, FILTER_OP>
-    where C: UnindexedConsumer<ITEM>, FILTER_OP: Fn(&ITEM) -> bool + Sync,
+impl<'f, ITEM, C, FILTER_OP: 'f> UnindexedConsumer<ITEM> for FilterConsumer<'f, C, FILTER_OP>
+    where C: UnindexedConsumer<ITEM>,
+          FILTER_OP: Fn(&ITEM) -> bool + Sync
 {
     fn split_off(&self) -> Self {
         FilterConsumer::new(self.base.split_off(), &self.filter_op)
@@ -109,7 +119,8 @@ struct FilterFolder<'f, C, FILTER_OP: 'f> {
 }
 
 impl<'f, C, FILTER_OP, ITEM> Folder<ITEM> for FilterFolder<'f, C, FILTER_OP>
-    where C: Folder<ITEM>, FILTER_OP: Fn(&ITEM) -> bool + 'f
+    where C: Folder<ITEM>,
+          FILTER_OP: Fn(&ITEM) -> bool + 'f
 {
     type Result = C::Result;
 
@@ -117,7 +128,10 @@ impl<'f, C, FILTER_OP, ITEM> Folder<ITEM> for FilterFolder<'f, C, FILTER_OP>
         let filter_op = self.filter_op;
         if filter_op(&item) {
             let base = self.base.consume(item);
-            FilterFolder { base: base, filter_op: filter_op }
+            FilterFolder {
+                base: base,
+                filter_op: filter_op,
+            }
         } else {
             self
         }

--- a/src/par_iter/find.rs
+++ b/src/par_iter/find.rs
@@ -5,7 +5,7 @@ use super::internal::*;
 
 pub fn find<PAR_ITER, FIND_OP>(pi: PAR_ITER, find_op: FIND_OP) -> Option<PAR_ITER::Item>
     where PAR_ITER: ParallelIterator,
-          FIND_OP: Fn(&PAR_ITER::Item) -> bool + Sync,
+          FIND_OP: Fn(&PAR_ITER::Item) -> bool + Sync
 {
     let found = AtomicBool::new(false);
     let consumer = FindConsumer::new(&find_op, &found);
@@ -27,7 +27,8 @@ impl<'f, FIND_OP> FindConsumer<'f, FIND_OP> {
 }
 
 impl<'f, ITEM, FIND_OP: 'f> Consumer<ITEM> for FindConsumer<'f, FIND_OP>
-    where ITEM: Send, FIND_OP: Fn(&ITEM) -> bool + Sync,
+    where ITEM: Send,
+          FIND_OP: Fn(&ITEM) -> bool + Sync
 {
     type Folder = FindFolder<'f, ITEM, FIND_OP>;
     type Reducer = FindReducer;
@@ -57,7 +58,8 @@ impl<'f, ITEM, FIND_OP: 'f> Consumer<ITEM> for FindConsumer<'f, FIND_OP>
 
 
 impl<'f, ITEM, FIND_OP: 'f> UnindexedConsumer<ITEM> for FindConsumer<'f, FIND_OP>
-    where ITEM: Send, FIND_OP: Fn(&ITEM) -> bool + Sync,
+    where ITEM: Send,
+          FIND_OP: Fn(&ITEM) -> bool + Sync
 {
     fn split_off(&self) -> Self {
         FindConsumer::new(self.find_op, self.found)

--- a/src/par_iter/flat_map.rs
+++ b/src/par_iter/flat_map.rs
@@ -9,28 +9,33 @@ pub struct FlatMap<M, MAP_OP> {
 
 impl<M, MAP_OP> FlatMap<M, MAP_OP> {
     pub fn new(base: M, map_op: MAP_OP) -> FlatMap<M, MAP_OP> {
-        FlatMap { base: base, map_op: map_op }
+        FlatMap {
+            base: base,
+            map_op: map_op,
+        }
     }
 }
 
 impl<M, MAP_OP, PI> ParallelIterator for FlatMap<M, MAP_OP>
     where M: ParallelIterator,
           MAP_OP: Fn(M::Item) -> PI + Sync,
-          PI: IntoParallelIterator,
+          PI: IntoParallelIterator
 {
     type Item = PI::Item;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        let consumer = FlatMapConsumer { base: consumer,
-                                         map_op: &self.map_op };
+        let consumer = FlatMapConsumer {
+            base: consumer,
+            map_op: &self.map_op,
+        };
         self.base.drive_unindexed(consumer)
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
-// Consumer implementation
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
 
 struct FlatMapConsumer<'m, C, MAP_OP: 'm> {
     base: C,
@@ -39,15 +44,17 @@ struct FlatMapConsumer<'m, C, MAP_OP: 'm> {
 
 impl<'m, C, MAP_OP> FlatMapConsumer<'m, C, MAP_OP> {
     fn new(base: C, map_op: &'m MAP_OP) -> Self {
-        FlatMapConsumer { base: base, map_op: map_op }
+        FlatMapConsumer {
+            base: base,
+            map_op: map_op,
+        }
     }
 }
 
-impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Consumer<ITEM>
-    for FlatMapConsumer<'m, C, MAP_OP>
+impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Consumer<ITEM> for FlatMapConsumer<'m, C, MAP_OP>
     where C: UnindexedConsumer<MAPPED_ITEM::Item>,
           MAP_OP: Fn(ITEM) -> MAPPED_ITEM + Sync,
-          MAPPED_ITEM: IntoParallelIterator,
+          MAPPED_ITEM: IntoParallelIterator
 {
     type Folder = FlatMapFolder<'m, C, MAP_OP, C::Result>;
     type Reducer = C::Reducer;
@@ -84,11 +91,10 @@ impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Consumer<ITEM>
     }
 }
 
-impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> UnindexedConsumer<ITEM>
-    for FlatMapConsumer<'m, C, MAP_OP>
+impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> UnindexedConsumer<ITEM> for FlatMapConsumer<'m, C, MAP_OP>
     where C: UnindexedConsumer<MAPPED_ITEM::Item>,
           MAP_OP: Fn(ITEM) -> MAPPED_ITEM + Sync,
-          MAPPED_ITEM: IntoParallelIterator,
+          MAPPED_ITEM: IntoParallelIterator
 {
     fn split_off(&self) -> Self {
         FlatMapConsumer::new(self.base.split_off(), self.map_op)
@@ -106,11 +112,10 @@ struct FlatMapFolder<'m, C, MAP_OP: 'm, R> {
     previous: Option<R>,
 }
 
-impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Folder<ITEM>
-    for FlatMapFolder<'m, C, MAP_OP, C::Result>
+impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Folder<ITEM> for FlatMapFolder<'m, C, MAP_OP, C::Result>
     where C: UnindexedConsumer<MAPPED_ITEM::Item>,
           MAP_OP: Fn(ITEM) -> MAPPED_ITEM + Sync,
-          MAPPED_ITEM: IntoParallelIterator,
+          MAPPED_ITEM: IntoParallelIterator
 {
     type Result = C::Result;
 
@@ -129,9 +134,11 @@ impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Folder<ITEM>
             }
         };
 
-        FlatMapFolder { base: self.base,
-                        map_op: map_op,
-                        previous: previous }
+        FlatMapFolder {
+            base: self.base,
+            map_op: map_op,
+            previous: previous,
+        }
     }
 
     fn complete(self) -> Self::Result {

--- a/src/par_iter/fold.rs
+++ b/src/par_iter/fold.rs
@@ -99,10 +99,8 @@ impl<'r, U, T, C, IDENTITY, FOLD_OP> Consumer<T> for FoldConsumer<'r, C, IDENTIT
     }
 }
 
-impl<'r, U, ITEM, C, IDENTITY, FOLD_OP> UnindexedConsumer<ITEM> for FoldConsumer<'r,
-                                                                                 C,
-                                                                                 IDENTITY,
-                                                                                 FOLD_OP>
+impl<'r, U, ITEM, C, IDENTITY, FOLD_OP> UnindexedConsumer<ITEM>
+    for FoldConsumer<'r, C, IDENTITY, FOLD_OP>
     where C: UnindexedConsumer<U>,
           FOLD_OP: Fn(U, ITEM) -> U + Sync,
           IDENTITY: Fn() -> U + Sync,

--- a/src/par_iter/for_each.rs
+++ b/src/par_iter/for_each.rs
@@ -3,10 +3,10 @@ use super::len::*;
 use super::internal::*;
 use super::noop::*;
 
-pub fn for_each<PAR_ITER,OP,T>(pi: PAR_ITER, op: &OP)
-    where PAR_ITER: ParallelIterator<Item=T>,
+pub fn for_each<PAR_ITER, OP, T>(pi: PAR_ITER, op: &OP)
+    where PAR_ITER: ParallelIterator<Item = T>,
           OP: Fn(T) + Sync,
-          T: Send,
+          T: Send
 {
     let consumer = ForEachConsumer { op: op };
     pi.drive_unindexed(consumer)
@@ -17,7 +17,7 @@ struct ForEachConsumer<'f, OP: 'f> {
 }
 
 impl<'f, OP, ITEM> Consumer<ITEM> for ForEachConsumer<'f, OP>
-    where OP: Fn(ITEM) + Sync,
+    where OP: Fn(ITEM) + Sync
 {
     type Folder = ForEachConsumer<'f, OP>;
     type Reducer = NoopReducer;
@@ -38,7 +38,7 @@ impl<'f, OP, ITEM> Consumer<ITEM> for ForEachConsumer<'f, OP>
 }
 
 impl<'f, OP, ITEM> Folder<ITEM> for ForEachConsumer<'f, OP>
-    where OP: Fn(ITEM) + Sync,
+    where OP: Fn(ITEM) + Sync
 {
     type Result = ();
 
@@ -47,12 +47,11 @@ impl<'f, OP, ITEM> Folder<ITEM> for ForEachConsumer<'f, OP>
         self
     }
 
-    fn complete(self) {
-    }
+    fn complete(self) {}
 }
 
 impl<'f, OP, ITEM> UnindexedConsumer<ITEM> for ForEachConsumer<'f, OP>
-    where OP: Fn(ITEM) + Sync,
+    where OP: Fn(ITEM) + Sync
 {
     fn split_off(&self) -> Self {
         ForEachConsumer { op: self.op }

--- a/src/par_iter/len.rs
+++ b/src/par_iter/len.rs
@@ -19,15 +19,19 @@ pub struct ParallelLen {
 
 impl ParallelLen {
     pub fn left_cost(&self, mid: usize) -> ParallelLen {
-        ParallelLen { maximal_len: mid,
-                      cost: self.cost / 2.0,
-                      sparse: self.sparse }
+        ParallelLen {
+            maximal_len: mid,
+            cost: self.cost / 2.0,
+            sparse: self.sparse,
+        }
     }
 
     pub fn right_cost(&self, mid: usize) -> ParallelLen {
-        ParallelLen { maximal_len: self.maximal_len - mid,
-                      cost: self.cost / 2.0,
-                      sparse: self.sparse }
+        ParallelLen {
+            maximal_len: self.maximal_len - mid,
+            cost: self.cost / 2.0,
+            sparse: self.sparse,
+        }
     }
 }
 

--- a/src/par_iter/noop.rs
+++ b/src/par_iter/noop.rs
@@ -8,8 +8,7 @@ impl NoopConsumer {
     }
 }
 
-impl<ITEM> Consumer<ITEM> for NoopConsumer
-{
+impl<ITEM> Consumer<ITEM> for NoopConsumer {
     type Folder = NoopConsumer;
     type Reducer = NoopReducer;
     type Result = ();
@@ -34,8 +33,7 @@ impl<ITEM> Folder<ITEM> for NoopConsumer {
         self
     }
 
-    fn complete(self) {
-    }
+    fn complete(self) {}
 }
 
 impl<ITEM> UnindexedConsumer<ITEM> for NoopConsumer {
@@ -51,5 +49,5 @@ impl<ITEM> UnindexedConsumer<ITEM> for NoopConsumer {
 pub struct NoopReducer;
 
 impl Reducer<()> for NoopReducer {
-    fn reduce(self, _left: (), _right: ()) { }
+    fn reduce(self, _left: (), _right: ()) {}
 }

--- a/src/par_iter/option.rs
+++ b/src/par_iter/option.rs
@@ -3,7 +3,7 @@ use super::internal::*;
 use std;
 
 pub struct OptionIter<T: Send> {
-    opt: Option<T>
+    opt: Option<T>,
 }
 
 impl<T: Send> IntoParallelIterator for Option<T> {
@@ -60,7 +60,7 @@ impl<'a, T: Send, E> IntoParallelIterator for &'a mut Result<T, E> {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////
 
 impl<T: Send> ParallelIterator for OptionIter<T> {
     type Item = T;
@@ -86,7 +86,10 @@ impl<T: Send> BoundedParallelIterator for OptionIter<T> {
 
 impl<T: Send> ExactParallelIterator for OptionIter<T> {
     fn len(&mut self) -> usize {
-        match self.opt { Some(_) => 1, None => 0 }
+        match self.opt {
+            Some(_) => 1,
+            None => 0,
+        }
     }
 }
 
@@ -98,10 +101,10 @@ impl<T: Send> IndexedParallelIterator for OptionIter<T> {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////
 
 pub struct OptionProducer<T: Send> {
-    opt: Option<T>
+    opt: Option<T>,
 }
 
 impl<T: Send> Producer for OptionProducer<T> {
@@ -111,7 +114,11 @@ impl<T: Send> Producer for OptionProducer<T> {
 
     fn split_at(self, index: usize) -> (Self, Self) {
         let none = OptionProducer { opt: None };
-        if index == 0 { (none, self) } else { (self, none) }
+        if index == 0 {
+            (none, self)
+        } else {
+            (self, none)
+        }
     }
 }
 

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -3,7 +3,7 @@ use super::internal::*;
 use std::ops::Range;
 
 pub struct RangeIter<T> {
-    range: Range<T>
+    range: Range<T>,
 }
 
 impl<T> IntoParallelIterator for Range<T>

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -12,8 +12,7 @@ impl<M> Skip<M>
 {
     pub fn new(mut base: M, n: usize) -> Skip<M> {
         let n = min(base.len(), n);
-        Skip { base: base,
-               n: n }
+        Skip { base: base, n: n }
     }
 }
 
@@ -55,8 +54,10 @@ impl<M> IndexedParallelIterator for Skip<M>
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        return self.base.with_producer(Callback { callback: callback,
-                                                  n: self.n});
+        return self.base.with_producer(Callback {
+            callback: callback,
+            n: self.n,
+        });
 
         struct Callback<CB> {
             callback: CB,
@@ -68,7 +69,7 @@ impl<M> IndexedParallelIterator for Skip<M>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item=ITEM>
+                where P: Producer<Item = ITEM>
             {
                 let (before_skip, after_skip) = base.split_at(self.n);
                 bridge_producer_consumer(self.n, before_skip, noop::NoopConsumer::new());

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -2,7 +2,7 @@ use super::*;
 use super::internal::*;
 
 pub struct SliceIterMut<'data, T: 'data + Send> {
-    slice: &'data mut [T]
+    slice: &'data mut [T],
 }
 
 impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut [T] {
@@ -28,7 +28,10 @@ impl<'data, T: Send + 'data> ToParallelChunksMut<'data> for [T] {
     type Iter = ChunksMutIter<'data, T>;
 
     fn par_chunks_mut(&'data mut self, chunk_size: usize) -> Self::Iter {
-        ChunksMutIter { chunk_size: chunk_size, slice: self }
+        ChunksMutIter {
+            chunk_size: chunk_size,
+            slice: self,
+        }
     }
 }
 
@@ -105,18 +108,20 @@ impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMutIter<'data, T>
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(SliceChunksMutProducer { chunk_size: self.chunk_size, slice: self.slice })
+        callback.callback(SliceChunksMutProducer {
+            chunk_size: self.chunk_size,
+            slice: self.slice,
+        })
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////
 
 pub struct SliceMutProducer<'data, T: 'data + Send> {
-    slice: &'data mut [T]
+    slice: &'data mut [T],
 }
 
-impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T>
-{
+impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T> {
     fn cost(&mut self, len: usize) -> f64 {
         len as f64
     }
@@ -138,7 +143,7 @@ impl<'data, T: 'data + Send> IntoIterator for SliceMutProducer<'data, T> {
 
 pub struct SliceChunksMutProducer<'data, T: 'data + Send> {
     chunk_size: usize,
-    slice: &'data mut [T]
+    slice: &'data mut [T],
 }
 
 impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
@@ -149,8 +154,14 @@ impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
     fn split_at(self, index: usize) -> (Self, Self) {
         let elem_index = index * self.chunk_size;
         let (left, right) = self.slice.split_at_mut(elem_index);
-        (SliceChunksMutProducer { chunk_size: self.chunk_size, slice: left },
-         SliceChunksMutProducer { chunk_size: self.chunk_size, slice: right })
+        (SliceChunksMutProducer {
+             chunk_size: self.chunk_size,
+             slice: left,
+         },
+         SliceChunksMutProducer {
+             chunk_size: self.chunk_size,
+             slice: right,
+         })
     }
 }
 

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -7,13 +7,12 @@ pub struct Take<M> {
     n: usize,
 }
 
-impl<M> Take<M> 
+impl<M> Take<M>
     where M: IndexedParallelIterator
 {
     pub fn new(mut base: M, n: usize) -> Take<M> {
         let n = min(base.len(), n);
-        Take { base: base,
-               n: n }
+        Take { base: base, n: n }
     }
 }
 
@@ -55,8 +54,10 @@ impl<M> IndexedParallelIterator for Take<M>
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        return self.base.with_producer(Callback { callback: callback,
-                                                  n: self.n});
+        return self.base.with_producer(Callback {
+            callback: callback,
+            n: self.n,
+        });
 
         struct Callback<CB> {
             callback: CB,
@@ -68,7 +69,7 @@ impl<M> IndexedParallelIterator for Take<M>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item=ITEM>
+                where P: Producer<Item = ITEM>
             {
                 let (producer, _) = base.split_at(self.n);
                 self.callback.callback(producer)

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -8,18 +8,18 @@ use std::collections::LinkedList;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::collections::{BinaryHeap, VecDeque};
 
-fn is_bounded<T: ExactParallelIterator>(_: T) { }
-fn is_exact<T: ExactParallelIterator>(_: T) { }
-fn is_indexed<T: IndexedParallelIterator>(_: T) { }
+fn is_bounded<T: ExactParallelIterator>(_: T) {}
+fn is_exact<T: ExactParallelIterator>(_: T) {}
+fn is_indexed<T: IndexedParallelIterator>(_: T) {}
 
 #[test]
 pub fn execute() {
     let a: Vec<i32> = (0..1024).collect();
     let mut b = vec![];
     a.par_iter()
-     .map(|&i| i + 1)
-     .collect_into(&mut b);
-    let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
+        .map(|&i| i + 1)
+        .collect_into(&mut b);
+    let c: Vec<i32> = (0..1024).map(|i| i + 1).collect();
     assert_eq!(b, c);
 }
 
@@ -28,9 +28,9 @@ pub fn execute_cloned() {
     let a: Vec<i32> = (0..1024).collect();
     let mut b: Vec<i32> = vec![];
     a.par_iter()
-     .weight_max()
-     .cloned()
-     .collect_into(&mut b);
+        .weight_max()
+        .cloned()
+        .collect_into(&mut b);
     let c: Vec<i32> = (0..1024).collect();
     assert_eq!(b, c);
 }
@@ -40,9 +40,9 @@ pub fn execute_range() {
     let a = 0i32..1024;
     let mut b = vec![];
     a.into_par_iter()
-     .map(|i| i + 1)
-     .collect_into(&mut b);
-    let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
+        .map(|i| i + 1)
+        .collect_into(&mut b);
+    let c: Vec<i32> = (0..1024).map(|i| i + 1).collect();
     assert_eq!(b, c);
 }
 
@@ -50,7 +50,7 @@ pub fn execute_range() {
 pub fn execute_unindexed_range() {
     let a = 0i64..1024;
     let b: LinkedList<i64> = a.into_par_iter().map(|i| i + 1).collect();
-    let c: LinkedList<i64> = (0..1024).map(|i| i+1).collect();
+    let c: LinkedList<i64> = (0..1024).map(|i| i + 1).collect();
     assert_eq!(b, c);
 }
 
@@ -66,12 +66,12 @@ pub fn check_map_exact_and_bounded() {
 pub fn map_sum() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
-              .weight_max()
-              .map(|&i| i + 1)
-              .sum();
+        .weight_max()
+        .map(|&i| i + 1)
+        .sum();
     let r2 = a.iter()
-              .map(|&i| i + 1)
-              .fold(0, |a,b| a+b);
+        .map(|&i| i + 1)
+        .fold(0, |a, b| a + b);
     assert_eq!(r1, r2);
 }
 
@@ -79,12 +79,12 @@ pub fn map_sum() {
 pub fn map_reduce() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
-              .weight_max()
-              .map(|&i| i + 1)
-              .reduce(|| 0, |i, j| i + j);
+        .weight_max()
+        .map(|&i| i + 1)
+        .reduce(|| 0, |i, j| i + j);
     let r2 = a.iter()
-              .map(|&i| i + 1)
-              .fold(0, |a,b| a+b);
+        .map(|&i| i + 1)
+        .fold(0, |a, b| a + b);
     assert_eq!(r1, r2);
 }
 
@@ -92,12 +92,12 @@ pub fn map_reduce() {
 pub fn map_reduce_with() {
     let a: Vec<i32> = (0..1024).collect();
     let r1 = a.par_iter()
-              .weight_max()
-              .map(|&i| i + 1)
-              .reduce_with(|i, j| i + j);
+        .weight_max()
+        .map(|&i| i + 1)
+        .reduce_with(|i, j| i + j);
     let r2 = a.iter()
-              .map(|&i| i + 1)
-              .fold(0, |a,b| a+b);
+        .map(|&i| i + 1)
+        .fold(0, |a, b| a + b);
     assert_eq!(r1, Some(r2));
 }
 
@@ -113,11 +113,18 @@ pub fn fold_map_reduce() {
     // individual vector by mapping each into their own vector (so we
     // have Vec<Vec<i32>>) and then reducing those into a single
     // vector.
-    let r1 = (0_i32..32).into_par_iter()
-                        .weight_max()
-                        .fold(|| vec![], |mut v, e| { v.push(e); v })
-                        .map(|v| vec![v])
-                        .reduce_with(|mut v_a, v_b| { v_a.extend(v_b); v_a });
+    let r1 = (0_i32..32)
+        .into_par_iter()
+        .weight_max()
+        .fold(|| vec![], |mut v, e| {
+            v.push(e);
+            v
+        })
+        .map(|v| vec![v])
+        .reduce_with(|mut v_a, v_b| {
+            v_a.extend(v_b);
+            v_a
+        });
     assert_eq!(r1,
                Some(vec![vec![0], vec![1], vec![2], vec![3], vec![4], vec![5], vec![6], vec![7],
                          vec![8], vec![9], vec![10], vec![11], vec![12], vec![13], vec![14],
@@ -140,9 +147,9 @@ pub fn check_enumerate() {
 
     let mut b = vec![];
     a.par_iter()
-     .enumerate()
-     .map(|(i, &x)| i + x)
-     .collect_into(&mut b);
+        .enumerate()
+        .map(|(i, &x)| i + x)
+        .collect_into(&mut b);
     assert!(b.iter().all(|&x| x == a.len() - 1));
 }
 
@@ -154,7 +161,9 @@ pub fn check_indices_after_enumerate_split() {
     struct WithProducer;
     impl<'a> ProducerCallback<(usize, &'a i32)> for WithProducer {
         type Output = ();
-        fn callback<P>(self, producer: P) where P: Producer<Item=(usize, &'a i32)> {
+        fn callback<P>(self, producer: P)
+            where P: Producer<Item = (usize, &'a i32)>
+        {
             let (a, b) = producer.split_at(512);
             for ((index, value), trusted_index) in a.into_iter().zip(0..) {
                 assert_eq!(index, trusted_index);
@@ -173,8 +182,8 @@ pub fn check_increment() {
     let mut a: Vec<usize> = (0..1024).rev().collect();
 
     a.par_iter_mut()
-     .enumerate()
-     .for_each(|(i, v)| *v += i);
+        .enumerate()
+        .for_each(|(i, v)| *v += i);
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
 }
@@ -230,9 +239,12 @@ pub fn check_inspect() {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     let a = AtomicUsize::new(0);
-    let b = (0_usize..1024).into_par_iter()
+    let b = (0_usize..1024)
+        .into_par_iter()
         .weight_max()
-        .inspect(|&i| { a.fetch_add(i, Ordering::Relaxed); })
+        .inspect(|&i| {
+            a.fetch_add(i, Ordering::Relaxed);
+        })
         .sum();
 
     assert_eq!(a.load(Ordering::Relaxed), b);
@@ -279,7 +291,9 @@ pub fn check_drops() {
     struct Partial;
     impl<'a> ProducerCallback<DropCounter<'a>> for Partial {
         type Output = ();
-        fn callback<P>(self, producer: P) where P: Producer<Item=DropCounter<'a>> {
+        fn callback<P>(self, producer: P)
+            where P: Producer<Item = DropCounter<'a>>
+        {
             let (a, _) = producer.split_at(5);
             a.into_iter().next();
         }
@@ -323,8 +337,8 @@ pub fn check_zip() {
     let b: Vec<usize> = (0..1024).collect();
 
     a.par_iter_mut()
-     .zip(&b[..])
-     .for_each(|(a, &b)| *a += b);
+        .zip(&b[..])
+        .for_each(|(a, &b)| *a += b);
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
 }
@@ -347,8 +361,8 @@ pub fn check_zip_into_mut_par_iter() {
     let mut b: Vec<usize> = (0..1024).collect();
 
     a.par_iter()
-     .zip(&mut b)
-     .for_each(|(&a, b)| *b += a);
+        .zip(&mut b)
+        .for_each(|(&a, b)| *b += a);
 
     assert!(b.iter().all(|&x| x == b.len() - 1));
 }
@@ -358,8 +372,8 @@ pub fn check_zip_range() {
     let mut a: Vec<usize> = (0..1024).rev().collect();
 
     a.par_iter_mut()
-     .zip(0usize..1024)
-     .for_each(|(a, b)| *a += b);
+        .zip(0usize..1024)
+        .for_each(|(a, b)| *a += b);
 
     assert!(a.iter().all(|&x| x == a.len() - 1));
 }
@@ -376,30 +390,26 @@ pub fn check_range_split_at_overflow() {
 #[test]
 pub fn check_sum_filtered_ints() {
     let a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let par_sum_evens =
-        a.par_iter()
-         .filter(|&x| (x & 1) == 0)
-         .map(|&x| x)
-         .sum();
-    let seq_sum_evens =
-        a.iter()
-         .filter(|&x| (x & 1) == 0)
-         .map(|&x| x)
-         .fold(0, |a,b| a+b);
+    let par_sum_evens = a.par_iter()
+        .filter(|&x| (x & 1) == 0)
+        .map(|&x| x)
+        .sum();
+    let seq_sum_evens = a.iter()
+        .filter(|&x| (x & 1) == 0)
+        .map(|&x| x)
+        .fold(0, |a, b| a + b);
     assert_eq!(par_sum_evens, seq_sum_evens);
 }
 
 #[test]
 pub fn check_sum_filtermap_ints() {
     let a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let par_sum_evens =
-        a.par_iter()
-         .filter_map(|&x| if (x & 1) == 0 {Some(x as f32)} else {None})
-         .sum();
-    let seq_sum_evens =
-        a.iter()
-         .filter_map(|&x| if (x & 1) == 0 {Some(x as f32)} else {None})
-         .fold(0.0, |a,b| a+b);
+    let par_sum_evens = a.par_iter()
+        .filter_map(|&x| if (x & 1) == 0 { Some(x as f32) } else { None })
+        .sum();
+    let seq_sum_evens = a.iter()
+        .filter_map(|&x| if (x & 1) == 0 { Some(x as f32) } else { None })
+        .fold(0.0, |a, b| a + b);
     assert_eq!(par_sum_evens, seq_sum_evens);
 }
 
@@ -407,16 +417,16 @@ pub fn check_sum_filtermap_ints() {
 pub fn check_flat_map_nested_ranges() {
     // FIXME -- why are precise type hints required on the integers here?
 
-    let v =
-        (0_i32..10).into_par_iter()
-                   .flat_map(|i| (0_i32..10).into_par_iter().map(move |j| (i, j)))
-                   .map(|(i, j)| i * j)
-                   .sum();
+    let v = (0_i32..10)
+        .into_par_iter()
+        .flat_map(|i| (0_i32..10).into_par_iter().map(move |j| (i, j)))
+        .map(|(i, j)| i * j)
+        .sum();
 
-    let w =
-        (0_i32..10).flat_map(|i| (0_i32..10).map(move |j| (i, j)))
-                   .map(|(i, j)| i * j)
-                   .fold(0, |i, j| i + j);
+    let w = (0_i32..10)
+        .flat_map(|i| (0_i32..10).map(move |j| (i, j)))
+        .map(|(i, j)| i * j)
+        .fold(0, |i, j| i + j);
 
     assert_eq!(v, w);
 }
@@ -444,27 +454,23 @@ pub fn check_empty_flat_map_sum() {
 #[test]
 pub fn check_chunks() {
     let a: Vec<i32> = vec![1, 5, 10, 4, 100, 3, 1000, 2, 10000, 1];
-    let par_sum_product_pairs =
-         a.par_chunks(2)
-          .weight_max()
-          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
-          .sum();
-    let seq_sum_product_pairs =
-         a.chunks(2)
-          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
-          .fold(0, |i, j| i+j);
+    let par_sum_product_pairs = a.par_chunks(2)
+        .weight_max()
+        .map(|c| c.iter().map(|&x| x).fold(1, |i, j| i * j))
+        .sum();
+    let seq_sum_product_pairs = a.chunks(2)
+        .map(|c| c.iter().map(|&x| x).fold(1, |i, j| i * j))
+        .fold(0, |i, j| i + j);
     assert_eq!(par_sum_product_pairs, 12345);
     assert_eq!(par_sum_product_pairs, seq_sum_product_pairs);
 
-    let par_sum_product_triples: i32 =
-         a.par_chunks(3)
-          .weight_max()
-          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
-          .sum();
-    let seq_sum_product_triples =
-         a.chunks(3)
-          .map(|c| c.iter().map(|&x|x).fold(1, |i, j| i*j))
-          .fold(0, |i, j| i+j);
+    let par_sum_product_triples: i32 = a.par_chunks(3)
+        .weight_max()
+        .map(|c| c.iter().map(|&x| x).fold(1, |i, j| i * j))
+        .sum();
+    let seq_sum_product_triples = a.chunks(3)
+        .map(|c| c.iter().map(|&x| x).fold(1, |i, j| i * j))
+        .fold(0, |i, j| i + j);
     assert_eq!(par_sum_product_triples, 5_0 + 12_00 + 2_000_0000 + 1);
     assert_eq!(par_sum_product_triples, seq_sum_product_triples);
 }
@@ -475,9 +481,9 @@ pub fn check_chunks_mut() {
     let mut b: Vec<i32> = a.clone();
     a.par_chunks_mut(2)
         .weight_max()
-        .for_each(|c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j));
+        .for_each(|c| c[0] = c.iter().map(|&x| x).fold(0, |i, j| i + j));
     b.chunks_mut(2)
-        .map(     |c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j))
+        .map(|c| c[0] = c.iter().map(|&x| x).fold(0, |i, j| i + j))
         .count();
     assert_eq!(a, &[3, 2, 7, 4, 11, 6, 15, 8, 19, 10]);
     assert_eq!(a, b);
@@ -486,9 +492,9 @@ pub fn check_chunks_mut() {
     let mut b: Vec<i32> = a.clone();
     a.par_chunks_mut(3)
         .weight_max()
-        .for_each(|c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j));
+        .for_each(|c| c[0] = c.iter().map(|&x| x).fold(0, |i, j| i + j));
     b.chunks_mut(3)
-        .map(     |c| c[0] = c.iter().map(|&x|x).fold(0, |i, j| i+j))
+        .map(|c| c[0] = c.iter().map(|&x| x).fold(0, |i, j| i + j))
         .count();
     assert_eq!(a, &[6, 2, 3, 15, 5, 6, 24, 8, 9, 10]);
     assert_eq!(a, b);
@@ -501,7 +507,8 @@ pub fn check_options() {
     assert_eq!(7, a.par_iter().flat_map(|opt| opt).cloned().sum());
     assert_eq!(7, a.par_iter().cloned().flat_map(|opt| opt).sum());
 
-    a.par_iter_mut().flat_map(|opt| opt)
+    a.par_iter_mut()
+        .flat_map(|opt| opt)
         .for_each(|x| *x = *x * *x);
 
     assert_eq!(21, a.into_par_iter().flat_map(|opt| opt).sum());
@@ -513,7 +520,8 @@ pub fn check_results() {
 
     assert_eq!(7, a.par_iter().flat_map(|res| res).cloned().sum());
 
-    a.par_iter_mut().flat_map(|res| res)
+    a.par_iter_mut()
+        .flat_map(|res| res)
         .for_each(|x| *x = *x * *x);
 
     assert_eq!(21, a.into_par_iter().flat_map(|res| res).sum());
@@ -612,8 +620,9 @@ pub fn check_chain() {
     let mut res = vec![];
 
     // stays indexed in the face of madness
-    Some(0).into_par_iter()
-        .chain(Ok::<_,()>(1))
+    Some(0)
+        .into_par_iter()
+        .chain(Ok::<_, ()>(1))
         .chain(1..4)
         .chain(Err("huh?"))
         .chain(None)
@@ -626,25 +635,29 @@ pub fn check_chain() {
         .weight_max()
         .collect_into(&mut res);
 
-    assert_eq!(res, vec![(0, 'a', 0),
-                         (1, 'b', -1),
-                         (2, 'b', -2),
-                         (3, 'c', -3),
-                         (4, 'd', -4),
-                         (5, 'f', -5),
-                         (6, 'i', -6),
-                         (7, 'n', -7),
-                         (8, 'x', -8),
-                         (9, 'y', -9),
-                         (10, 'z', -10)]);
+    assert_eq!(res,
+               vec![(0, 'a', 0),
+                    (1, 'b', -1),
+                    (2, 'b', -2),
+                    (3, 'c', -3),
+                    (4, 'd', -4),
+                    (5, 'f', -5),
+                    (6, 'i', -6),
+                    (7, 'n', -7),
+                    (8, 'x', -8),
+                    (9, 'y', -9),
+                    (10, 'z', -10)]);
 
     // unindexed is ok too
-    let sum = Some(1i32).into_par_iter()
-        .chain((2i32..4).into_par_iter()
-                .chain(vec![5, 6, 7, 8, 9])
-                .chain(Some((10, 100)).into_par_iter()
-                       .flat_map(|(a, b)| a..b))
-                .filter(|x| x & 1 == 1))
+    let sum = Some(1i32)
+        .into_par_iter()
+        .chain((2i32..4)
+            .into_par_iter()
+            .chain(vec![5, 6, 7, 8, 9])
+            .chain(Some((10, 100))
+                .into_par_iter()
+                .flat_map(|(a, b)| a..b))
+            .filter(|x| x & 1 == 1))
         .weight_max()
         .sum();
     assert_eq!(sum, 2500);
@@ -653,9 +666,9 @@ pub fn check_chain() {
 
 #[test]
 pub fn check_count() {
-    let c0 = (0_u32..24*1024).filter(|i| i % 2 == 0).count();
-    let c1 = (0_u32..24*1024).into_par_iter().filter(|i| i % 2 == 0).count();
-    let c2 = (0_u32..24*1024).into_par_iter().weight_max().filter(|i| i % 2 == 0).count();
+    let c0 = (0_u32..24 * 1024).filter(|i| i % 2 == 0).count();
+    let c1 = (0_u32..24 * 1024).into_par_iter().filter(|i| i % 2 == 0).count();
+    let c2 = (0_u32..24 * 1024).into_par_iter().weight_max().filter(|i| i % 2 == 0).count();
     assert_eq!(c0, c1);
     assert_eq!(c1, c2);
 }
@@ -666,11 +679,13 @@ pub fn find_any() {
     let a: Vec<i32> = (0..1024).collect();
 
     assert!(a.par_iter().find_any(|&&x| x % 42 == 41).is_some());
-    assert_eq!(a.par_iter().find_any(|&&x| x % 19 == 1 && x % 53 == 0), Some(&742_i32));
+    assert_eq!(a.par_iter().find_any(|&&x| x % 19 == 1 && x % 53 == 0),
+               Some(&742_i32));
     assert_eq!(a.par_iter().find_any(|&&x| x < 0), None);
 
     assert!(a.par_iter().position_any(|&x| x % 42 == 41).is_some());
-    assert_eq!(a.par_iter().position_any(|&x| x % 19 == 1 && x % 53 == 0), Some(742_usize));
+    assert_eq!(a.par_iter().position_any(|&x| x % 19 == 1 && x % 53 == 0),
+               Some(742_usize));
     assert_eq!(a.par_iter().position_any(|&x| x < 0), None);
 
     assert!(a.par_iter().any(|&x| x > 1000));
@@ -683,10 +698,12 @@ pub fn find_any() {
 #[test]
 pub fn check_find_not_present() {
     let counter = AtomicUsize::new(0);
-    let value: Option<i32> =
-        (0_i32..2048)
+    let value: Option<i32> = (0_i32..2048)
         .into_par_iter()
-        .find_any(|&p| { counter.fetch_add(1, Ordering::SeqCst); p >= 2048 });
+        .find_any(|&p| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            p >= 2048
+        });
     assert!(value.is_none());
     assert!(counter.load(Ordering::SeqCst) == 2048); // should have visited every single one
 }
@@ -694,10 +711,12 @@ pub fn check_find_not_present() {
 #[test]
 pub fn check_find_is_present() {
     let counter = AtomicUsize::new(0);
-    let value: Option<i32> =
-        (0_i32..2048)
+    let value: Option<i32> = (0_i32..2048)
         .into_par_iter()
-        .find_any(|&p| { counter.fetch_add(1, Ordering::SeqCst); p >= 1024 && p < 1096 });
+        .find_any(|&p| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            p >= 1024 && p < 1096
+        });
     let q = value.unwrap();
     assert!(q >= 1024 && q < 1096);
     assert!(counter.load(Ordering::SeqCst) < 2048); // should not have visited every single one
@@ -707,7 +726,7 @@ pub fn check_find_is_present() {
 pub fn par_iter_collect() {
     let a: Vec<i32> = (0..1024).collect();
     let b: Vec<i32> = a.par_iter().map(|&i| i + 1).collect();
-    let c: Vec<i32> = (0..1024).map(|i| i+1).collect();
+    let c: Vec<i32> = (0..1024).map(|i| i + 1).collect();
     assert_eq!(b, c);
 }
 
@@ -771,7 +790,12 @@ pub fn par_iter_collect_linked_list() {
 
 #[test]
 pub fn par_iter_collect_linked_list_flat_map_filter() {
-    let b: LinkedList<i32> = (0_i32..1024).into_par_iter().weight_max().flat_map(|i| (0..i)).filter(|&i| i % 2 == 0).collect();
+    let b: LinkedList<i32> = (0_i32..1024)
+        .into_par_iter()
+        .weight_max()
+        .flat_map(|i| (0..i))
+        .filter(|&i| i % 2 == 0)
+        .collect();
     let c: LinkedList<i32> = (0_i32..1024).flat_map(|i| (0..i)).filter(|&i| i % 2 == 0).collect();
     assert_eq!(b, c);
 }
@@ -780,7 +804,7 @@ pub fn par_iter_collect_linked_list_flat_map_filter() {
 fn min_max() {
     let mut rng = XorShiftRng::from_seed([14159, 26535, 89793, 23846]);
     let a: Vec<i32> = rng.gen_iter().take(1024).collect();
-    for i in 0 .. a.len() + 1 {
+    for i in 0..a.len() + 1 {
         let slice = &a[..i];
         assert_eq!(slice.par_iter().min(), slice.iter().min());
         assert_eq!(slice.par_iter().max(), slice.iter().max());
@@ -792,10 +816,12 @@ fn min_max_by() {
     let mut rng = XorShiftRng::from_seed([14159, 26535, 89793, 23846]);
     // Make sure there are duplicate keys, for testing sort stability
     let r: Vec<i32> = rng.gen_iter().take(512).collect();
-    let a: Vec<(i32, u16)> = r.iter().chain(&r).cloned().zip(0 ..).collect();
-    for i in 0 .. a.len() + 1 {
+    let a: Vec<(i32, u16)> = r.iter().chain(&r).cloned().zip(0..).collect();
+    for i in 0..a.len() + 1 {
         let slice = &a[..i];
-        assert_eq!(slice.par_iter().min_by_key(|x| x.0), slice.iter().min_by_key(|x| x.0));
-        assert_eq!(slice.par_iter().max_by_key(|x| x.0), slice.iter().max_by_key(|x| x.0));
+        assert_eq!(slice.par_iter().min_by_key(|x| x.0),
+                   slice.iter().min_by_key(|x| x.0));
+        assert_eq!(slice.par_iter().max_by_key(|x| x.0),
+                   slice.iter().max_by_key(|x| x.0));
     }
 }

--- a/src/par_iter/vec.rs
+++ b/src/par_iter/vec.rs
@@ -63,10 +63,10 @@ impl<T: Send> IndexedParallelIterator for VecIter<T> {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////
 
 pub struct VecProducer<'data, T: 'data + Send> {
-    slice: &'data mut [T]
+    slice: &'data mut [T],
 }
 
 impl<'data, T: 'data + Send> Producer for VecProducer<'data, T> {
@@ -99,18 +99,19 @@ impl<'data, T: 'data + Send> Drop for VecProducer<'data, T> {
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////
 
 // like std::vec::Drain, without updating a source Vec
 pub struct SliceDrain<'data, T: 'data> {
-    iter: std::slice::IterMut<'data, T>
+    iter: std::slice::IterMut<'data, T>,
 }
 
 impl<'data, T: 'data> Iterator for SliceDrain<'data, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
-        self.iter.next()
+        self.iter
+            .next()
             .map(|ptr| unsafe { std::ptr::read(ptr) })
     }
 }
@@ -119,7 +120,9 @@ impl<'data, T: 'data> Drop for SliceDrain<'data, T> {
     fn drop(&mut self) {
         for ptr in &mut self.iter {
             // use drop_in_place once stable
-            unsafe { std::ptr::read(ptr); }
+            unsafe {
+                std::ptr::read(ptr);
+            }
         }
     }
 }

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -15,7 +15,8 @@ impl<A: IndexedParallelIterator, B: IndexedParallelIterator> ZipIter<A, B> {
 }
 
 impl<A, B> ParallelIterator for ZipIter<A, B>
-    where A: IndexedParallelIterator, B: IndexedParallelIterator
+    where A: IndexedParallelIterator,
+          B: IndexedParallelIterator
 {
     type Item = (A::Item, B::Item);
 
@@ -26,8 +27,9 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     }
 }
 
-impl<A,B> BoundedParallelIterator for ZipIter<A,B>
-    where A: IndexedParallelIterator, B: IndexedParallelIterator
+impl<A, B> BoundedParallelIterator for ZipIter<A, B>
+    where A: IndexedParallelIterator,
+          B: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -40,16 +42,18 @@ impl<A,B> BoundedParallelIterator for ZipIter<A,B>
     }
 }
 
-impl<A,B> ExactParallelIterator for ZipIter<A,B>
-    where A: IndexedParallelIterator, B: IndexedParallelIterator
+impl<A, B> ExactParallelIterator for ZipIter<A, B>
+    where A: IndexedParallelIterator,
+          B: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         min(self.a.len(), self.b.len())
     }
 }
 
-impl<A,B> IndexedParallelIterator for ZipIter<A,B>
-    where A: IndexedParallelIterator, B: IndexedParallelIterator
+impl<A, B> IndexedParallelIterator for ZipIter<A, B>
+    where A: IndexedParallelIterator,
+          B: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -61,17 +65,17 @@ impl<A,B> IndexedParallelIterator for ZipIter<A,B>
 
         struct CallbackA<CB, B> {
             callback: CB,
-            b: B
+            b: B,
         }
 
         impl<CB, A_ITEM, B> ProducerCallback<A_ITEM> for CallbackA<CB, B>
             where B: IndexedParallelIterator,
-                  CB: ProducerCallback<(A_ITEM, B::Item)>,
+                  CB: ProducerCallback<(A_ITEM, B::Item)>
         {
             type Output = CB::Output;
 
             fn callback<A>(self, a_producer: A) -> Self::Output
-                where A: Producer<Item=A_ITEM>
+                where A: Producer<Item = A_ITEM>
             {
                 return self.b.with_producer(CallbackB {
                     a_producer: a_producer,
@@ -82,26 +86,29 @@ impl<A,B> IndexedParallelIterator for ZipIter<A,B>
 
         struct CallbackB<CB, A> {
             a_producer: A,
-            callback: CB
+            callback: CB,
         }
 
         impl<CB, A, B_ITEM> ProducerCallback<B_ITEM> for CallbackB<CB, A>
             where A: Producer,
-                  CB: ProducerCallback<(A::Item, B_ITEM)>,
+                  CB: ProducerCallback<(A::Item, B_ITEM)>
         {
             type Output = CB::Output;
 
             fn callback<B>(self, b_producer: B) -> Self::Output
-                where B: Producer<Item=B_ITEM>
+                where B: Producer<Item = B_ITEM>
             {
-                self.callback.callback(ZipProducer { a: self.a_producer, b: b_producer })
+                self.callback.callback(ZipProducer {
+                    a: self.a_producer,
+                    b: b_producer,
+                })
             }
         }
 
     }
 }
 
-///////////////////////////////////////////////////////////////////////////
+/// ////////////////////////////////////////////////////////////////////////
 
 pub struct ZipProducer<A: Producer, B: Producer> {
     a: A,
@@ -121,8 +128,14 @@ impl<A: Producer, B: Producer> Producer for ZipProducer<A, B> {
     fn split_at(self, index: usize) -> (Self, Self) {
         let (a_left, a_right) = self.a.split_at(index);
         let (b_left, b_right) = self.b.split_at(index);
-        (ZipProducer { a: a_left, b: b_left },
-         ZipProducer { a: a_right, b: b_right, })
+        (ZipProducer {
+             a: a_left,
+             b: b_left,
+         },
+         ZipProducer {
+             a: a_right,
+             b: b_right,
+         })
     }
 }
 

--- a/src/scope/test.rs
+++ b/src/scope/test.rs
@@ -12,15 +12,20 @@ use std::sync::Mutex;
 
 #[test]
 fn scope_empty() {
-    scope(|_| { });
+    scope(|_| {
+    });
 }
 
 #[test]
 fn scope_two() {
     let counter = &AtomicUsize::new(0);
     scope(|s| {
-        s.spawn(move |_| { counter.fetch_add(1, Ordering::SeqCst); });
-        s.spawn(move |_| { counter.fetch_add(10, Ordering::SeqCst); });
+        s.spawn(move |_| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+        s.spawn(move |_| {
+            counter.fetch_add(10, Ordering::SeqCst);
+        });
     });
 
     let v = counter.load(Ordering::SeqCst);
@@ -40,9 +45,7 @@ fn scope_divide_and_conquer() {
     assert_eq!(p, s);
 }
 
-fn divide_and_conquer<'scope>(
-    scope: &Scope<'scope>, counter: &'scope AtomicUsize, size: usize)
-{
+fn divide_and_conquer<'scope>(scope: &Scope<'scope>, counter: &'scope AtomicUsize, size: usize) {
     if size > 1 {
         scope.spawn(move |scope| divide_and_conquer(scope, counter, size / 2));
         scope.spawn(move |scope| divide_and_conquer(scope, counter, size / 2));
@@ -72,12 +75,12 @@ fn scope_mix() {
         s.spawn(move |_| {
             let a: Vec<i32> = (0..1024).collect();
             let r1 = a.par_iter()
-                      .weight_max()
-                      .map(|&i| i + 1)
-                      .reduce_with(|i, j| i + j);
+                .weight_max()
+                .map(|&i| i + 1)
+                .reduce_with(|i, j| i + j);
             let r2 = a.iter()
-                      .map(|&i| i + 1)
-                      .fold(0, |a,b| a+b);
+                .map(|&i| i + 1)
+                .fold(0, |a, b| a + b);
             assert_eq!(r1.unwrap(), r2);
         });
     });
@@ -89,8 +92,7 @@ struct Tree<T> {
 }
 
 impl<T> Tree<T> {
-    pub fn iter<'s>(&'s self) -> impl Iterator<Item=&'s T> + 's
-    {
+    pub fn iter<'s>(&'s self) -> impl Iterator<Item = &'s T> + 's {
         once(&self.value)
             .chain(self.children.iter().flat_map(|c| c.iter()))
             .collect::<Vec<_>>() // seems like it shouldn't be needed... but prevents overflow
@@ -98,7 +100,8 @@ impl<T> Tree<T> {
     }
 
     pub fn update<OP>(&mut self, op: OP)
-        where OP: Fn(&mut T) + Sync, T: Send,
+        where OP: Fn(&mut T) + Sync,
+              T: Send
     {
         scope(|s| self.update_in_scope(&op, s));
     }
@@ -132,7 +135,10 @@ fn random_tree1(depth: usize, rng: &mut XorShiftRng) -> Tree<u32> {
             .collect()
     };
 
-    Tree { value: rng.next_u32() % 1_000_000, children: children }
+    Tree {
+        value: rng.next_u32() % 1_000_000,
+        children: children,
+    }
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,18 +7,17 @@ use rand::{Rng, SeedableRng, XorShiftRng};
 use std::path::PathBuf;
 use std::error::Error;
 
-fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
+fn quick_sort<T: PartialOrd + Send>(v: &mut [T]) {
     if v.len() <= 1 {
         return;
     }
 
     let mid = partition(v);
     let (lo, hi) = v.split_at_mut(mid);
-    join(|| quick_sort(lo),
-         || quick_sort(hi));
+    join(|| quick_sort(lo), || quick_sort(hi));
 }
 
-fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
+fn partition<T: PartialOrd + Send>(v: &mut [T]) -> usize {
     let pivot = v.len() - 1;
     let mut i = 0;
     for j in 0..pivot {
@@ -34,7 +33,7 @@ fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {
 #[test]
 fn sort() {
     let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
-    let mut data: Vec<_> = (0..6*1024).map(|_| rng.next_u32()).collect();
+    let mut data: Vec<_> = (0..6 * 1024).map(|_| rng.next_u32()).collect();
 
     let result = initialize(Configuration::new());
 
@@ -46,7 +45,7 @@ fn sort() {
             sorted_data.sort();
 
             assert_eq!(data, sorted_data);
-        },
+        }
         Err(e) => panic!("expected InitOk, but got {:?}", e),
     }
 }
@@ -54,7 +53,7 @@ fn sort() {
 #[test]
 fn sort_in_pool() {
     let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
-    let mut data: Vec<_> = (0..12*1024).map(|_| rng.next_u32()).collect();
+    let mut data: Vec<_> = (0..12 * 1024).map(|_| rng.next_u32()).collect();
 
     let result = ThreadPool::new(Configuration::new());
 
@@ -68,8 +67,8 @@ fn sort_in_pool() {
             sorted_data.sort();
 
             assert_eq!(data, sorted_data);
-        },
-        Err(_) => panic!("expected Ok() but got Err()")
+        }
+        Err(_) => panic!("expected Ok() but got Err()"),
     }
 }
 
@@ -79,7 +78,7 @@ fn error_in_pool() {
 
     match result {
         Ok(_) => panic!("expected Err(), but got Ok()"),
-        Err(error) => assert_eq!(error, InitError::NumberOfThreadsZero)
+        Err(error) => assert_eq!(error, InitError::NumberOfThreadsZero),
     }
 }
 
@@ -166,6 +165,6 @@ fn positive_test_run_pass_unstable() {
 
 #[test]
 fn coerce_to_box_error() {
-     // check that coercion succeeds
+    // check that coercion succeeds
     let _: Box<Error> = From::from(InitError::NumberOfThreadsZero);
 }

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -13,7 +13,7 @@ use std::thread;
 /// `Err` result. The assumption is that any panic will be propagated
 /// later with `resume_unwinding`, and hence `f` can be treated as
 /// exception safe.
-pub fn halt_unwinding<F,R>(func: F) -> thread::Result<R>
+pub fn halt_unwinding<F, R>(func: F) -> thread::Result<R>
     where F: FnOnce() -> R
 {
     panic::catch_unwind(AssertUnwindSafe(func))
@@ -34,10 +34,13 @@ impl Drop for AbortIfPanic {
     }
 }
 
-pub fn finally<A,F>(arg: A, func: F) -> FinallyGuard<A,F>
+pub fn finally<A, F>(arg: A, func: F) -> FinallyGuard<A, F>
     where F: FnMut(&mut A)
 {
-    FinallyGuard { arg: arg, func: func }
+    FinallyGuard {
+        arg: arg,
+        func: func,
+    }
 }
 
 pub struct FinallyGuard<A, F>


### PR DESCRIPTION
This causes a project with compilation as it converts the implementation of Tree iter function in src/scope/test.rs line 95 to a todo. However this should give us a baseline of how to proceed. 

I can easily rebase this moving forwards so no worries there. 

Now fixing this is as easy as copy pasting, however it evades the problem that people can't safely run rustfmt on the code without an unintended side-effect. So instead it seems like we need an implementation that can be converted successfully so that way people can keep their code formatted in the standardized way.

First commit should obviously fail tests until the problem solution has been formalized.