### PR TITLE
Require `Send` output in `map`, `cloned`, `filter_map`

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -176,7 +176,8 @@ pub trait ParallelIterator: Sized {
     /// Applies `map_op` to each item of this iterator, producing a new
     /// iterator with the results.
     fn map<MAP_OP, R>(self, map_op: MAP_OP) -> Map<Self, MapFn<MAP_OP>>
-        where MAP_OP: Fn(Self::Item) -> R + Sync
+        where MAP_OP: Fn(Self::Item) -> R + Sync,
+              R: Send
     {
         Map::new(self, MapFn(map_op))
     }
@@ -184,7 +185,7 @@ pub trait ParallelIterator: Sized {
     /// Creates an iterator which clones all of its elements.  This may be
     /// useful when you have an iterator over `&T`, but you need `T`.
     fn cloned<'a, T>(self) -> Map<Self, MapCloned>
-        where T: 'a + Clone,
+        where T: 'a + Clone + Send,
               Self: ParallelIterator<Item = &'a T>
     {
         Map::new(self, MapCloned)
@@ -210,7 +211,8 @@ pub trait ParallelIterator: Sized {
     /// Applies `filter_op` to each item of this iterator to get an `Option`,
     /// producing a new iterator with only the items from `Some` results.
     fn filter_map<FILTER_OP, R>(self, filter_op: FILTER_OP) -> FilterMap<Self, FILTER_OP>
-        where FILTER_OP: Fn(Self::Item) -> Option<R> + Sync
+        where FILTER_OP: Fn(Self::Item) -> Option<R> + Sync,
+              R: Send
     {
         FilterMap::new(self, filter_op)
     }

--- a/tests/compile-fail/no_send_par_iter.rs
+++ b/tests/compile-fail/no_send_par_iter.rs
@@ -1,0 +1,27 @@
+extern crate rayon;
+
+// Check that `!Send` types fail early.
+
+use rayon::prelude::*;
+use std::ptr::null;
+
+#[derive(Copy, Clone)]
+struct NoSend(*const ());
+
+unsafe impl Sync for NoSend {}
+
+fn main() {
+    let x = Some(NoSend(null()));
+
+    x.par_iter()
+        .map(|&x| x) //~ ERROR Send` is not satisfied
+        .count(); //~ ERROR no method named `count`
+
+    x.par_iter()
+        .filter_map(|&x| Some(x)) //~ ERROR Send` is not satisfied
+        .count(); //~ ERROR Send` is not satisfied
+
+    x.par_iter()
+        .cloned() //~ ERROR Send` is not satisfied
+        .count(); //~ ERROR no method named `count`
+}


### PR DESCRIPTION
All three of these methods lacked any constraints on their output types,
even though it has to be `Send` for the returned adaptor to itself be a
`ParallelIterator`.  This sometimes leads to error messages in usage
that give no indication that missing `Send` is the real problem.  If we
add that requirement up front, it should be a more helpful error.

Fixes #204.