### PR TITLE
Use drop_in_place in vec's SliceDrain

### DIFF
--- a/src/par_iter/vec.rs
+++ b/src/par_iter/vec.rs
@@ -123,9 +123,8 @@ impl<'data, T: 'data> Iterator for SliceDrain<'data, T> {
 impl<'data, T: 'data> Drop for SliceDrain<'data, T> {
     fn drop(&mut self) {
         for ptr in &mut self.iter {
-            // use drop_in_place once stable
             unsafe {
-                std::ptr::read(ptr);
+                std::ptr::drop_in_place(ptr);
             }
         }
     }


### PR DESCRIPTION
There was a comment that we should use `ptr::drop_in_place` once stable,
which happened in Rust 1.8.  We're beyond that minimum already for other
features, so let's go ahead and use it.