### PR TITLE
Use `find_first` to short-circuit `cmp` and `partial_cmp`

### DIFF
--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -724,39 +724,44 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
 
     /// Lexicographically compares the elements of this `ParallelIterator` with those of
     /// another.
-    fn cmp<I>(self, other: I) -> Ordering
+    fn cmp<I>(mut self, other: I) -> Ordering
         where I: IntoParallelIterator<Item = Self::Item>,
               I::Iter: IndexedParallelIterator,
               Self::Item: Ord
     {
-        self.zip(other.into_par_iter())
+        let mut other = other.into_par_iter();
+        let ord_len = self.len().cmp(&other.len());
+        self.zip(other)
             .map(|(x, y)| Ord::cmp(&x, &y))
             .find_first(|&ord| ord != Ordering::Equal)
-            .unwrap_or(Ordering::Equal)
+            .unwrap_or(ord_len)
     }
 
     /// Lexicographically compares the elements of this `ParallelIterator` with those of
     /// another.
-    fn partial_cmp<I>(self, other: I) -> Option<Ordering>
+    fn partial_cmp<I>(mut self, other: I) -> Option<Ordering>
         where I: IntoParallelIterator,
               I::Iter: IndexedParallelIterator,
               Self::Item: PartialOrd<I::Item>
     {
-        self.zip(other.into_par_iter())
+        let mut other = other.into_par_iter();
+        let ord_len = self.len().cmp(&other.len());
+        self.zip(other)
             .map(|(x, y)| PartialOrd::partial_cmp(&x, &y))
             .find_first(|&ord| ord != Some(Ordering::Equal))
-            .unwrap_or(Some(Ordering::Equal))
+            .unwrap_or(Some(ord_len))
     }
 
     /// Determines if the elements of this `ParallelIterator`
     /// are equal to those of another
-    fn eq<I>(self, other: I) -> bool
+    fn eq<I>(mut self, other: I) -> bool
         where I: IntoParallelIterator,
               I::Iter: IndexedParallelIterator,
               Self::Item: PartialEq<I::Item>
     {
-        self.zip(other.into_par_iter())
-            .all(|(x, y)| x.eq(&y))
+        let mut other = other.into_par_iter();
+        self.len() == other.len() &&
+            self.zip(other).all(|(x, y)| x.eq(&y))
     }
 
     /// Determines if the elements of this `ParallelIterator`

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -731,12 +731,8 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
     {
         self.zip(other.into_par_iter())
             .map(|(x, y)| Ord::cmp(&x, &y))
-            .reduce(|| Ordering::Equal,
-                    |cmp_a, cmp_b| if cmp_a == Ordering::Equal {
-                        cmp_b
-                    } else {
-                        cmp_a
-                    })
+            .find_first(|&ord| ord != Ordering::Equal)
+            .unwrap_or(Ordering::Equal)
     }
 
     /// Lexicographically compares the elements of this `ParallelIterator` with those of
@@ -748,11 +744,8 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
     {
         self.zip(other.into_par_iter())
             .map(|(x, y)| PartialOrd::partial_cmp(&x, &y))
-            .reduce(|| Some(Ordering::Equal), |cmp_a, cmp_b| match cmp_a {
-                Some(Ordering::Equal) => cmp_b,
-                Some(_) => cmp_a,
-                None => None,
-            })
+            .find_first(|&ord| ord != Some(Ordering::Equal))
+            .unwrap_or(Some(Ordering::Equal))
     }
 
     /// Determines if the elements of this `ParallelIterator`

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -600,6 +600,16 @@ pub fn check_partial_cmp_late_nane_to_seq() {
     assert_eq!(par_result, seq_result);
 }
 
+#[test]
+pub fn check_cmp_lengths() {
+    // comparisons should consider length if they are otherwise equal
+    let a = vec![0; 1024];
+    let b = vec![0; 1025];
+
+    assert_eq!(a.par_iter().cmp(&b), a.iter().cmp(&b));
+    assert_eq!(a.par_iter().partial_cmp(&b), a.iter().partial_cmp(&b));
+}
+
 
 #[test]
 pub fn check_eq_direct() {
@@ -631,10 +641,20 @@ pub fn check_ne_direct() {
 
 #[test]
 pub fn check_ne_to_seq() {
-    let par_result = (0..1024).into_par_iter().ne((1..1024).into_par_iter());
-    let seq_result = (0..1024).ne(1..1024);
+    let par_result = (0..1024).into_par_iter().ne((1..1025).into_par_iter());
+    let seq_result = (0..1024).ne(1..1025);
 
     assert_eq!(par_result, seq_result);
+}
+
+#[test]
+pub fn check_ne_lengths() {
+    // equality should consider length too
+    let a = vec![0; 1024];
+    let b = vec![0; 1025];
+
+    assert_eq!(a.par_iter().eq(&b), a.iter().eq(&b));
+    assert_eq!(a.par_iter().ne(&b), a.iter().ne(&b));
 }
 
 #[test]


### PR DESCRIPTION
Lexicographic comparisons are entirely decided by the first unequal
elements, which `find_first` can pull out for us.