### PR TITLE
Document and test the minimum rustc explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.12.0
   - stable
   - nightly
 script:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ part, adding calls to Rayon should not change how your programs works
 at all, in fact. However, if you operate on mutexes or atomic
 integers, please see the [notes on atomicity](#atomicity).
 
+Rayon currently requires `rustc 1.12.0` or greater.
+
 ### Contribution
 
 Rayon is an open source project! If you'd like to contribute to Rayon, check out [the list of "help wanted" issues](https://github.com/nikomatsakis/rayon/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22). These are all (or should be) issues that are suitable for getting started, and they generally include a detailed set of instructions for what to do. Please ask questions if anything is unclear! Also, check out the [Guide to Development](https://github.com/nikomatsakis/rayon/wiki/Guide-to-Development) page on the wiki. Note that all code submitted in PRs to Rayon is assumed to [be licensed under Rayon's dual MIT/Apache2 licensing](https://github.com/nikomatsakis/rayon/blob/master/README.md#license).


### PR DESCRIPTION
Rayon currently requires 1.12.0 to allow building with `impl Trait`
syntax in some of the tests, as they must parse even in normal builds.

Closes #145.