### PR TITLE
Add `par_split(Fn)` and `par_split_whitespace` for strings

### DIFF
--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -103,6 +103,30 @@ impl Pattern for char {
     }
 }
 
+impl<FN: Sync + Fn(char) -> bool> Pattern for FN {
+    fn find_in(&self, chars: &str) -> Option<usize> {
+        chars.find(self)
+    }
+
+    fn rfind_in(&self, chars: &str) -> Option<usize> {
+        chars.rfind(self)
+    }
+
+    fn is_suffix_of(&self, chars: &str) -> bool {
+        chars.ends_with(self)
+    }
+
+    fn fold_with<'ch, F>(&self, chars: &'ch str, folder: F, skip_last: bool) -> F
+        where F: Folder<&'ch str>
+    {
+        let mut split = chars.split(self);
+        if skip_last {
+            split.next_back();
+        }
+        folder.consume_iter(split)
+    }
+}
+
 
 // /////////////////////////////////////////////////////////////////////////
 

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -2,6 +2,13 @@ use super::internal::*;
 use super::*;
 use std::cmp::min;
 
+mod private {
+    /// If this type is pub but not publically rechable, third parties can't
+    /// name it and can't implement traits using it.
+    pub struct PrivateMarker;
+} 
+
+
 /// Test if a byte is the start of a UTF-8 character.
 /// (extracted from `str::is_char_boundary`)
 fn is_char_boundary(b: u8) -> bool {
@@ -28,6 +35,11 @@ fn find_char_midpoint(chars: &str) -> usize {
 
 /// Parallel extensions for strings.
 pub trait ParallelString {
+    /// This trait is private; this method exists to make it impossible
+    /// to implement outside the crate.
+    #[doc(hidden)]
+    fn private_parallel_string(&self) -> private::PrivateMarker;
+
     /// Returns a parallel iterator over the characters of a string.
     fn par_chars(&self) -> ParChars;
 
@@ -56,6 +68,10 @@ pub trait ParallelString {
 }
 
 impl ParallelString for str {
+    fn private_parallel_string(&self) -> private::PrivateMarker {
+        private::PrivateMarker
+    }
+
     fn par_chars(&self) -> ParChars {
         ParChars { chars: self }
     }

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -6,7 +6,7 @@ mod private {
     /// If this type is pub but not publically rechable, third parties can't
     /// name it and can't implement traits using it.
     pub struct PrivateMarker;
-} 
+}
 
 
 /// Test if a byte is the start of a UTF-8 character.
@@ -102,8 +102,7 @@ pub trait Pattern: Sized + Sync {
     fn find_in(&self, &str) -> Option<usize>;
     fn rfind_in(&self, &str) -> Option<usize>;
     fn is_suffix_of(&self, &str) -> bool;
-    fn fold_with<'ch, F>(&self, &'ch str, folder: F, skip_last: bool) -> F
-        where F: Folder<&'ch str>;
+    fn fold_with<'ch, F>(&self, &'ch str, folder: F, skip_last: bool) -> F where F: Folder<&'ch str>;
 }
 
 impl Pattern for char {
@@ -340,9 +339,7 @@ pub struct ParSplitTerminatorProducer<'ch, 'sep, P: Pattern + 'sep> {
 
 impl<'ch, P: Pattern> ParSplitTerminator<'ch, P> {
     fn new(chars: &'ch str, terminator: P) -> Self {
-        ParSplitTerminator {
-            splitter: ParSplit::new(chars, terminator),
-        }
+        ParSplitTerminator { splitter: ParSplit::new(chars, terminator) }
     }
 }
 

--- a/src/par_iter/string.rs
+++ b/src/par_iter/string.rs
@@ -69,11 +69,11 @@ impl ParallelString for str {
 
 // /////////////////////////////////////////////////////////////////////////
 
-pub struct ParChars<'a> {
-    chars: &'a str,
+pub struct ParChars<'ch> {
+    chars: &'ch str,
 }
 
-impl<'a> ParallelIterator for ParChars<'a> {
+impl<'ch> ParallelIterator for ParChars<'ch> {
     type Item = char;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -83,7 +83,7 @@ impl<'a> ParallelIterator for ParChars<'a> {
     }
 }
 
-impl<'a> UnindexedProducer for ParChars<'a> {
+impl<'ch> UnindexedProducer for ParChars<'ch> {
     type Item = char;
 
     fn split(&mut self) -> Option<Self> {
@@ -107,20 +107,34 @@ impl<'a> UnindexedProducer for ParChars<'a> {
 
 // /////////////////////////////////////////////////////////////////////////
 
-pub struct ParSplit<'a> {
-    chars: &'a str,
+pub struct ParSplit<'ch> {
+    chars: &'ch str,
     separator: char,
+}
+
+pub struct ParSplitProducer<'ch, 'sep> {
+    chars: &'ch str,
+    separator: &'sep char,
 
     /// Marks the endpoint beyond which we've already found no separators.
     tail: usize,
 }
 
-impl<'a> ParSplit<'a> {
-    fn new(chars: &'a str, separator: char) -> Self {
+impl<'ch> ParSplit<'ch> {
+    fn new(chars: &'ch str, separator: char) -> Self {
         ParSplit {
             chars: chars,
             separator: separator,
-            tail: chars.len(),
+        }
+    }
+}
+
+impl<'ch, 'sep> ParSplitProducer<'ch, 'sep> {
+    fn new(split: &'sep ParSplit<'ch>) -> Self {
+        ParSplitProducer {
+            chars: split.chars,
+            separator: &split.separator,
+            tail: split.chars.len(),
         }
     }
 
@@ -129,21 +143,21 @@ impl<'a> ParSplit<'a> {
     fn fold_with<F>(self, folder: F, skip_last: bool) -> F
         where F: Folder<<Self as UnindexedProducer>::Item>
     {
-        let ParSplit { chars, separator, tail } = self;
+        let ParSplitProducer { chars, separator, tail } = self;
 
         if tail == chars.len() {
             // No tail section, so just let `str::split` handle it.
-            let mut split = chars.split(separator);
+            let mut split = chars.split(*separator);
             if skip_last {
                 split.next_back();
             }
             folder.consume_iter(split)
 
-        } else if let Some(index) = chars[..tail].rfind(separator) {
+        } else if let Some(index) = chars[..tail].rfind(*separator) {
             // We found the last separator to complete the tail, so
             // end with that slice after `str::split` finds the rest.
             let head = &chars[..index];
-            let folder = folder.consume_iter(head.split(separator));
+            let folder = folder.consume_iter(head.split(*separator));
             if skip_last || folder.full() {
                 folder
             } else {
@@ -162,30 +176,31 @@ impl<'a> ParSplit<'a> {
     }
 }
 
-impl<'a> ParallelIterator for ParSplit<'a> {
-    type Item = &'a str;
+impl<'ch> ParallelIterator for ParSplit<'ch> {
+    type Item = &'ch str;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        bridge_unindexed(self, consumer)
+        let producer = ParSplitProducer::new(&self);
+        bridge_unindexed(producer, consumer)
     }
 }
 
-impl<'a> UnindexedProducer for ParSplit<'a> {
-    type Item = &'a str;
+impl<'ch, 'sep> UnindexedProducer for ParSplitProducer<'ch, 'sep> {
+    type Item = &'ch str;
 
     fn split(&mut self) -> Option<Self> {
-        let ParSplit { chars, separator, tail } = *self;
+        let ParSplitProducer { chars, separator, tail } = *self;
 
         // First find a suitable UTF-8 boundary in the unsearched region.
         let char_index = find_char_midpoint(&chars[..tail]);
 
         // Look forward for the separator, and failing that look backward.
         let index = chars[char_index..tail]
-            .find(separator)
+            .find(*separator)
             .map(|i| char_index + i)
-            .or_else(|| chars[..char_index].rfind(separator));
+            .or_else(|| chars[..char_index].rfind(*separator));
 
         if let Some(index) = index {
             // Update `self` as the region before the separator.
@@ -194,7 +209,7 @@ impl<'a> UnindexedProducer for ParSplit<'a> {
 
             // Create the right split following the separator.
             let right_index = index + separator.len_utf8();
-            let mut right = ParSplit {
+            let mut right = ParSplitProducer {
                 chars: &chars[right_index..],
                 separator: separator,
                 tail: tail - right_index,
@@ -224,38 +239,51 @@ impl<'a> UnindexedProducer for ParSplit<'a> {
 
 // /////////////////////////////////////////////////////////////////////////
 
-pub struct ParSplitTerminator<'a> {
-    splitter: ParSplit<'a>,
+pub struct ParSplitTerminator<'ch> {
+    splitter: ParSplit<'ch>,
+}
+
+pub struct ParSplitTerminatorProducer<'ch, 'sep> {
+    splitter: ParSplitProducer<'ch, 'sep>,
     endpoint: bool,
 }
 
-impl<'a> ParSplitTerminator<'a> {
-    fn new(chars: &'a str, terminator: char) -> Self {
+impl<'ch> ParSplitTerminator<'ch> {
+    fn new(chars: &'ch str, terminator: char) -> Self {
         ParSplitTerminator {
             splitter: ParSplit::new(chars, terminator),
+        }
+    }
+}
+
+impl<'ch, 'sep> ParSplitTerminatorProducer<'ch, 'sep> {
+    fn new(split: &'sep ParSplitTerminator<'ch>) -> Self {
+        ParSplitTerminatorProducer {
+            splitter: ParSplitProducer::new(&split.splitter),
             endpoint: true,
         }
     }
 }
 
-impl<'a> ParallelIterator for ParSplitTerminator<'a> {
-    type Item = &'a str;
+impl<'ch> ParallelIterator for ParSplitTerminator<'ch> {
+    type Item = &'ch str;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
     {
-        bridge_unindexed(self, consumer)
+        let producer = ParSplitTerminatorProducer::new(&self);
+        bridge_unindexed(producer, consumer)
     }
 }
 
-impl<'a> UnindexedProducer for ParSplitTerminator<'a> {
-    type Item = &'a str;
+impl<'ch, 'sep> UnindexedProducer for ParSplitTerminatorProducer<'ch, 'sep> {
+    type Item = &'ch str;
 
     fn split(&mut self) -> Option<Self> {
         self.splitter.split().map(|right| {
             let endpoint = self.endpoint;
             self.endpoint = false;
-            ParSplitTerminator {
+            ParSplitTerminatorProducer {
                 splitter: right,
                 endpoint: endpoint,
             }
@@ -269,7 +297,7 @@ impl<'a> UnindexedProducer for ParSplitTerminator<'a> {
         let skip_last = if self.endpoint {
             let chars = self.splitter.chars;
             let terminator = self.splitter.separator;
-            chars.is_empty() || chars.ends_with(terminator)
+            chars.is_empty() || chars.ends_with(*terminator)
         } else {
             false
         };
@@ -281,10 +309,10 @@ impl<'a> UnindexedProducer for ParSplitTerminator<'a> {
 
 // /////////////////////////////////////////////////////////////////////////
 
-pub struct ParLines<'a>(&'a str);
+pub struct ParLines<'ch>(&'ch str);
 
-impl<'a> ParallelIterator for ParLines<'a> {
-    type Item = &'a str;
+impl<'ch> ParallelIterator for ParLines<'ch> {
+    type Item = &'ch str;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -83,6 +83,8 @@ pub fn execute_strings_split() {
                      ("A..B..", '.'),
                      ("foo\r\nbar\n\nbaz\n", '\n'),
                      ("foo\nbar\n\r\nbaz", '\n'),
+                     ("A few words", ' '),
+                     (" Mary   had\ta\u{2009}little  \n\t lamb", ' '),
                      (include_str!("test.rs"), ' ')];
 
     for &(string, separator) in &tests {
@@ -110,6 +112,12 @@ pub fn execute_strings_split() {
     for &(string, _) in &tests {
         let serial: Vec<_> = string.lines().collect();
         let parallel: Vec<_> = string.par_lines().collect();
+        assert_eq!(serial, parallel);
+    }
+
+    for &(string, _) in &tests {
+        let serial: Vec<_> = string.split_whitespace().collect();
+        let parallel: Vec<_> = string.par_split_whitespace().collect();
         assert_eq!(serial, parallel);
     }
 }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -89,11 +89,21 @@ pub fn execute_strings_split() {
         let serial: Vec<_> = string.split(separator).collect();
         let parallel: Vec<_> = string.par_split(separator).collect();
         assert_eq!(serial, parallel);
+
+        let serial_fn: Vec<_> = string.split(|c| c == separator).collect();
+        let parallel_fn: Vec<_> = string.par_split(|c| c == separator).collect();
+        assert_eq!(serial_fn, parallel_fn);
     }
 
     for &(string, separator) in &tests {
         let serial: Vec<_> = string.split_terminator(separator).collect();
         let parallel: Vec<_> = string.par_split_terminator(separator).collect();
+        assert_eq!(serial, parallel);
+    }
+
+    for &(string, separator) in &tests {
+        let serial: Vec<_> = string.split_terminator(|c| c == separator).collect();
+        let parallel: Vec<_> = string.par_split_terminator(|c| c == separator).collect();
         assert_eq!(serial, parallel);
     }
 


### PR DESCRIPTION
Both `par_split` and `par_split_terminator` can now accept `Fn(char) -> bool` for the separator, in addition to a simple `char`.  This is somewhat modeled after the standard library `Pattern`, but that's not stable so we can't use it directly.  From this, `par_split_whitespace` follows easily.

This also adds a "private" method to `ParallelString`, as suggested by @bluss, so we can add methods without worrying about breaking third-party implementations.

Fixes #133.