### PR TITLE
Remove the fake specialization on chain collect

### DIFF
--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -35,10 +35,15 @@ impl<A, B> ParallelIterator for ChainIter<A, B>
     }
 
     fn opt_len(&mut self) -> Option<usize> {
-        match (self.a.opt_len(), self.b.opt_len()) {
-            (Some(a_len), Some(b_len)) => a_len.checked_add(b_len),
-            _ => None,
-        }
+        // NB: Even though we could compute the indexed length as below,
+        // we can't support collect's faux `UnindexedConsumer` in our
+        // `drive_unindexed`, so we must leave this un-"specialized".
+        //
+        // match (self.a.opt_len(), self.b.opt_len()) {
+        //     (Some(a_len), Some(b_len)) => a_len.checked_add(b_len),
+        //     _ => None,
+        // }
+        None
     }
 }
 

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -931,6 +931,7 @@ pub fn check_chain() {
         .enumerate()
         .map(|(a, (b, c))| (a, b, c))
         .weight_max()
+        .chain(None)
         .collect_into(&mut res);
 
     assert_eq!(res,
@@ -947,7 +948,7 @@ pub fn check_chain() {
                     (10, 'z', -10)]);
 
     // unindexed is ok too
-    let sum = Some(1i32)
+    let res: Vec<i32> = Some(1i32)
         .into_par_iter()
         .chain((2i32..4)
             .into_par_iter()
@@ -957,8 +958,11 @@ pub fn check_chain() {
                 .flat_map(|(a, b)| a..b))
             .filter(|x| x & 1 == 1))
         .weight_max()
-        .sum();
-    assert_eq!(sum, 2500);
+        .collect();
+    let other: Vec<i32> = (0..100)
+        .filter(|x| x & 1 == 1)
+        .collect();
+    assert_eq!(res, other);
 }
 
 


### PR DESCRIPTION
`ChainIter::drive_unindexed` can't deal with the fake specialization
used by `CollectConsumer`, as it has to directly call `split_off`.  So
we must not report an `opt_len`, and thus iterators with any chaining
can't take advantage of that optimization.

However, it would be a regression if we couldn't even use `collect_into`
with chains, so we need to let that call a direct indexed `drive` again.
So refactor the entry points with `collect_into` calling `drive`, and
still `special_collect_into` calling `drive_unindexed`, with all of
their common code in a new `Collect` wrapper.

Fixes #175.