### PR TITLE
Give one last tickle to terminated registries

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -181,6 +181,7 @@ impl Registry {
     /// extant work is completed.
     pub fn terminate(&self) {
         self.terminate_latch.set();
+        self.sleep.tickle(usize::MAX);
     }
 }
 

--- a/src/thread_pool/test.rs
+++ b/src/thread_pool/test.rs
@@ -34,3 +34,22 @@ fn workers_stop() {
     // should lead to worker threads stopping
     registry.wait_until_stopped();
 }
+
+#[test]
+fn sleeper_stop() {
+    use std::{thread, time};
+
+    let registry;
+
+    { // once we exit this block, thread-pool will be dropped
+        let thread_pool = ThreadPool::new(Configuration::new().set_num_threads(22)).unwrap();
+        registry = thread_pool.registry.clone();
+
+        // Give time for at least some of the thread pool to fall asleep.
+        thread::sleep(time::Duration::from_secs(1));
+    }
+
+    // once thread-pool is dropped, registry should terminate, which
+    // should lead to worker threads stopping
+    registry.wait_until_stopped();
+}


### PR DESCRIPTION
`Registry::terminate` was merely setting `terminate_latch`, leaving
sleeping threads in an eternal slumber.  Normally that would just amount
to a resource leak, but `thread_pool::test::workers_stop` will stall
waiting for every thread to stop.  We just need a `tickle` to make sure
every thread will wake up and exit.

Fixes #200.