### PR TITLE
Require `UnindexedProducer::fold_with` without `IntoIterator`           

### DIFF
--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -118,19 +118,15 @@ pub trait UnindexedConsumer<ITEM>: Consumer<ITEM> {
 
 /// An unindexed producer that doesn't know its exact length.
 /// (or can't represent its known length in a `usize`)
-pub trait UnindexedProducer: IntoIterator + Send + Sized {
+pub trait UnindexedProducer: Send + Sized {
+    type Item;
+
     /// Split midway into a new producer if possible, otherwise return `None`.
     fn split(&mut self) -> Option<Self>;
 
     /// Iterate the producer, feeding each element to `folder`, and
     /// stop when the folder is full (or all elements have been consumed).
-    ///
-    /// The provided implementation is sufficient for most iterables.
-    fn fold_with<F>(self, folder: F) -> F
-        where F: Folder<Self::Item>,
-    {
-        folder.consume_iter(self)
-    }
+    fn fold_with<F>(self, folder: F) -> F where F: Folder<Self::Item>;
 }
 
 /// A splitter controls the policy for splitting into smaller work items.

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -112,6 +112,8 @@ macro_rules! unindexed_range_impl {
         }
 
         impl UnindexedProducer for RangeIter<$t> {
+            type Item = $t;
+
             fn split(&mut self) -> Option<Self> {
                 let index = self.len() / 2;
                 if index > 0 {
@@ -122,6 +124,12 @@ macro_rules! unindexed_range_impl {
                 } else {
                     None
                 }
+            }
+
+            fn fold_with<F>(self, folder: F) -> F
+                where F: Folder<Self::Item>
+            {
+                folder.consume_iter(self)
             }
         }
     }


### PR DESCRIPTION
Our `string::ParSplit` can write a better `fold_with` than its iterator, because it can bypass the chain-Option iterator logic.  However, this duplicates some slightly tricky logic if we still keep the trait requirement for `IntoIterator`.  We can drop that and just *require* `fold_with`, without a default implementation.  It's trivial now for those that do have `IntoIterator` to use `Folder::consume_iter`.        
