### PR TITLE
Add a string `par_split` method for `char` separators

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -134,10 +134,15 @@ pub trait ToParallelChunksMut<'data> {
 
 /// Parallel extensions for strings.
 pub trait ParallelString {
-    type Chars;
+    type Chars: ParallelIterator;
+    type Split: ParallelIterator;
 
     /// Returns a parallel iterator over the characters of a string.
     fn par_chars(self) -> Self::Chars;
+
+    /// Returns a parallel iterator over substrings separated by a
+    /// given character, similar to `str::split`.
+    fn par_split(self, char) -> Self::Split;
 }
 
 /// The `ParallelIterator` interface.

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -29,6 +29,8 @@ use self::internal::*;
 use self::weight::Weight;
 use self::zip::ZipIter;
 
+pub use self::string::ParallelString;
+
 pub mod find;
 pub mod chain;
 pub mod collect;
@@ -130,19 +132,6 @@ pub trait ToParallelChunksMut<'data> {
     /// implementation should strive to maximize chunk size when
     /// possible.
     fn par_chunks_mut(&'data mut self, size: usize) -> Self::Iter;
-}
-
-/// Parallel extensions for strings.
-pub trait ParallelString {
-    type Chars: ParallelIterator;
-    type Split: ParallelIterator;
-
-    /// Returns a parallel iterator over the characters of a string.
-    fn par_chars(self) -> Self::Chars;
-
-    /// Returns a parallel iterator over substrings separated by a
-    /// given character, similar to `str::split`.
-    fn par_split(self, char) -> Self::Split;
 }
 
 /// The `ParallelIterator` interface.

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -112,16 +112,16 @@ macro_rules! unindexed_range_impl {
         }
 
         impl UnindexedProducer for RangeIter<$t> {
-            fn can_split(&self) -> bool {
-                self.len() > 1
-            }
-
-            fn split(self) -> (Self, Self) {
+            fn split(&mut self) -> Option<Self> {
                 let index = self.len() / 2;
-                let mid = self.range.start.wrapping_add(index as $t);
-                let left = self.range.start .. mid;
-                let right = mid .. self.range.end;
-                (RangeIter { range: left }, RangeIter { range: right })
+                if index > 0 {
+                    let mid = self.range.start.wrapping_add(index as $t);
+                    let right = mid .. self.range.end;
+                    self.range.end = mid;
+                    Some(RangeIter { range: right })
+                } else {
+                    None
+                }
             }
         }
     }

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -240,7 +240,10 @@ impl<'a> UnindexedProducer for ParSplitTerminator<'a> {
         self.splitter.split().map(|right| {
             let endpoint = self.endpoint;
             self.endpoint = false;
-            ParSplitTerminator { splitter: right, endpoint: endpoint }
+            ParSplitTerminator {
+                splitter: right,
+                endpoint: endpoint,
+            }
         })
     }
 }
@@ -280,12 +283,15 @@ impl<'a> ParallelIterator for ParLines<'a> {
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        self.0.par_split_terminator('\n').map(|line| {
-            if line.ends_with('\r') {
-                &line[..line.len() - 1]
-            } else {
-                line
-            }
-        }).drive_unindexed(consumer)
+        self.0
+            .par_split_terminator('\n')
+            .map(|line| {
+                if line.ends_with('\r') {
+                    &line[..line.len() - 1]
+                } else {
+                    line
+                }
+            })
+            .drive_unindexed(consumer)
     }
 }

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -31,26 +31,20 @@ fn find_char_midpoint(chars: &str) -> usize {
 
 /// Parallel extensions for strings.
 pub trait ParallelString {
-    type Chars: ParallelIterator;
-    type Split: ParallelIterator;
-
     /// Returns a parallel iterator over the characters of a string.
-    fn par_chars(self) -> Self::Chars;
+    fn par_chars(&self) -> ParChars;
 
     /// Returns a parallel iterator over substrings separated by a
     /// given character, similar to `str::split`.
-    fn par_split(self, char) -> Self::Split;
+    fn par_split(&self, char) -> ParSplit;
 }
 
-impl<'a> ParallelString for &'a str {
-    type Chars = ParChars<'a>;
-    type Split = ParSplit<'a>;
-
-    fn par_chars(self) -> Self::Chars {
+impl ParallelString for str {
+    fn par_chars(&self) -> ParChars {
         ParChars { chars: self }
     }
 
-    fn par_split(self, separator: char) -> Self::Split {
+    fn par_split(&self, separator: char) -> ParSplit {
         ParSplit::new(self, separator)
     }
 }

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -29,6 +29,19 @@ fn find_char_midpoint(chars: &str) -> usize {
 }
 
 
+/// Parallel extensions for strings.
+pub trait ParallelString {
+    type Chars: ParallelIterator;
+    type Split: ParallelIterator;
+
+    /// Returns a parallel iterator over the characters of a string.
+    fn par_chars(self) -> Self::Chars;
+
+    /// Returns a parallel iterator over substrings separated by a
+    /// given character, similar to `str::split`.
+    fn par_split(self, char) -> Self::Split;
+}
+
 impl<'a> ParallelString for &'a str {
     type Chars = ParChars<'a>;
     type Split = ParSplit<'a>;

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -1,6 +1,8 @@
 use super::internal::*;
 use super::*;
-use std::str::Chars;
+use std::cmp::max;
+use std::iter::{self, Chain, Once};
+use std::str::{Chars, Split};
 
 /// Test if a byte is the start of a UTF-8 character.
 /// (extracted from `str::is_char_boundary`)
@@ -9,15 +11,38 @@ fn is_char_boundary(b: u8) -> bool {
     (b as i8) >= -0x40
 }
 
+/// Find the index of a character boundary near the midpoint.
+fn find_char_midpoint(chars: &str) -> usize {
+    let mid = chars.len() / 2;
+
+    // We want to split near the midpoint, but we need to find an actual
+    // character boundary.  So we look at the raw bytes, first scanning
+    // forward from the midpoint for a boundary, then trying backward.
+    let (left, right) = chars.as_bytes().split_at(mid);
+    right.iter()
+        .cloned()
+        .position(is_char_boundary)
+        .map(|i| mid + i)
+        .or_else(|| left.iter().cloned().rposition(is_char_boundary))
+        .unwrap_or(0)
+}
+
 
 impl<'a> ParallelString for &'a str {
     type Chars = ParChars<'a>;
+    type Split = ParSplit<'a>;
 
     fn par_chars(self) -> Self::Chars {
         ParChars { chars: self }
     }
+
+    fn par_split(self, separator: char) -> Self::Split {
+        ParSplit::new(self, separator)
+    }
 }
 
+
+// /////////////////////////////////////////////////////////////////////////
 
 pub struct ParChars<'a> {
     chars: &'a str,
@@ -42,19 +67,7 @@ impl<'a> UnindexedProducer for ParChars<'a> {
     }
 
     fn split(self) -> (Self, Self) {
-        let mid = self.chars.len() / 2;
-
-        // We want to split near the midpoint, but we need to find an actual
-        // character boundary.  So we look at the raw bytes, first scanning
-        // forward from the midpoint for a boundary, then trying backward.
-        let (left, right) = self.chars.as_bytes().split_at(mid);
-        let index = right.iter()
-            .cloned()
-            .position(is_char_boundary)
-            .map(|i| mid + i)
-            .or_else(|| left.iter().cloned().rposition(is_char_boundary))
-            .unwrap_or(0);
-
+        let index = find_char_midpoint(self.chars);
         let (left, right) = self.chars.split_at(index);
         (ParChars { chars: left }, ParChars { chars: right })
     }
@@ -66,5 +79,105 @@ impl<'a> IntoIterator for ParChars<'a> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.chars.chars()
+    }
+}
+
+
+// /////////////////////////////////////////////////////////////////////////
+
+pub struct ParSplit<'a> {
+    chars: &'a str,
+    separator: char,
+
+    /// Keeps track of the first separator found in the string.  This lets us
+    /// quickly answer `can_split`, and it also corresponds to what parts we've
+    /// already scanned as we keep splitting smaller.
+    first: Option<usize>,
+}
+
+impl<'a> ParSplit<'a> {
+    fn new(chars: &'a str, separator: char) -> Self {
+        ParSplit {
+            chars: chars,
+            separator: separator,
+            first: chars.find(separator),
+        }
+    }
+}
+
+impl<'a> ParallelIterator for ParSplit<'a> {
+    type Item = &'a str;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge_unindexed(self, consumer)
+    }
+}
+
+impl<'a> UnindexedProducer for ParSplit<'a> {
+    fn can_split(&self) -> bool {
+        self.first.is_some()
+    }
+
+    fn split(self) -> (Self, Self) {
+        let ParSplit { chars, separator, first } = self;
+        let first = first.expect("error: splitting with no separator present!");
+
+        // First find a suitable UTF-8 boundary in the unsearched region.
+        let char_index = find_char_midpoint(&chars[first..]) + first;
+
+        // Find a separator in reverse, towards the `first` that we know exists.
+        let index = chars[first..char_index]
+            .rfind(separator)
+            .map(|i| i + first)
+            .unwrap_or(first);
+
+        // Create the left side of the split.  It might not have a `first` anymore
+        // if that's the exact separator we're splitting on now.
+        let left_first = if first < index { Some(first) } else { None };
+        let left_split = ParSplit {
+            chars: &chars[..index],
+            separator: separator,
+            first: left_first,
+        };
+
+        // Create the right side of the split starting just after this separator.
+        // We find its `first` starting from the `char_index` already scanned above.
+        let right_index = index + separator.len_utf8();
+        let right_search = max(char_index, right_index);
+        let right_first = chars[right_search..]
+            .find(separator)
+            .map(|i| i + (right_search - right_index));
+        let right_split = ParSplit {
+            chars: &chars[right_index..],
+            separator: separator,
+            first: right_first,
+        };
+
+        // All done, now we are two!
+        (left_split, right_split)
+    }
+}
+
+impl<'a> IntoIterator for ParSplit<'a> {
+    type Item = &'a str;
+    type IntoIter = Chain<Once<&'a str>, Split<'a, char>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        if let Some(first) = self.first {
+            // We know where the first separator is, so start with that
+            // and then let `str::split` find the rest.
+            let head = &self.chars[..first];
+            let tail = &self.chars[first + self.separator.len_utf8()..];
+            iter::once(head).chain(tail.split(self.separator))
+        } else {
+            // We know there are no separators at all.  Return our whole string,
+            // but for type correctness we need to chain an emptied `Split` too.
+            let head = self.chars;
+            let mut tail = "".split('\0');
+            Iterator::last(&mut tail);
+            iter::once(head).chain(tail)
+        }
     }
 }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -70,7 +70,7 @@ pub fn execute_strings() {
 
 #[test]
 pub fn execute_strings_split() {
-    // char testcases from `str::split` and `split_terminator` examples,
+    // char testcases from examples in `str::split` etc.,
     // plus a large self-test for good measure.
     let tests = vec![("Mary had a little lamb", ' '),
                      ("", 'X'),
@@ -81,6 +81,8 @@ pub fn execute_strings_split() {
                      ("    a  b c", ' '),
                      ("A.B.", '.'),
                      ("A..B..", '.'),
+                     ("foo\r\nbar\n\nbaz\n", '\n'),
+                     ("foo\nbar\n\r\nbaz", '\n'),
                      (include_str!("test.rs"), ' ')];
 
     for &(string, separator) in &tests {
@@ -92,6 +94,12 @@ pub fn execute_strings_split() {
     for &(string, separator) in &tests {
         let serial: Vec<_> = string.split_terminator(separator).collect();
         let parallel: Vec<_> = string.par_split_terminator(separator).collect();
+        assert_eq!(serial, parallel);
+    }
+
+    for &(string, _) in &tests {
+        let serial: Vec<_> = string.lines().collect();
+        let parallel: Vec<_> = string.par_lines().collect();
         assert_eq!(serial, parallel);
     }
 }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -69,6 +69,26 @@ pub fn execute_strings() {
 }
 
 #[test]
+pub fn execute_strings_split() {
+    // char testcases from `str::split` examples,
+    // plus a large self-test for good measure.
+    let tests = vec![("Mary had a little lamb", ' '),
+                     ("", 'X'),
+                     ("lionXXtigerXleopard", 'X'),
+                     ("||||a||b|c", '|'),
+                     ("(///)", '/'),
+                     ("010", '0'),
+                     ("    a  b c", ' '),
+                     (include_str!("test.rs"), ' ')];
+
+    for (string, separator) in tests {
+        let serial: Vec<_> = string.split(separator).collect();
+        let parallel: Vec<_> = string.par_split(separator).collect();
+        assert_eq!(serial, parallel);
+    }
+}
+
+#[test]
 pub fn check_map_exact_and_bounded() {
     let a = [1, 2, 3];
     is_bounded(a.par_iter().map(|x| x));

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -70,7 +70,7 @@ pub fn execute_strings() {
 
 #[test]
 pub fn execute_strings_split() {
-    // char testcases from `str::split` examples,
+    // char testcases from `str::split` and `split_terminator` examples,
     // plus a large self-test for good measure.
     let tests = vec![("Mary had a little lamb", ' '),
                      ("", 'X'),
@@ -79,11 +79,19 @@ pub fn execute_strings_split() {
                      ("(///)", '/'),
                      ("010", '0'),
                      ("    a  b c", ' '),
+                     ("A.B.", '.'),
+                     ("A..B..", '.'),
                      (include_str!("test.rs"), ' ')];
 
-    for (string, separator) in tests {
+    for &(string, separator) in &tests {
         let serial: Vec<_> = string.split(separator).collect();
         let parallel: Vec<_> = string.par_split(separator).collect();
+        assert_eq!(serial, parallel);
+    }
+
+    for &(string, separator) in &tests {
+        let serial: Vec<_> = string.split_terminator(separator).collect();
+        let parallel: Vec<_> = string.par_split_terminator(separator).collect();
         assert_eq!(serial, parallel);
     }
 }


### PR DESCRIPTION
This should give the exact same result at `str::split`, just in parallel!  But we only support a plain `char` for the separator right now, versus the fancy `str::Pattern` trait.  The test cases are taken from the `str::split` docstring, as well as a split on `test.rs` itself for something larger.