### PR TITLE
Fork into `rayon-core` and a stable `rayon` facade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 script:
   - cargo build
   - |
-    ( cd rayon-stable && cargo build )
+    ( cd rayon-stable && cargo build && cargo clean )
   - |
     [ $TRAVIS_RUST_VERSION != nightly ] ||
     cargo test && cargo clean

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rust:
 script:
   - cargo build
   - |
+    ( cd rayon-stable && cargo build )
+  - |
     [ $TRAVIS_RUST_VERSION != nightly ] ||
     cargo test && cargo clean
   - |
@@ -13,4 +15,4 @@ script:
     cargo test --features "unstable"
   - |
     [ $TRAVIS_RUST_VERSION != nightly ] ||
-    ( cd rayon-demo && cargo test && cd ../../ )
+    ( cd rayon-demo && cargo test )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "rayon"
-version = "0.6.0"
+name = "rayon-core"
+version = "0.7.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 description = "Simple work-stealing parallelism for Rust"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/nikomatsakis/rayon"
-documentation = "https://docs.rs/rayon/"
+documentation = "https://docs.rs/rayon-core/"
 
 [workspace]
-members = [ "rayon-demo" ]
+members = [ "rayon-demo", "rayon-stable" ]
 
 [dependencies]
 rand = "0.3"

--- a/examples/cpu_monitor.rs
+++ b/examples/cpu_monitor.rs
@@ -34,10 +34,9 @@ pub struct Args {
 }
 
 fn main() {
-    let args: &Args =
-        &Docopt::new(USAGE)
-            .and_then(|d| d.argv(env::args()).decode())
-            .unwrap_or_else(|e| e.exit());
+    let args: &Args = &Docopt::new(USAGE)
+        .and_then(|d| d.argv(env::args()).decode())
+        .unwrap_or_else(|e| e.exit());
 
     match &args.arg_scenario[..] {
         "tasks_ended" => tasks_ended(args),

--- a/examples/cpu_monitor.rs
+++ b/examples/cpu_monitor.rs
@@ -1,5 +1,5 @@
 extern crate docopt;
-extern crate rayon;
+extern crate rayon_core as rayon;
 extern crate rustc_serialize;
 
 use docopt::Docopt;
@@ -87,7 +87,7 @@ fn task_stall_scope(args: &Args) {
 }
 
 #[cfg(not(feature = "unstable"))]
-fn task_stall_scope(args: &Args) {
+fn task_stall_scope(_args: &Args) {
     println!("try `cargo run` with `--features unstable`");
     process::exit(1);
 }

--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
 [dependencies]
-rayon = { path = "../", features = ["unstable"] }
+rayon = { path = "../rayon-stable" }
 cgmath = "0.11"
 docopt = "0.6"
 glium = "0.15"

--- a/rayon-demo/src/factorial/mod.rs
+++ b/rayon-demo/src/factorial/mod.rs
@@ -1,7 +1,5 @@
 //! Benchmark Factorial N! = 1×2×⋯×N
 
-#![feature(test)]
-
 use num::{One, BigUint};
 use rayon;
 use rayon::prelude::*;

--- a/rayon-demo/src/pythagoras/mod.rs
+++ b/rayon-demo/src/pythagoras/mod.rs
@@ -1,8 +1,6 @@
 //! How many Pythagorean triples exist less than or equal to a million?
 //! i.e. a²+b²=c² and a,b,c ≤ 1000000
 
-#![feature(test)]
-
 use num::Integer;
 use rayon::prelude::*;
 use std::f64::INFINITY;

--- a/rayon-stable/Cargo.toml
+++ b/rayon-stable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rayon"
+version = "0.7.0"
+authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+description = "Simple work-stealing parallelism for Rust"
+license = "Apache-2.0/MIT"
+repository = "https://github.com/nikomatsakis/rayon"
+documentation = "https://docs.rs/rayon/"
+
+[dependencies]
+rayon-core = { version = "0.7", path = "../" }

--- a/rayon-stable/src/lib.rs
+++ b/rayon-stable/src/lib.rs
@@ -1,0 +1,13 @@
+extern crate rayon_core;
+
+pub mod par_iter;
+
+pub use rayon_core::prelude;
+
+pub use rayon_core::Configuration;
+pub use rayon_core::InitError;
+pub use rayon_core::dump_stats;
+pub use rayon_core::initialize;
+pub use rayon_core::ThreadPool;
+pub use rayon_core::join;
+pub use rayon_core::{scope, Scope};

--- a/rayon-stable/src/par_iter.rs
+++ b/rayon-stable/src/par_iter.rs
@@ -1,0 +1,19 @@
+//! The `ParallelIterator` module makes it easy to write parallel programs
+//! using an iterator-style interface. To get access to all the methods you
+//! want, the easiest is to write `use rayon::prelude::*;` at the top of your
+//! module, which will import the various traits and methods you need.
+
+pub use rayon_core::par_iter::IntoParallelIterator;
+pub use rayon_core::par_iter::IntoParallelRefIterator;
+pub use rayon_core::par_iter::IntoParallelRefMutIterator;
+pub use rayon_core::par_iter::ParallelIterator;
+pub use rayon_core::par_iter::BoundedParallelIterator;
+pub use rayon_core::par_iter::ExactParallelIterator;
+pub use rayon_core::par_iter::IndexedParallelIterator;
+
+pub use rayon_core::par_iter::ToParallelChunks;
+pub use rayon_core::par_iter::ToParallelChunksMut;
+
+pub use rayon_core::par_iter::ParallelString;
+
+pub use rayon_core::par_iter::FromParallelIterator;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -141,4 +141,3 @@ pub fn initialize(config: Configuration) -> Result<(), InitError> {
 pub fn dump_stats() {
     dump_stats!();
 }
-

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -98,8 +98,7 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
 unsafe fn join_recover_from_panic(worker_thread: &WorkerThread,
                                   job_b_latch: &SpinLatch,
                                   err: Box<Any + Send>)
-                                  -> !
-{
+                                  -> ! {
     worker_thread.wait_until(job_b_latch);
     unwind::resume_unwinding(err)
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -11,7 +11,11 @@ use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 pub enum Event {
     Tickle { worker: usize, old_state: usize },
     GetSleepy { worker: usize, state: usize },
-    GotSleepy { worker: usize, old_state: usize, new_state: usize },
+    GotSleepy {
+        worker: usize,
+        old_state: usize,
+        new_state: usize,
+    },
     GotAwoken { worker: usize },
     FellAsleep { worker: usize },
     GotInterrupted { worker: usize },

--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::cmp::min;
 use std::iter;
@@ -20,9 +19,9 @@ impl<A, B> ChainIter<A, B>
     }
 }
 
-impl<A, B> ParallelIterator for ChainIter<A, B>
-    where A: ParallelIterator,
-          B: ParallelIterator<Item = A::Item>
+impl<A, B> ParallelIteratorImpl for ChainIter<A, B>
+    where A: ParallelIteratorImpl,
+          B: ParallelIteratorImpl<Item = A::Item>
 {
     type Item = A::Item;
 
@@ -48,12 +47,12 @@ impl<A, B> ParallelIterator for ChainIter<A, B>
     }
 }
 
-impl<A, B> BoundedParallelIterator for ChainIter<A, B>
-    where A: BoundedParallelIterator,
-          B: BoundedParallelIterator<Item = A::Item>
+impl<A, B> BoundedParallelIteratorImpl for ChainIter<A, B>
+    where A: BoundedParallelIteratorImpl,
+          B: BoundedParallelIteratorImpl<Item = A::Item>
 {
-    fn upper_bound(&mut self) -> usize {
-        self.a.upper_bound() + self.b.upper_bound()
+    fn impl_upper_bound(&mut self) -> usize {
+        self.a.impl_upper_bound() + self.b.impl_upper_bound()
     }
 
     fn drive<C>(mut self, consumer: C) -> C::Result
@@ -66,18 +65,18 @@ impl<A, B> BoundedParallelIterator for ChainIter<A, B>
     }
 }
 
-impl<A, B> ExactParallelIterator for ChainIter<A, B>
-    where A: ExactParallelIterator,
-          B: ExactParallelIterator<Item = A::Item>
+impl<A, B> ExactParallelIteratorImpl for ChainIter<A, B>
+    where A: ExactParallelIteratorImpl,
+          B: ExactParallelIteratorImpl<Item = A::Item>
 {
-    fn len(&mut self) -> usize {
-        self.a.len() + self.b.len()
+    fn impl_len(&mut self) -> usize {
+        self.a.impl_len() + self.b.impl_len()
     }
 }
 
-impl<A, B> IndexedParallelIterator for ChainIter<A, B>
-    where A: IndexedParallelIterator,
-          B: IndexedParallelIterator<Item = A::Item>
+impl<A, B> IndexedParallelIteratorImpl for ChainIter<A, B>
+    where A: IndexedParallelIteratorImpl,
+          B: IndexedParallelIteratorImpl<Item = A::Item>
 {
     fn with_producer<CB>(mut self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -96,7 +95,7 @@ impl<A, B> IndexedParallelIterator for ChainIter<A, B>
         }
 
         impl<CB, B> ProducerCallback<B::Item> for CallbackA<CB, B>
-            where B: IndexedParallelIterator,
+            where B: IndexedParallelIteratorImpl,
                   CB: ProducerCallback<B::Item>
         {
             type Output = CB::Output;

--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -188,7 +188,7 @@ impl<A, B> Producer for ChainProducer<A, B>
     }
 
     fn fold_with<F>(self, mut folder: F) -> F
-        where F: Folder<A::Item>,
+        where F: Folder<A::Item>
     {
         folder = self.a.fold_with(folder);
         if folder.full() {

--- a/src/par_iter/collect/mod.rs
+++ b/src/par_iter/collect/mod.rs
@@ -1,5 +1,4 @@
-use super::{ParallelIterator, ExactParallelIterator, IntoParallelIterator};
-use super::from_par_iter::FromParallelIterator;
+use super::*;
 use std::collections::LinkedList;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/par_iter/enumerate.rs
+++ b/src/par_iter/enumerate.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::iter;
 use std::ops::RangeFrom;
@@ -13,7 +12,7 @@ impl<M> Enumerate<M> {
     }
 }
 
-impl<M> ParallelIterator for Enumerate<M>
+impl<M> ParallelIteratorImpl for Enumerate<M>
     where M: IndexedParallelIterator
 {
     type Item = (usize, M::Item);
@@ -29,10 +28,10 @@ impl<M> ParallelIterator for Enumerate<M>
     }
 }
 
-impl<M> BoundedParallelIterator for Enumerate<M>
+impl<M> BoundedParallelIteratorImpl for Enumerate<M>
     where M: IndexedParallelIterator
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.len()
     }
 
@@ -41,15 +40,15 @@ impl<M> BoundedParallelIterator for Enumerate<M>
     }
 }
 
-impl<M> ExactParallelIterator for Enumerate<M>
+impl<M> ExactParallelIteratorImpl for Enumerate<M>
     where M: IndexedParallelIterator
 {
-    fn len(&mut self) -> usize {
+    fn impl_len(&mut self) -> usize {
         self.base.len()
     }
 }
 
-impl<M> IndexedParallelIterator for Enumerate<M>
+impl<M> IndexedParallelIteratorImpl for Enumerate<M>
     where M: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output

--- a/src/par_iter/filter.rs
+++ b/src/par_iter/filter.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::len::*;
 use super::*;
 
@@ -16,8 +15,8 @@ impl<M, FILTER_OP> Filter<M, FILTER_OP> {
     }
 }
 
-impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
-    where M: ParallelIterator,
+impl<M, FILTER_OP> ParallelIteratorImpl for Filter<M, FILTER_OP>
+    where M: ParallelIteratorImpl,
           FILTER_OP: Fn(&M::Item) -> bool + Sync
 {
     type Item = M::Item;
@@ -30,11 +29,11 @@ impl<M, FILTER_OP> ParallelIterator for Filter<M, FILTER_OP>
     }
 }
 
-impl<M, FILTER_OP> BoundedParallelIterator for Filter<M, FILTER_OP>
-    where M: BoundedParallelIterator,
+impl<M, FILTER_OP> BoundedParallelIteratorImpl for Filter<M, FILTER_OP>
+    where M: BoundedParallelIteratorImpl,
           FILTER_OP: Fn(&M::Item) -> bool + Sync
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 

--- a/src/par_iter/filter_map.rs
+++ b/src/par_iter/filter_map.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::len::*;
 use super::*;
 
@@ -16,8 +15,8 @@ impl<M, FILTER_OP> FilterMap<M, FILTER_OP> {
     }
 }
 
-impl<M, FILTER_OP, R> ParallelIterator for FilterMap<M, FILTER_OP>
-    where M: ParallelIterator,
+impl<M, FILTER_OP, R> ParallelIteratorImpl for FilterMap<M, FILTER_OP>
+    where M: ParallelIteratorImpl,
           FILTER_OP: Fn(M::Item) -> Option<R> + Sync,
           R: Send
 {
@@ -31,12 +30,12 @@ impl<M, FILTER_OP, R> ParallelIterator for FilterMap<M, FILTER_OP>
     }
 }
 
-impl<M, FILTER_OP, R> BoundedParallelIterator for FilterMap<M, FILTER_OP>
-    where M: BoundedParallelIterator,
+impl<M, FILTER_OP, R> BoundedParallelIteratorImpl for FilterMap<M, FILTER_OP>
+    where M: BoundedParallelIteratorImpl,
           FILTER_OP: Fn(M::Item) -> Option<R> + Sync,
           R: Send
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 

--- a/src/par_iter/find.rs
+++ b/src/par_iter/find.rs
@@ -1,5 +1,4 @@
 use std::sync::atomic::{AtomicBool, Ordering};
-use super::internal::*;
 use super::len::*;
 use super::*;
 

--- a/src/par_iter/find_first_last/mod.rs
+++ b/src/par_iter/find_first_last/mod.rs
@@ -1,6 +1,5 @@
 use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use super::internal::*;
 use super::*;
 use super::len::*;
 

--- a/src/par_iter/find_first_last/mod.rs
+++ b/src/par_iter/find_first_last/mod.rs
@@ -67,7 +67,8 @@ struct FindConsumer<'f, FIND_OP: 'f> {
 impl<'f, FIND_OP> FindConsumer<'f, FIND_OP> {
     fn new(find_op: &'f FIND_OP,
            match_position: MatchPosition,
-           best_found: &'f AtomicUsize) -> Self {
+           best_found: &'f AtomicUsize)
+           -> Self {
         FindConsumer {
             find_op: find_op,
             lower_bound: Cell::new(0),
@@ -80,7 +81,7 @@ impl<'f, FIND_OP> FindConsumer<'f, FIND_OP> {
     fn current_index(&self) -> usize {
         match self.match_position {
             MatchPosition::Leftmost => self.lower_bound.get(),
-            MatchPosition::Rightmost => self.upper_bound
+            MatchPosition::Rightmost => self.upper_bound,
         }
     }
 }
@@ -99,9 +100,7 @@ impl<'f, ITEM, FIND_OP> Consumer<ITEM> for FindConsumer<'f, FIND_OP>
 
     fn split_at(self, _index: usize) -> (Self, Self, Self::Reducer) {
         let dir = self.match_position;
-        (self.split_off_left(),
-         self,
-         FindReducer { match_position: dir })
+        (self.split_off_left(), self, FindReducer { match_position: dir })
     }
 
     fn into_folder(self) -> Self::Folder {
@@ -189,7 +188,7 @@ impl<'f, FIND_OP: 'f + Fn(&ITEM) -> bool, ITEM> Folder<ITEM> for FindFolder<'f, 
                     Ok(_) => {
                         self.item = Some(item);
                         break;
-                    },
+                    }
                     Err(v) => current = v,
                 }
             }
@@ -208,9 +207,9 @@ impl<'f, FIND_OP: 'f + Fn(&ITEM) -> bool, ITEM> Folder<ITEM> for FindFolder<'f, 
         };
 
         found_best_in_range ||
-            better_position(self.best_found.load(Ordering::Relaxed),
-                            self.boundary,
-                            self.match_position)
+        better_position(self.best_found.load(Ordering::Relaxed),
+                        self.boundary,
+                        self.match_position)
     }
 }
 
@@ -247,14 +246,14 @@ fn find_last_folder_yields_last_match() {
 }
 
 struct FindReducer {
-    match_position: MatchPosition
+    match_position: MatchPosition,
 }
 
 impl<ITEM> Reducer<Option<ITEM>> for FindReducer {
     fn reduce(self, left: Option<ITEM>, right: Option<ITEM>) -> Option<ITEM> {
         match self.match_position {
             MatchPosition::Leftmost => left.or(right),
-            MatchPosition::Rightmost => right.or(left)
+            MatchPosition::Rightmost => right.or(left),
         }
     }
 }

--- a/src/par_iter/flat_map.rs
+++ b/src/par_iter/flat_map.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::f64;
 
@@ -16,8 +15,8 @@ impl<M, MAP_OP> FlatMap<M, MAP_OP> {
     }
 }
 
-impl<M, MAP_OP, PI> ParallelIterator for FlatMap<M, MAP_OP>
-    where M: ParallelIterator,
+impl<M, MAP_OP, PI> ParallelIteratorImpl for FlatMap<M, MAP_OP>
+    where M: ParallelIteratorImpl,
           MAP_OP: Fn(M::Item) -> PI + Sync,
           PI: IntoParallelIterator
 {

--- a/src/par_iter/fold.rs
+++ b/src/par_iter/fold.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::len::*;
 use super::*;
 
@@ -24,8 +23,8 @@ pub struct Fold<BASE, IDENTITY, FOLD_OP> {
     fold_op: FOLD_OP,
 }
 
-impl<U, BASE, IDENTITY, FOLD_OP> ParallelIterator for Fold<BASE, IDENTITY, FOLD_OP>
-    where BASE: ParallelIterator,
+impl<U, BASE, IDENTITY, FOLD_OP> ParallelIteratorImpl for Fold<BASE, IDENTITY, FOLD_OP>
+    where BASE: ParallelIteratorImpl,
           FOLD_OP: Fn(U, BASE::Item) -> U + Sync,
           IDENTITY: Fn() -> U + Sync,
           U: Send
@@ -44,13 +43,13 @@ impl<U, BASE, IDENTITY, FOLD_OP> ParallelIterator for Fold<BASE, IDENTITY, FOLD_
     }
 }
 
-impl<U, BASE, IDENTITY, FOLD_OP> BoundedParallelIterator for Fold<BASE, IDENTITY, FOLD_OP>
-    where BASE: BoundedParallelIterator,
+impl<U, BASE, IDENTITY, FOLD_OP> BoundedParallelIteratorImpl for Fold<BASE, IDENTITY, FOLD_OP>
+    where BASE: BoundedParallelIteratorImpl,
           FOLD_OP: Fn(U, BASE::Item) -> U + Sync,
           IDENTITY: Fn() -> U + Sync,
           U: Send
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 

--- a/src/par_iter/imp.rs
+++ b/src/par_iter/imp.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+/// The `ParallelIterator` implementation interface.
+pub trait ParallelIteratorImpl: Sized {
+    type Item: Send;
+
+    /// Internal method used to define the behavior of this parallel
+    /// iterator. You should not need to call this directly.
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result where C: UnindexedConsumer<Self::Item>;
+
+    /// Returns the number of items produced by this iterator, if known
+    /// statically. This can be used by consumers to trigger special fast
+    /// paths. Therefore, if `Some(_)` is returned, this iterator must only
+    /// use the (indexed) `Consumer` methods when driving a consumer, such
+    /// as `split_at()`. Calling `UnindexedConsumer::split_off_left()` or
+    /// other `UnindexedConsumer` methods -- or returning an inaccurate
+    /// value -- may result in panics.
+    ///
+    /// This is hidden & considered internal for now, until we decide
+    /// whether it makes sense for a public API.  Right now it is only used
+    /// to optimize `collect`  for want of true Rust specialization.
+    #[doc(hidden)]
+    fn opt_len(&mut self) -> Option<usize> {
+        None
+    }
+}
+
+impl<T> ParallelIterator for T where T: ParallelIteratorImpl {}
+
+
+/// A trait for parallel iterators items where the precise number of
+/// items is not known, but we can at least give an upper-bound. These
+/// sorts of iterators result from filtering.
+pub trait BoundedParallelIteratorImpl: ParallelIterator {
+    fn impl_upper_bound(&mut self) -> usize;
+
+    /// Internal method used to define the behavior of this parallel
+    /// iterator. You should not need to call this directly.
+    fn drive<'c, C: Consumer<Self::Item>>(self, consumer: C) -> C::Result;
+}
+
+impl<T> BoundedParallelIterator for T
+    where T: BoundedParallelIteratorImpl
+{
+    fn upper_bound(&mut self) -> usize {
+        self.impl_upper_bound()
+    }
+}
+
+
+/// A trait for parallel iterators items where the precise number of
+/// items is known. This occurs when e.g. iterating over a
+/// vector. Knowing precisely how many items will be produced is very
+/// useful.
+pub trait ExactParallelIteratorImpl: BoundedParallelIterator {
+    /// Produces an exact count of how many items this iterator will
+    /// produce, presuming no panic occurs.
+    fn impl_len(&mut self) -> usize;
+}
+
+impl<T> ExactParallelIterator for T
+    where T: ExactParallelIteratorImpl
+{
+    fn len(&mut self) -> usize {
+        self.impl_len()
+    }
+}
+
+
+/// An iterator that supports "random access" to its data, meaning
+/// that you can split it at arbitrary indices and draw data from
+/// those points.
+pub trait IndexedParallelIteratorImpl: ExactParallelIterator {
+    /// Convert this parallel iterator into a producer that can be
+    /// used to request the items.
+    fn with_producer<CB: ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output;
+}
+
+impl<T> IndexedParallelIterator for T where T: IndexedParallelIteratorImpl {}

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -34,7 +34,7 @@ pub trait Producer: IntoIterator + Send + Sized {
     ///
     /// The provided implementation is sufficient for most iterables.
     fn fold_with<F>(self, mut folder: F) -> F
-        where F: Folder<Self::Item>,
+        where F: Folder<Self::Item>
     {
         for item in self {
             folder = folder.consume(item);
@@ -120,7 +120,7 @@ pub trait UnindexedProducer: IntoIterator + Send + Sized {
     ///
     /// The provided implementation is sufficient for most iterables.
     fn fold_with<F>(self, mut folder: F) -> F
-        where F: Folder<Self::Item>,
+        where F: Folder<Self::Item>
     {
         for item in self {
             folder = folder.consume(item);

--- a/src/par_iter/map.rs
+++ b/src/par_iter/map.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::len::*;
 use super::*;
 
@@ -59,8 +58,8 @@ impl<M, MAP_OP> Map<M, MAP_OP> {
     }
 }
 
-impl<M, MAP_OP> ParallelIterator for Map<M, MAP_OP>
-    where M: ParallelIterator,
+impl<M, MAP_OP> ParallelIteratorImpl for Map<M, MAP_OP>
+    where M: ParallelIteratorImpl,
           MAP_OP: MapOp<M::Item>
 {
     type Item = MAP_OP::Output;
@@ -77,11 +76,11 @@ impl<M, MAP_OP> ParallelIterator for Map<M, MAP_OP>
     }
 }
 
-impl<M, MAP_OP> BoundedParallelIterator for Map<M, MAP_OP>
-    where M: BoundedParallelIterator,
+impl<M, MAP_OP> BoundedParallelIteratorImpl for Map<M, MAP_OP>
+    where M: BoundedParallelIteratorImpl,
           MAP_OP: MapOp<M::Item>
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 
@@ -93,17 +92,17 @@ impl<M, MAP_OP> BoundedParallelIterator for Map<M, MAP_OP>
     }
 }
 
-impl<M, MAP_OP> ExactParallelIterator for Map<M, MAP_OP>
-    where M: ExactParallelIterator,
+impl<M, MAP_OP> ExactParallelIteratorImpl for Map<M, MAP_OP>
+    where M: ExactParallelIteratorImpl,
           MAP_OP: MapOp<M::Item>
 {
-    fn len(&mut self) -> usize {
+    fn impl_len(&mut self) -> usize {
         self.base.len()
     }
 }
 
-impl<M, MAP_OP> IndexedParallelIterator for Map<M, MAP_OP>
-    where M: IndexedParallelIterator,
+impl<M, MAP_OP> IndexedParallelIteratorImpl for Map<M, MAP_OP>
+    where M: IndexedParallelIteratorImpl,
           MAP_OP: MapOp<M::Item>
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -577,7 +577,8 @@ pub trait ParallelIterator: Sized {
     /// will be stopped, while attempts to the left must continue in case
     /// an earlier match is found.
     fn find_first<FIND_OP>(self, predicate: FIND_OP) -> Option<Self::Item>
-        where FIND_OP: Fn(&Self::Item) -> bool + Sync {
+        where FIND_OP: Fn(&Self::Item) -> bool + Sync
+    {
         find_first_last::find_first(self, predicate)
     }
 
@@ -588,12 +589,14 @@ pub trait ParallelIterator: Sized {
     /// will be stopped, while attempts to the right must continue in case
     /// a later match is found.
     fn find_last<FIND_OP>(self, predicate: FIND_OP) -> Option<Self::Item>
-        where FIND_OP: Fn(&Self::Item) -> bool + Sync {
+        where FIND_OP: Fn(&Self::Item) -> bool + Sync
+    {
         find_first_last::find_last(self, predicate)
     }
 
     #[doc(hidden)]
-    #[deprecated(note = "parallel `find` does not search in order -- use `find_any`, `find_first`, or `find_last`")]
+    #[deprecated(note = "parallel `find` does not search in order -- \
+                 use `find_any`, `find_first`, or `find_last`")]
     fn find<FIND_OP>(self, predicate: FIND_OP) -> Option<Self::Item>
         where FIND_OP: Fn(&Self::Item) -> bool + Sync
     {
@@ -874,7 +877,8 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
     }
 
     #[doc(hidden)]
-    #[deprecated(note = "parallel `position` does not search in order -- use `position_any`, `position_first`, or `position_last`")]
+    #[deprecated(note = "parallel `position` does not search in order -- \
+                 use `position_any`, `position_first`, or `position_last`")]
     fn position<POSITION_OP>(self, predicate: POSITION_OP) -> Option<usize>
         where POSITION_OP: Fn(Self::Item) -> bool + Sync
     {

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -238,6 +238,8 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     /// Example:
     ///
     /// ```
+    /// # extern crate rayon_core as rayon;
+    /// # fn main() {
     /// // Iterate over a sequence of pairs `(x0, y0), ..., (xN, yN)`
     /// // and use reduce to compute one pair `(x0 + ... + xN, y0 + ... + yN)`
     /// // where the first/second elements are summed separately.
@@ -248,6 +250,7 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     ///            .reduce(|| (0, 0), // the "identity" is 0 in both columns
     ///                    |a, b| (a.0 + b.0, a.1 + b.1));
     /// assert_eq!(sums, (0 + 5 + 16 + 8, 1 + 6 + 2 + 9));
+    /// # }
     /// ```
     ///
     /// **Note:** unlike a sequential `fold` operation, the order in
@@ -372,6 +375,8 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     /// map/reduce, you might try this:
     ///
     /// ```
+    /// # extern crate rayon_core as rayon;
+    /// # fn main() {
     /// use rayon::prelude::*;
     /// let s =
     ///     ['a', 'b', 'c', 'd', 'e']
@@ -380,6 +385,7 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     ///     .reduce(|| String::new(),
     ///             |mut a: String, b: String| { a.push_str(&b); a });
     /// assert_eq!(s, "abcde");
+    /// # }
     /// ```
     ///
     /// Because reduce produces the same type of element as its input,
@@ -389,6 +395,8 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     /// do this instead:
     ///
     /// ```
+    /// # extern crate rayon_core as rayon;
+    /// # fn main() {
     /// use rayon::prelude::*;
     /// let s =
     ///     ['a', 'b', 'c', 'd', 'e']
@@ -398,6 +406,7 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     ///     .reduce(|| String::new(),
     ///             |mut a: String, b: String| { a.push_str(&b); a });
     /// assert_eq!(s, "abcde");
+    /// # }
     /// ```
     ///
     /// Now `fold` will process groups of our characters at a time,
@@ -418,12 +427,15 @@ pub trait ParallelIterator: ParallelIteratorImpl {
     /// combination in effect:
     ///
     /// ```
+    /// # extern crate rayon_core as rayon;
+    /// # fn main() {
     /// use rayon::prelude::*;
     /// let bytes = 0..22_u8; // series of u8 bytes
     /// let sum = bytes.into_par_iter()
     ///                .fold(|| 0_u32, |a: u32, b: u8| a + (b as u32))
     ///                .sum();
     /// assert_eq!(sum, (0..22).sum()); // compare to sequential
+    /// # }
     /// ```
     fn fold<IDENTITY_ITEM, IDENTITY, FOLD_OP>(self,
                                               identity: IDENTITY,

--- a/src/par_iter/option.rs
+++ b/src/par_iter/option.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std;
 
@@ -62,7 +61,7 @@ impl<'a, T: Send, E> IntoParallelIterator for &'a mut Result<T, E> {
 
 /// ////////////////////////////////////////////////////////////////////////
 
-impl<T: Send> ParallelIterator for OptionIter<T> {
+impl<T: Send> ParallelIteratorImpl for OptionIter<T> {
     type Item = T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -76,8 +75,8 @@ impl<T: Send> ParallelIterator for OptionIter<T> {
     }
 }
 
-impl<T: Send> BoundedParallelIterator for OptionIter<T> {
-    fn upper_bound(&mut self) -> usize {
+impl<T: Send> BoundedParallelIteratorImpl for OptionIter<T> {
+    fn impl_upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 
@@ -88,8 +87,8 @@ impl<T: Send> BoundedParallelIterator for OptionIter<T> {
     }
 }
 
-impl<T: Send> ExactParallelIterator for OptionIter<T> {
-    fn len(&mut self) -> usize {
+impl<T: Send> ExactParallelIteratorImpl for OptionIter<T> {
+    fn impl_len(&mut self) -> usize {
         match self.opt {
             Some(_) => 1,
             None => 0,
@@ -97,7 +96,7 @@ impl<T: Send> ExactParallelIterator for OptionIter<T> {
     }
 }
 
-impl<T: Send> IndexedParallelIterator for OptionIter<T> {
+impl<T: Send> IndexedParallelIteratorImpl for OptionIter<T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::ops::Range;
 
@@ -9,7 +8,7 @@ pub struct RangeIter<T> {
 impl<T> IntoParallelIterator for Range<T>
     where RangeIter<T>: ParallelIterator
 {
-    type Item = <RangeIter<T> as ParallelIterator>::Item;
+    type Item = <RangeIter<T> as ParallelIteratorImpl>::Item;
     type Iter = RangeIter<T>;
 
     fn into_par_iter(self) -> Self::Iter {
@@ -30,7 +29,7 @@ impl<T> IntoIterator for RangeIter<T>
 
 macro_rules! indexed_range_impl {
     ( $t:ty ) => {
-        impl ParallelIterator for RangeIter<$t> {
+        impl ParallelIteratorImpl for RangeIter<$t> {
             type Item = $t;
 
             fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -44,8 +43,8 @@ macro_rules! indexed_range_impl {
             }
         }
 
-        impl BoundedParallelIterator for RangeIter<$t> {
-            fn upper_bound(&mut self) -> usize {
+        impl BoundedParallelIteratorImpl for RangeIter<$t> {
+            fn impl_upper_bound(&mut self) -> usize {
                 ExactParallelIterator::len(self)
             }
 
@@ -56,13 +55,13 @@ macro_rules! indexed_range_impl {
             }
         }
 
-        impl ExactParallelIterator for RangeIter<$t> {
-            fn len(&mut self) -> usize {
+        impl ExactParallelIteratorImpl for RangeIter<$t> {
+            fn impl_len(&mut self) -> usize {
                 self.range.len()
             }
         }
 
-        impl IndexedParallelIterator for RangeIter<$t> {
+        impl IndexedParallelIteratorImpl for RangeIter<$t> {
             fn with_producer<CB>(self, callback: CB) -> CB::Output
                 where CB: ProducerCallback<Self::Item>
             {
@@ -101,7 +100,7 @@ macro_rules! unindexed_range_impl {
             }
         }
 
-        impl ParallelIterator for RangeIter<$t> {
+        impl ParallelIteratorImpl for RangeIter<$t> {
             type Item = $t;
 
             fn drive_unindexed<C>(self, consumer: C) -> C::Result

--- a/src/par_iter/skip.rs
+++ b/src/par_iter/skip.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::cmp::min;
 
@@ -16,7 +15,7 @@ impl<M> Skip<M>
     }
 }
 
-impl<M> ParallelIterator for Skip<M>
+impl<M> ParallelIteratorImpl for Skip<M>
     where M: IndexedParallelIterator
 {
     type Item = M::Item;
@@ -32,18 +31,18 @@ impl<M> ParallelIterator for Skip<M>
     }
 }
 
-impl<M> ExactParallelIterator for Skip<M>
+impl<M> ExactParallelIteratorImpl for Skip<M>
     where M: IndexedParallelIterator
 {
-    fn len(&mut self) -> usize {
+    fn impl_len(&mut self) -> usize {
         self.base.len() - self.n
     }
 }
 
-impl<M> BoundedParallelIterator for Skip<M>
+impl<M> BoundedParallelIteratorImpl for Skip<M>
     where M: IndexedParallelIterator
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.len()
     }
 
@@ -52,7 +51,7 @@ impl<M> BoundedParallelIterator for Skip<M>
     }
 }
 
-impl<M> IndexedParallelIterator for Skip<M>
+impl<M> IndexedParallelIteratorImpl for Skip<M>
     where M: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
@@ -76,7 +75,7 @@ impl<M> IndexedParallelIterator for Skip<M>
                 where P: Producer<Item = ITEM>
             {
                 let (before_skip, after_skip) = base.split_at(self.n);
-                bridge_producer_consumer(self.n, before_skip, noop::NoopConsumer::new());
+                bridge_producer_consumer(self.n, before_skip, NoopConsumer::new());
                 self.callback.callback(after_skip)
             }
         }

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 
 pub struct SliceIter<'data, T: 'data + Sync> {
@@ -35,7 +34,7 @@ impl<'data, T: Sync + 'data> ToParallelChunks<'data> for [T] {
     }
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> ParallelIteratorImpl for SliceIter<'data, T> {
     type Item = &'data T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -49,8 +48,8 @@ impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for SliceIter<'data, T> {
-    fn upper_bound(&mut self) -> usize {
+impl<'data, T: Sync + 'data> BoundedParallelIteratorImpl for SliceIter<'data, T> {
+    fn impl_upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 
@@ -61,13 +60,13 @@ impl<'data, T: Sync + 'data> BoundedParallelIterator for SliceIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for SliceIter<'data, T> {
-    fn len(&mut self) -> usize {
+impl<'data, T: Sync + 'data> ExactParallelIteratorImpl for SliceIter<'data, T> {
+    fn impl_len(&mut self) -> usize {
         self.slice.len()
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> IndexedParallelIteratorImpl for SliceIter<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -80,7 +79,7 @@ pub struct ChunksIter<'data, T: 'data + Sync> {
     slice: &'data [T],
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for ChunksIter<'data, T> {
+impl<'data, T: Sync + 'data> ParallelIteratorImpl for ChunksIter<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -94,8 +93,8 @@ impl<'data, T: Sync + 'data> ParallelIterator for ChunksIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for ChunksIter<'data, T> {
-    fn upper_bound(&mut self) -> usize {
+impl<'data, T: Sync + 'data> BoundedParallelIteratorImpl for ChunksIter<'data, T> {
+    fn impl_upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 
@@ -106,13 +105,13 @@ impl<'data, T: Sync + 'data> BoundedParallelIterator for ChunksIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for ChunksIter<'data, T> {
-    fn len(&mut self) -> usize {
+impl<'data, T: Sync + 'data> ExactParallelIteratorImpl for ChunksIter<'data, T> {
+    fn impl_len(&mut self) -> usize {
         (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for ChunksIter<'data, T> {
+impl<'data, T: Sync + 'data> IndexedParallelIteratorImpl for ChunksIter<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 
 pub struct SliceIterMut<'data, T: 'data + Send> {
@@ -35,7 +34,7 @@ impl<'data, T: Send + 'data> ToParallelChunksMut<'data> for [T] {
     }
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> ParallelIteratorImpl for SliceIterMut<'data, T> {
     type Item = &'data mut T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -49,8 +48,8 @@ impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> BoundedParallelIterator for SliceIterMut<'data, T> {
-    fn upper_bound(&mut self) -> usize {
+impl<'data, T: Send + 'data> BoundedParallelIteratorImpl for SliceIterMut<'data, T> {
+    fn impl_upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 
@@ -61,13 +60,13 @@ impl<'data, T: Send + 'data> BoundedParallelIterator for SliceIterMut<'data, T> 
     }
 }
 
-impl<'data, T: Send + 'data> ExactParallelIterator for SliceIterMut<'data, T> {
-    fn len(&mut self) -> usize {
+impl<'data, T: Send + 'data> ExactParallelIteratorImpl for SliceIterMut<'data, T> {
+    fn impl_len(&mut self) -> usize {
         self.slice.len()
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> IndexedParallelIteratorImpl for SliceIterMut<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -80,7 +79,7 @@ pub struct ChunksMutIter<'data, T: 'data + Send> {
     slice: &'data mut [T],
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for ChunksMutIter<'data, T> {
+impl<'data, T: Send + 'data> ParallelIteratorImpl for ChunksMutIter<'data, T> {
     type Item = &'data mut [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -94,8 +93,8 @@ impl<'data, T: Send + 'data> ParallelIterator for ChunksMutIter<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMutIter<'data, T> {
-    fn upper_bound(&mut self) -> usize {
+impl<'data, T: Send + 'data> BoundedParallelIteratorImpl for ChunksMutIter<'data, T> {
+    fn impl_upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 
@@ -106,13 +105,13 @@ impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMutIter<'data, T>
     }
 }
 
-impl<'data, T: Send + 'data> ExactParallelIterator for ChunksMutIter<'data, T> {
-    fn len(&mut self) -> usize {
+impl<'data, T: Send + 'data> ExactParallelIteratorImpl for ChunksMutIter<'data, T> {
+    fn impl_len(&mut self) -> usize {
         (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMutIter<'data, T> {
+impl<'data, T: Send + 'data> IndexedParallelIteratorImpl for ChunksMutIter<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::cmp::min;
 use std::iter::Chain;
@@ -76,7 +75,7 @@ pub struct ParChars<'a> {
     chars: &'a str,
 }
 
-impl<'a> ParallelIterator for ParChars<'a> {
+impl<'a> ParallelIteratorImpl for ParChars<'a> {
     type Item = char;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -129,7 +128,7 @@ impl<'a> ParSplit<'a> {
     }
 }
 
-impl<'a> ParallelIterator for ParSplit<'a> {
+impl<'a> ParallelIteratorImpl for ParSplit<'a> {
     type Item = &'a str;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -225,7 +224,7 @@ impl<'a> ParSplitTerminator<'a> {
     }
 }
 
-impl<'a> ParallelIterator for ParSplitTerminator<'a> {
+impl<'a> ParallelIteratorImpl for ParSplitTerminator<'a> {
     type Item = &'a str;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -277,7 +276,7 @@ impl<'a> IntoIterator for ParSplitTerminator<'a> {
 
 pub struct ParLines<'a>(&'a str);
 
-impl<'a> ParallelIterator for ParLines<'a> {
+impl<'a> ParallelIteratorImpl for ParLines<'a> {
     type Item = &'a str;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result

--- a/src/par_iter/take.rs
+++ b/src/par_iter/take.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::cmp::min;
 
@@ -16,7 +15,7 @@ impl<M> Take<M>
     }
 }
 
-impl<M> ParallelIterator for Take<M>
+impl<M> ParallelIteratorImpl for Take<M>
     where M: IndexedParallelIterator
 {
     type Item = M::Item;
@@ -32,18 +31,18 @@ impl<M> ParallelIterator for Take<M>
     }
 }
 
-impl<M> ExactParallelIterator for Take<M>
+impl<M> ExactParallelIteratorImpl for Take<M>
     where M: IndexedParallelIterator
 {
-    fn len(&mut self) -> usize {
+    fn impl_len(&mut self) -> usize {
         self.n
     }
 }
 
-impl<M> BoundedParallelIterator for Take<M>
+impl<M> BoundedParallelIteratorImpl for Take<M>
     where M: IndexedParallelIterator
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.len()
     }
 
@@ -52,7 +51,7 @@ impl<M> BoundedParallelIterator for Take<M>
     }
 }
 
-impl<M> IndexedParallelIterator for Take<M>
+impl<M> IndexedParallelIteratorImpl for Take<M>
     where M: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -1042,7 +1042,8 @@ pub fn find_first_or_last() {
                Some(&742_i32));
     assert_eq!(a.par_iter().find_first(|&&x| x < 0), None);
 
-    assert_eq!(a.par_iter().position_first(|&x| x % 42 == 41), Some(41_usize));
+    assert_eq!(a.par_iter().position_first(|&x| x % 42 == 41),
+               Some(41_usize));
     assert_eq!(a.par_iter().position_first(|&x| x % 19 == 1 && x % 53 == 0),
                Some(742_usize));
     assert_eq!(a.par_iter().position_first(|&x| x < 0), None);
@@ -1052,7 +1053,8 @@ pub fn find_first_or_last() {
                Some(&742_i32));
     assert_eq!(a.par_iter().find_last(|&&x| x < 0), None);
 
-    assert_eq!(a.par_iter().position_last(|&x| x % 42 == 41), Some(1007_usize));
+    assert_eq!(a.par_iter().position_last(|&x| x % 42 == 41),
+               Some(1007_usize));
     assert_eq!(a.par_iter().position_last(|&x| x % 19 == 1 && x % 53 == 0),
                Some(742_usize));
     assert_eq!(a.par_iter().position_last(|&x| x < 0), None);

--- a/src/par_iter/vec.rs
+++ b/src/par_iter/vec.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std;
 
@@ -15,7 +14,7 @@ impl<T: Send> IntoParallelIterator for Vec<T> {
     }
 }
 
-impl<T: Send> ParallelIterator for VecIter<T> {
+impl<T: Send> ParallelIteratorImpl for VecIter<T> {
     type Item = T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -29,8 +28,8 @@ impl<T: Send> ParallelIterator for VecIter<T> {
     }
 }
 
-impl<T: Send> BoundedParallelIterator for VecIter<T> {
-    fn upper_bound(&mut self) -> usize {
+impl<T: Send> BoundedParallelIteratorImpl for VecIter<T> {
+    fn impl_upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
 
@@ -41,13 +40,13 @@ impl<T: Send> BoundedParallelIterator for VecIter<T> {
     }
 }
 
-impl<T: Send> ExactParallelIterator for VecIter<T> {
-    fn len(&mut self) -> usize {
+impl<T: Send> ExactParallelIteratorImpl for VecIter<T> {
+    fn impl_len(&mut self) -> usize {
         self.vec.len()
     }
 }
 
-impl<T: Send> IndexedParallelIterator for VecIter<T> {
+impl<T: Send> IndexedParallelIteratorImpl for VecIter<T> {
     fn with_producer<CB>(mut self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 
 pub struct Weight<M> {
@@ -15,8 +14,8 @@ impl<M> Weight<M> {
     }
 }
 
-impl<M> ParallelIterator for Weight<M>
-    where M: ParallelIterator
+impl<M> ParallelIteratorImpl for Weight<M>
+    where M: ParallelIteratorImpl
 {
     type Item = M::Item;
 
@@ -32,8 +31,8 @@ impl<M> ParallelIterator for Weight<M>
     }
 }
 
-impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> {
-    fn upper_bound(&mut self) -> usize {
+impl<M: BoundedParallelIteratorImpl> BoundedParallelIteratorImpl for Weight<M> {
+    fn impl_upper_bound(&mut self) -> usize {
         self.base.upper_bound()
     }
 
@@ -45,13 +44,13 @@ impl<M: BoundedParallelIterator> BoundedParallelIterator for Weight<M> {
     }
 }
 
-impl<M: ExactParallelIterator> ExactParallelIterator for Weight<M> {
-    fn len(&mut self) -> usize {
+impl<M: ExactParallelIteratorImpl> ExactParallelIteratorImpl for Weight<M> {
+    fn impl_len(&mut self) -> usize {
         self.base.len()
     }
 }
 
-impl<M: IndexedParallelIterator> IndexedParallelIterator for Weight<M> {
+impl<M: IndexedParallelIteratorImpl> IndexedParallelIteratorImpl for Weight<M> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -1,4 +1,3 @@
-use super::internal::*;
 use super::*;
 use std::cmp::min;
 use std::iter;
@@ -14,7 +13,7 @@ impl<A: IndexedParallelIterator, B: IndexedParallelIterator> ZipIter<A, B> {
     }
 }
 
-impl<A, B> ParallelIterator for ZipIter<A, B>
+impl<A, B> ParallelIteratorImpl for ZipIter<A, B>
     where A: IndexedParallelIterator,
           B: IndexedParallelIterator
 {
@@ -31,11 +30,11 @@ impl<A, B> ParallelIterator for ZipIter<A, B>
     }
 }
 
-impl<A, B> BoundedParallelIterator for ZipIter<A, B>
+impl<A, B> BoundedParallelIteratorImpl for ZipIter<A, B>
     where A: IndexedParallelIterator,
           B: IndexedParallelIterator
 {
-    fn upper_bound(&mut self) -> usize {
+    fn impl_upper_bound(&mut self) -> usize {
         self.len()
     }
 
@@ -46,16 +45,16 @@ impl<A, B> BoundedParallelIterator for ZipIter<A, B>
     }
 }
 
-impl<A, B> ExactParallelIterator for ZipIter<A, B>
+impl<A, B> ExactParallelIteratorImpl for ZipIter<A, B>
     where A: IndexedParallelIterator,
           B: IndexedParallelIterator
 {
-    fn len(&mut self) -> usize {
+    fn impl_len(&mut self) -> usize {
         min(self.a.len(), self.b.len())
     }
 }
 
-impl<A, B> IndexedParallelIterator for ZipIter<A, B>
+impl<A, B> IndexedParallelIteratorImpl for ZipIter<A, B>
     where A: IndexedParallelIterator,
           B: IndexedParallelIterator
 {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,4 +15,4 @@ pub use par_iter::ToParallelChunksMut;
 
 pub use par_iter::ParallelString;
 
-pub use par_iter::from_par_iter::FromParallelIterator;
+pub use par_iter::FromParallelIterator;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -161,7 +161,8 @@ impl Registry {
             // drops) a `ThreadPool`; and, in that case, they cannot be
             // calling `inject()` later, since they dropped their
             // `ThreadPool`.
-            assert!(!self.terminate_latch.probe(), "inject() sees state.terminate as true");
+            assert!(!self.terminate_latch.probe(),
+                    "inject() sees state.terminate as true");
 
             for &job_ref in injected_jobs {
                 state.job_injector.push(job_ref);
@@ -194,14 +195,12 @@ impl Registry {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RegistryId {
-    addr: usize
+    addr: usize,
 }
 
 impl RegistryState {
     pub fn new(job_injector: Worker<JobRef>) -> RegistryState {
-        RegistryState {
-            job_injector: job_injector,
-        }
+        RegistryState { job_injector: job_injector }
     }
 }
 
@@ -321,8 +320,8 @@ impl WorkerThread {
             // outside. The idea is to finish what we started before
             // we take on something new.
             if let Some(job) = self.pop()
-                                   .or_else(|| self.steal())
-                                   .or_else(|| self.registry.pop_injected_job(self.index)) {
+                .or_else(|| self.steal())
+                .or_else(|| self.registry.pop_injected_job(self.index)) {
                 yields = self.registry.sleep.work_found(self.index, yields);
                 self.execute(job);
             } else {
@@ -373,8 +372,8 @@ impl WorkerThread {
             let rng = &mut *self.rng.get();
             rng.next_u32() % num_threads as u32
         } as usize;
-        (start .. num_threads)
-            .chain(0 .. start)
+        (start..num_threads)
+            .chain(0..start)
             .filter(|&i| i != self.index)
             .filter_map(|victim_index| {
                 let victim = &self.registry.thread_infos[victim_index];
@@ -383,7 +382,10 @@ impl WorkerThread {
                         Stolen::Empty => return None,
                         Stolen::Abort => (), // retry
                         Stolen::Data(v) => {
-                            log!(StoleWork { worker: self.index, victim: victim_index });
+                            log!(StoleWork {
+                                worker: self.index,
+                                victim: victim_index,
+                            });
                             return Some(v);
                         }
                     }
@@ -429,7 +431,8 @@ unsafe fn main_loop(worker: Worker<JobRef>, registry: Arc<Registry>, index: usiz
 /// `op` completes and return its return value. If `op` panics, that
 /// panic will be propagated as well.
 pub fn in_worker<OP, R>(op: OP) -> R
-    where OP: FnOnce(&WorkerThread) -> R + Send, R: Send
+    where OP: FnOnce(&WorkerThread) -> R + Send,
+          R: Send
 {
     unsafe {
         let owner_thread = WorkerThread::current();
@@ -446,7 +449,8 @@ pub fn in_worker<OP, R>(op: OP) -> R
 
 #[cold]
 unsafe fn in_worker_cold<OP, R>(op: OP) -> R
-    where OP: FnOnce(&WorkerThread) -> R + Send, R: Send
+    where OP: FnOnce(&WorkerThread) -> R + Send,
+          R: Send
 {
     // never run from a worker thread; just shifts over into worker threads
     debug_assert!(WorkerThread::current().is_null());

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -50,6 +50,7 @@ pub struct Scope<'scope> {
 /// it would be less efficient than the real implementation:
 ///
 /// ```rust
+/// # use rayon_core as rayon;
 /// pub fn join<A,B,RA,RB>(oper_a: A, oper_b: B) -> (RA, RB)
 ///     where A: FnOnce() -> RA + Send,
 ///           B: FnOnce() -> RB + Send,
@@ -90,6 +91,7 @@ pub struct Scope<'scope> {
 /// To see how and when tasks are joined, consider this example:
 ///
 /// ```rust
+/// # use rayon_core as rayon;
 /// // point start
 /// rayon::scope(|s| {
 ///     s.spawn(|s| { // task s.1
@@ -143,6 +145,7 @@ pub struct Scope<'scope> {
 /// spawned task.
 ///
 /// ```rust
+/// # use rayon_core as rayon;
 /// let ok: Vec<i32> = vec![1, 2, 3];
 /// rayon::scope(|s| {
 ///     let bad: Vec<i32> = vec![4, 5, 6];
@@ -166,6 +169,7 @@ pub struct Scope<'scope> {
 /// in this case including both `ok` *and* `bad`:
 ///
 /// ```rust
+/// # use rayon_core as rayon;
 /// let ok: Vec<i32> = vec![1, 2, 3];
 /// rayon::scope(|s| {
 ///     let bad: Vec<i32> = vec![4, 5, 6];
@@ -186,6 +190,7 @@ pub struct Scope<'scope> {
 /// is a borrow of `ok` and capture *that*:
 ///
 /// ```rust
+/// # use rayon_core as rayon;
 /// let ok: Vec<i32> = vec![1, 2, 3];
 /// rayon::scope(|s| {
 ///     let bad: Vec<i32> = vec![4, 5, 6];
@@ -207,6 +212,7 @@ pub struct Scope<'scope> {
 /// of individual variables:
 ///
 /// ```rust
+/// # use rayon_core as rayon;
 /// let ok: Vec<i32> = vec![1, 2, 3];
 /// rayon::scope(|s| {
 ///     let bad: Vec<i32> = vec![4, 5, 6];

--- a/src/thread_pool/test.rs
+++ b/src/thread_pool/test.rs
@@ -17,12 +17,13 @@ fn panic_propagate() {
 fn workers_stop() {
     let registry;
 
-    { // once we exit this block, thread-pool will be dropped
+    {
+        // once we exit this block, thread-pool will be dropped
         let thread_pool = ThreadPool::new(Configuration::new().set_num_threads(22)).unwrap();
         registry = thread_pool.install(|| {
             // do some work on these threads
-            let s1 = (0..10*1024).into_par_iter().sum();
-            let s2 = (0..10*1024).sum();
+            let s1 = (0..10 * 1024).into_par_iter().sum();
+            let s2 = (0..10 * 1024).sum();
             assert_eq!(s1, s2);
 
             thread_pool.registry.clone()
@@ -41,7 +42,8 @@ fn sleeper_stop() {
 
     let registry;
 
-    { // once we exit this block, thread-pool will be dropped
+    {
+        // once we exit this block, thread-pool will be dropped
         let thread_pool = ThreadPool::new(Configuration::new().set_num_threads(22)).unwrap();
         registry = thread_pool.registry.clone();
 

--- a/tests/compile-fail/cannot_collect_filtermap_data.rs
+++ b/tests/compile-fail/cannot_collect_filtermap_data.rs
@@ -1,6 +1,6 @@
-extern crate rayon;
+extern crate rayon_core;
 
-use rayon::prelude::*;
+use rayon_core::prelude::*;
 
 // zip requires data of exact size, but filter yields only bounded
 // size, so check that we cannot apply it.

--- a/tests/compile-fail/cannot_zip_filtered_data.rs
+++ b/tests/compile-fail/cannot_zip_filtered_data.rs
@@ -1,6 +1,6 @@
-extern crate rayon;
+extern crate rayon_core;
 
-use rayon::prelude::*;
+use rayon_core::prelude::*;
 
 // zip requires data of exact size, but filter yields only bounded
 // size, so check that we cannot apply it.

--- a/tests/compile-fail/cell_par_iter.rs
+++ b/tests/compile-fail/cell_par_iter.rs
@@ -1,8 +1,8 @@
-extern crate rayon;
+extern crate rayon_core;
 
 // Check that we can't use the par-iter API to access contents of a `Cell`.
 
-use rayon::prelude::*;
+use rayon_core::prelude::*;
 use std::cell::Cell;
 
 fn main() {

--- a/tests/compile-fail/quicksort_race1.rs
+++ b/tests/compile-fail/quicksort_race1.rs
@@ -1,4 +1,4 @@
-extern crate rayon;
+extern crate rayon_core;
 
 fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
     if v.len() <= 1 {
@@ -7,7 +7,7 @@ fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
 
     let mid = partition(v);
     let (lo, hi) = v.split_at_mut(mid);
-    rayon::join(|| quick_sort(lo), || quick_sort(lo)); //~ ERROR E0524
+    rayon_core::join(|| quick_sort(lo), || quick_sort(lo)); //~ ERROR E0524
 }
 
 fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {

--- a/tests/compile-fail/quicksort_race2.rs
+++ b/tests/compile-fail/quicksort_race2.rs
@@ -1,4 +1,4 @@
-extern crate rayon;
+extern crate rayon_core;
 
 fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
     if v.len() <= 1 {
@@ -7,7 +7,7 @@ fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
 
     let mid = partition(v);
     let (lo, hi) = v.split_at_mut(mid);
-    rayon::join(|| quick_sort(lo), || quick_sort(v)); //~ ERROR E0500
+    rayon_core::join(|| quick_sort(lo), || quick_sort(v)); //~ ERROR E0500
 }
 
 fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {

--- a/tests/compile-fail/quicksort_race3.rs
+++ b/tests/compile-fail/quicksort_race3.rs
@@ -1,4 +1,4 @@
-extern crate rayon;
+extern crate rayon_core;
 
 fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
     if v.len() <= 1 {
@@ -7,7 +7,7 @@ fn quick_sort<T:PartialOrd+Send>(v: &mut [T]) {
 
     let mid = partition(v);
     let (lo, hi) = v.split_at_mut(mid);
-    rayon::join(|| quick_sort(hi), || quick_sort(hi)); //~ ERROR E0524
+    rayon_core::join(|| quick_sort(hi), || quick_sort(hi)); //~ ERROR E0524
 }
 
 fn partition<T:PartialOrd+Send>(v: &mut [T]) -> usize {

--- a/tests/compile-fail/rc_par_iter.rs
+++ b/tests/compile-fail/rc_par_iter.rs
@@ -1,9 +1,9 @@
-extern crate rayon;
+extern crate rayon_core;
 
 // Check that we can't use the par-iter API to access contents of an
 // `Rc`.
 
-use rayon::par_iter::IntoParallelIterator;
+use rayon_core::par_iter::IntoParallelIterator;
 use std::rc::Rc;
 
 fn main() {

--- a/tests/compile-fail/rc_return.rs
+++ b/tests/compile-fail/rc_return.rs
@@ -1,9 +1,9 @@
-extern crate rayon;
+extern crate rayon_core;
 
 use std::rc::Rc;
 
 fn main() {
-    rayon::join(|| Rc::new(22), || Rc::new(23));
+    rayon_core::join(|| Rc::new(22), || Rc::new(23));
     //~^ ERROR E0277
     //~| ERROR E0277
 }

--- a/tests/compile-fail/rc_upvar.rs
+++ b/tests/compile-fail/rc_upvar.rs
@@ -1,9 +1,9 @@
-extern crate rayon;
+extern crate rayon_core;
 
 use std::rc::Rc;
 
 fn main() {
     let r = Rc::new(22);
-    rayon::join(|| r.clone(), || r.clone());
+    rayon_core::join(|| r.clone(), || r.clone());
     //~^ ERROR E0277
 }

--- a/tests/compile-fail/scope_join_bad.rs
+++ b/tests/compile-fail/scope_join_bad.rs
@@ -1,9 +1,9 @@
-extern crate rayon;
+extern crate rayon_core;
 
 fn bad_scope<F>(f: F)
     where F: FnOnce(&i32) + Send,
 {
-    rayon::scope(|s| {
+    rayon_core::scope(|s| {
         let x = 22;
         s.spawn(|_| f(&x)); //~ ERROR `x` does not live long enough
     });
@@ -13,7 +13,7 @@ fn good_scope<F>(f: F)
     where F: FnOnce(&i32) + Send,
 {
     let x = 22;
-    rayon::scope(|s| {
+    rayon_core::scope(|s| {
         s.spawn(|_| f(&x));
     });
 }

--- a/tests/run-fail/iter_panic.rs
+++ b/tests/run-fail/iter_panic.rs
@@ -1,7 +1,7 @@
-extern crate rayon;
+extern crate rayon_core;
 
-use rayon::*;
-use rayon::prelude::*;
+use rayon_core::*;
+use rayon_core::prelude::*;
 
 // error-pattern:boom
 

--- a/tests/run-fail/simple_panic.rs
+++ b/tests/run-fail/simple_panic.rs
@@ -1,6 +1,6 @@
-extern crate rayon;
+extern crate rayon_core;
 
-use rayon::*;
+use rayon_core::*;
 
 // error-pattern:should panic
 

--- a/tests/run-pass/init_fail_thread_number_not_equal.rs
+++ b/tests/run-pass/init_fail_thread_number_not_equal.rs
@@ -1,6 +1,6 @@
-extern crate rayon;
+extern crate rayon_core;
 
-use rayon::*;
+use rayon_core::*;
 
 fn main() {
     let result1 = initialize(Configuration::new().set_num_threads(2));

--- a/tests/run-pass/init_fail_zero_threads.rs
+++ b/tests/run-pass/init_fail_zero_threads.rs
@@ -1,6 +1,6 @@
-extern crate rayon;
+extern crate rayon_core;
 
-use rayon::*;
+use rayon_core::*;
 
 fn main() {
     let result = initialize(Configuration::new().set_num_threads(0));

--- a/tests/run-pass/named-threads.rs
+++ b/tests/run-pass/named-threads.rs
@@ -1,9 +1,9 @@
-extern crate rayon;
+extern crate rayon_core;
 
 use std::collections::HashSet;
 
-use rayon::*;
-use rayon::prelude::*;
+use rayon_core::*;
+use rayon_core::prelude::*;
 
 fn main() {
     let result = initialize(Configuration::new().set_thread_name(|i| format!("hello-name-test-{}", i)));

--- a/tests/run-pass/scope_join.rs
+++ b/tests/run-pass/scope_join.rs
@@ -1,11 +1,11 @@
-extern crate rayon;
+extern crate rayon_core;
 
 /// Test that one can emulate join with `scope`:
 fn pseudo_join<F, G>(f: F, g: G)
     where F: FnOnce() + Send,
           G: FnOnce() + Send,
 {
-    rayon::scope(|s| {
+    rayon_core::scope(|s| {
         s.spawn(|_| g());
         f();
     });


### PR DESCRIPTION
The root crate is now `rayon-core`, with all functionality, and under
`rayon-stable/` is the new `rayon` crate that only publicizes select
really-stable interfaces -- those we feel are nearly ready for 1.0.  For
the most part, this means the APIs for *using* rayon, while we can
continue tweaking the APIs for *implementing* rayon traits in the core
with proper pre-1.0 semver bumps.

(The directories are structured this way just to minimize the code churn.)

Most of the traits are now split, e.g. `ParallelIterator` and a new
`ParallelIteratorImpl`, so only the former is publicized in `rayon`.
Methods like `drive` and `with_producer`, anything that implementors
have to provide, are isolated in `*Impl`.