### PR TITLE
Rename `base_thread_name` to `thread_name`

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -46,7 +46,7 @@ impl Error for InitError {
 pub struct Configuration {
     /// The number of threads in the rayon thread pool. Must not be zero.
     num_threads: Option<usize>,
-    get_base_thread_name: Option<Box<FnMut(usize) -> String>>,
+    get_thread_name: Option<Box<FnMut(usize) -> String>>,
 }
 
 impl Configuration {
@@ -54,7 +54,7 @@ impl Configuration {
     pub fn new() -> Configuration {
         Configuration {
             num_threads: None,
-            get_base_thread_name: None,
+            get_thread_name: None,
         }
     }
 
@@ -65,15 +65,15 @@ impl Configuration {
     }
 
     /// Get the base thread name for the given index.
-    pub fn base_thread_name(&mut self, index: usize) -> Option<String> {
-        self.get_base_thread_name.as_mut().map(|c| c(index))
+    pub fn thread_name(&mut self, index: usize) -> Option<String> {
+        self.get_thread_name.as_mut().map(|c| c(index))
     }
 
     /// Set a closure which takes the thread index and return
     /// the threads name.
-    pub fn set_base_thread_name<F>(mut self, closure: F) -> Self
+    pub fn set_thread_name<F>(mut self, closure: F) -> Self
     where F: FnMut(usize) -> String + 'static {
-        self.get_base_thread_name = Some(Box::new(closure));
+        self.get_thread_name = Some(Box::new(closure));
         self
     }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -64,13 +64,13 @@ impl Configuration {
         self.num_threads
     }
 
-    /// Get the base thread name for the given index.
+    /// Get the thread name for the thread with the given index.
     pub fn thread_name(&mut self, index: usize) -> Option<String> {
         self.get_thread_name.as_mut().map(|c| c(index))
     }
 
-    /// Set a closure which takes the thread index and return
-    /// the threads name.
+    /// Set a closure which takes a thread index and returns
+    /// the thread's name.
     pub fn set_thread_name<F>(mut self, closure: F) -> Self
     where F: FnMut(usize) -> String + 'static {
         self.get_thread_name = Some(Box::new(closure));

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -105,7 +105,7 @@ impl Registry {
         for (index, worker) in workers.into_iter().enumerate() {
             let registry = registry.clone();
             let mut b = thread::Builder::new();
-            if let Some(name) = configuration.base_thread_name(index) {
+            if let Some(name) = configuration.thread_name(index) {
                 b = b.name(name);
             }
             // FIXME(#205) recover from this error

--- a/tests/run-pass/named-threads.rs
+++ b/tests/run-pass/named-threads.rs
@@ -5,12 +5,8 @@ use std::collections::HashSet;
 use rayon::*;
 use rayon::prelude::*;
 
-fn long_function() {
-    ::std::thread::sleep(::std::time::Duration::new(4, 0))
-}
-
 fn main() {
-    let result = initialize(Configuration::new().set_base_thread_name(|i| format!("hello-name-test-{}", i)));
+    let result = initialize(Configuration::new().set_thread_name(|i| format!("hello-name-test-{}", i)));
 
     const N: usize = 10000;
 


### PR DESCRIPTION
This was missed while merging #202 😄 