### PR TITLE
Fix some compiler warnings from find_first/last

### DIFF
--- a/src/par_iter/find_first_last/mod.rs
+++ b/src/par_iter/find_first_last/mod.rs
@@ -225,7 +225,7 @@ impl<'f, FIND_OP: 'f + Fn(&ITEM) -> bool, ITEM> Folder<ITEM> for FindFolder<'f, 
 fn find_first_folder_does_not_clobber_first_found() {
     let best_found = AtomicUsize::new(usize::max_value());
     let f = FindFolder {
-        find_op: &(|&x: &i32| -> bool { true }),
+        find_op: &(|&_: &i32| -> bool { true }),
         boundary: 0,
         match_position: MatchPosition::Leftmost,
         best_found: &best_found,
@@ -240,7 +240,7 @@ fn find_first_folder_does_not_clobber_first_found() {
 fn find_last_folder_yields_last_match() {
     let best_found = AtomicUsize::new(0);
     let f = FindFolder {
-        find_op: &(|&x: &i32| -> bool { true }),
+        find_op: &(|&_: &i32| -> bool { true }),
         boundary: 0,
         match_position: MatchPosition::Rightmost,
         best_found: &best_found,

--- a/src/par_iter/find_first_last/test.rs
+++ b/src/par_iter/find_first_last/test.rs
@@ -13,7 +13,7 @@ fn same_range_first_consumers_return_correct_answer() {
 
     // split until we have an indivisible range
     let bits_in_usize = usize::min_value().count_zeros();
-    for i in 0..bits_in_usize {
+    for _ in 0..bits_in_usize {
         consumer.split_off();
     }
 
@@ -46,7 +46,7 @@ fn same_range_last_consumers_return_correct_answer() {
 
     // split until we have an indivisible range
     let bits_in_usize = usize::min_value().count_zeros();
-    for i in 0..bits_in_usize {
+    for _ in 0..bits_in_usize {
         consumer.split_off();
     }
 


### PR DESCRIPTION
I just found a few compiler warnings I forgot about from find_first/find_last that I went ahead and fixed.