### PR TITLE
Reorder use super::* / super::internal::*

### DIFF
--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::cmp::min;
 use std::iter;
 

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::iter;
 use std::ops::RangeFrom;
 

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -1,6 +1,6 @@
-use super::*;
-use super::len::*;
 use super::internal::*;
+use super::len::*;
+use super::*;
 
 pub struct Filter<M, FILTER_OP> {
     base: M,

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -1,6 +1,6 @@
-use super::*;
-use super::len::*;
 use super::internal::*;
+use super::len::*;
+use super::*;
 
 pub struct FilterMap<M, FILTER_OP> {
     base: M,

--- a/src/par_iter/find.rs
+++ b/src/par_iter/find.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use super::*;
-use super::len::*;
 use super::internal::*;
+use super::len::*;
+use super::*;
 
 pub fn find<PAR_ITER, FIND_OP>(pi: PAR_ITER, find_op: FIND_OP) -> Option<PAR_ITER::Item>
     where PAR_ITER: ParallelIterator,

--- a/src/par_iter/flat_map.rs
+++ b/src/par_iter/flat_map.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::f64;
 
 pub struct FlatMap<M, MAP_OP> {

--- a/src/par_iter/fold.rs
+++ b/src/par_iter/fold.rs
@@ -1,6 +1,6 @@
-use super::*;
-use super::len::*;
 use super::internal::*;
+use super::len::*;
+use super::*;
 
 pub fn fold<U, BASE, IDENTITY, FOLD_OP>(base: BASE,
                                         identity: IDENTITY,

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -1,6 +1,6 @@
-use super::*;
-use super::len::*;
 use super::internal::*;
+use super::len::*;
+use super::*;
 
 pub trait MapOp<In>: Sync {
     type Output: Send;

--- a/src/par_iter/option.rs
+++ b/src/par_iter/option.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std;
 
 pub struct OptionIter<T: Send> {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::ops::Range;
 
 pub struct RangeIter<T> {

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::cmp::min;
 
 pub struct Skip<M> {

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 
 pub struct SliceIter<'data, T: 'data + Sync> {
     slice: &'data [T],

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 
 pub struct SliceIterMut<'data, T: 'data + Send> {
     slice: &'data mut [T],

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::str::Chars;
 
 /// Test if a byte is the start of a UTF-8 character.

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::cmp::min;
 
 pub struct Take<M> {

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use super::*;
 use super::internal::*;
+use super::*;
 
 use rand::{Rng, SeedableRng, XorShiftRng};
 use std::collections::LinkedList;

--- a/src/par_iter/vec.rs
+++ b/src/par_iter/vec.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std;
 
 pub struct VecIter<T: Send> {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 
 pub struct Weight<M> {
     base: M,

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::internal::*;
+use super::*;
 use std::cmp::min;
 use std::iter;
 


### PR DESCRIPTION
Nightly started warning that many `use super::internal::*` imports under
`par_iter` were unused -- see rust-lang/rust#38104.  It turns out that
all those modules also had `use super::*`, and `par_iter/mod.rs` has its
own `use internal::*`, so apparently this now adds to what the other
modules get.

But we can't just remove those lines, because it doesn't work for older
rustc.  Instead we can reorder it so `super::internal::*` comes first,
and nothing looks unused to the linter.