### PR TITLE
Add support for naming threads

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -47,18 +47,34 @@ impl Error for InitError {
 pub struct Configuration {
     /// The number of threads in the rayon thread pool. Must not be zero.
     num_threads: Option<usize>,
+    base_thread_name: Option<String>,
 }
 
 impl Configuration {
     /// Creates and return a valid rayon thread pool configuration, but does not initialize it.
     pub fn new() -> Configuration {
-        Configuration { num_threads: None }
+        Configuration {
+            num_threads: None,
+            base_thread_name: None,
+        }
     }
 
     /// Get the number of threads that will be used for the thread
     /// pool. See `set_num_threads` for more information.
     pub fn num_threads(&self) -> Option<usize> {
         self.num_threads
+    }
+
+    /// Get the base thread name for this configuration.
+    pub fn base_thread_name(&self) -> Option<&str> {
+        self.base_thread_name.as_ref().map(String::as_str)
+    }
+
+    /// Set the base thread name. Each thread will get
+    /// the name `format!("{}{}", base_name, i)`.
+    pub fn set_base_thread_name(mut self, base_thread_name: String) -> Self {
+        self.base_thread_name = Some(base_thread_name);
+        self
     }
 
     /// Set the number of threads to be used in the rayon threadpool.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -104,13 +104,11 @@ impl Registry {
 
         for (index, worker) in workers.into_iter().enumerate() {
             let registry = registry.clone();
+            let mut b = thread::Builder::new();
             if let Some(name) = configuration.base_thread_name(index) {
-                let _ = thread::Builder::new()
-                    .name(name)
-                    .spawn(move || unsafe { main_loop(worker, registry, index) });
-            } else {
-                thread::spawn(move || unsafe { main_loop(worker, registry, index) });
+                b = b.name(name);
             }
+            b.spawn(move || unsafe { main_loop(worker, registry, index) });
         }
 
         registry

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -78,7 +78,7 @@ unsafe fn init_registry(config: Configuration) {
 }
 
 impl Registry {
-    pub fn new(configuration: Configuration) -> Arc<Registry> {
+    pub fn new(mut configuration: Configuration) -> Arc<Registry> {
         let limit_value = match configuration.num_threads() {
             Some(value) => value,
             None => {
@@ -104,9 +104,9 @@ impl Registry {
 
         for (index, worker) in workers.into_iter().enumerate() {
             let registry = registry.clone();
-            if let Some(name) = configuration.base_thread_name() {
+            if let Some(name) = configuration.base_thread_name(index) {
                 let _ = thread::Builder::new()
-                    .name(format!("{}{}", name, index))
+                    .name(name)
                     .spawn(move || unsafe { main_loop(worker, registry, index) });
             } else {
                 thread::spawn(move || unsafe { main_loop(worker, registry, index) });

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -108,7 +108,8 @@ impl Registry {
             if let Some(name) = configuration.base_thread_name(index) {
                 b = b.name(name);
             }
-            b.spawn(move || unsafe { main_loop(worker, registry, index) });
+            // FIXME(#205) recover from this error
+            b.spawn(move || unsafe { main_loop(worker, registry, index) }).unwrap();
         }
 
         registry

--- a/src/thread_pool/mod.rs
+++ b/src/thread_pool/mod.rs
@@ -18,7 +18,7 @@ impl ThreadPool {
     /// result.  See `InitError` for more details.
     pub fn new(configuration: Configuration) -> Result<ThreadPool, InitError> {
         try!(configuration.validate());
-        Ok(ThreadPool { registry: Registry::new(configuration.num_threads()) })
+        Ok(ThreadPool { registry: Registry::new(configuration) })
     }
 
     /// Executes `op` within the threadpool. Any attempts to use

--- a/tests/run-pass/named-threads.rs
+++ b/tests/run-pass/named-threads.rs
@@ -1,0 +1,23 @@
+extern crate rayon;
+
+use std::collections::HashSet;
+
+use rayon::*;
+use rayon::prelude::*;
+
+fn long_function() {
+    ::std::thread::sleep(::std::time::Duration::new(4, 0))
+}
+
+fn main() {
+    let result = initialize(Configuration::new().set_base_thread_name(|i| format!("hello-name-test-{}", i)));
+
+    const N: usize = 10000;
+
+    let thread_names = (0..N).into_par_iter()
+        .flat_map(|_| ::std::thread::current().name().map(|s| s.to_owned()))
+        .collect::<HashSet<String>>();
+
+    let all_contains_name = thread_names.iter().all(|name| name.starts_with("hello-name-test-"));
+    assert!(all_contains_name);
+}


### PR DESCRIPTION
This PR adds support for specifying names for rayon threads, and fixes issue #142.

Most notable things are:
 - `Registry::new` takes the entire `Configuration`, not just the number of threads
 - The thread name is `format!("{}{}", name, i)`

I found it difficult to test the thread naming. Any ideas?