### PR TITLE
cleanup redundant pointer type in global variable

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -50,13 +50,13 @@ struct RegistryState {
 /// ////////////////////////////////////////////////////////////////////////
 /// Initialization
 
-static mut THE_REGISTRY: Option<&'static Arc<Registry>> = None;
+static mut THE_REGISTRY: Option<&'static Registry> = None;
 static THE_REGISTRY_SET: Once = ONCE_INIT;
 
 /// Starts the worker threads (if that has not already happened). If
 /// initialization has not already occurred, use the default
 /// configuration.
-pub fn global_registry() -> &'static Arc<Registry> {
+pub fn global_registry() -> &'static Registry {
     THE_REGISTRY_SET.call_once(|| unsafe { init_registry(Configuration::new()) });
     unsafe { THE_REGISTRY.unwrap() }
 }
@@ -73,7 +73,7 @@ pub fn get_registry_with_config(config: Configuration) -> &'static Registry {
 /// function. Declared `unsafe` because it writes to `THE_REGISTRY` in
 /// an unsynchronized fashion.
 unsafe fn init_registry(config: Configuration) {
-    let registry = leak(Arc::new(Registry::new(config)));
+    let registry = leak(Registry::new(config));
     THE_REGISTRY = Some(registry);
 }
 


### PR DESCRIPTION
The `Arc` pointer behind a `&'static` reference seems useless.