### PR TITLE
Expose the number of threads in the pool and the index of the current thread

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -234,6 +234,21 @@ impl ThreadPool {
             job_a.into_result()
         }
     }
+
+    /// Returns the number of threads in the thread pool.
+    pub fn num_threads(&self) -> usize {
+        self.registry.num_threads()
+    }
+
+    /// Returns the index of the current thread in the thread pool. Panics if
+    /// the current thread is not in this thread pool.
+    pub fn current_thread_index(&self) -> usize {
+        unsafe {
+            let curr = WorkerThread::current();
+            assert!(!curr.is_null());
+            (*curr).index()
+        }
+    }
 }
 
 impl Drop for ThreadPool {

--- a/src/test.rs
+++ b/src/test.rs
@@ -168,3 +168,12 @@ fn coerce_to_box_error() {
     // check that coercion succeeds
     let _: Box<Error> = From::from(InitError::NumberOfThreadsZero);
 }
+
+#[test]
+fn worker_thread_index() {
+    let pool = ThreadPool::new(Configuration::new().set_num_threads(22)).unwrap();
+    assert_eq!(pool.num_threads(), 22);
+    assert_eq!(pool.current_thread_index(), None);
+    let index = pool.install(|| pool.current_thread_index().unwrap());
+    assert!(index < 22);
+}

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -90,6 +90,13 @@ impl Registry {
         registry
     }
 
+    /// Returns an opaque identifier for this registry.
+    pub fn id(&self) -> RegistryId {
+        // We can rely on `self` not to change since we only ever create
+        // registries that are boxed up in an `Arc` (see `new()` above).
+        RegistryId { addr: self as *const Self as usize }
+    }
+
     pub fn num_threads(&self) -> usize {
         self.thread_infos.len()
     }
@@ -188,6 +195,11 @@ impl Registry {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RegistryId {
+    addr: usize
+}
+
 impl RegistryState {
     pub fn new() -> RegistryState {
         RegistryState {
@@ -262,6 +274,8 @@ pub struct WorkerThread {
 
     /// A weak random number generator.
     rng: rand::XorShiftRng,
+
+    registry: Arc<Registry>,
 }
 
 // This is a bit sketchy, but basically: the WorkerThread is
@@ -292,6 +306,12 @@ impl WorkerThread {
         });
     }
 
+    /// Returns the registry that owns this worker thread.
+    pub fn registry(&self) -> &Arc<Registry> {
+        &self.registry
+    }
+
+    /// Our index amongst the worker threads (ranges from `0..self.num_threads()`).
     #[inline]
     pub fn index(&self) -> usize {
         self.index
@@ -408,6 +428,7 @@ unsafe fn main_loop(worker: Worker<JobRef>, registry: Arc<Registry>, index: usiz
         index: index,
         spawn_count: Cell::new(0),
         rng: rand::weak_rng(),
+        registry: registry.clone(),
     };
     worker_thread.set_current();
 


### PR DESCRIPTION
Per discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=1323372

We need either this or #185, but not both.

CC @emilio