### PR TITLE
doc: the `Producer::split_at` index can equal the length

### DIFF
--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -26,7 +26,7 @@ pub trait Producer: IntoIterator + Send + Sized {
     fn cost(&mut self, len: usize) -> f64;
 
     /// Split into two producers; one produces items `0..index`, the
-    /// other `index..N`. Index must be less than `N`.
+    /// other `index..N`. Index must be less than or equal to `N`.
     fn split_at(self, index: usize) -> (Self, Self);
 
     /// Iterate the producer, feeding each element to `folder`, and


### PR DESCRIPTION
It was documented that the index must be strictly less than the length,
but in practice it may also equal the length, especially in the current
`ChainProducer` that often carries a zero-length side around.

Fixes #215.