### PR TITLE
Implement rev

### DIFF
--- a/src/par_iter/chain.rs
+++ b/src/par_iter/chain.rs
@@ -211,7 +211,6 @@ impl<A, B> Producer for ChainProducer<A, B>
 
 pub struct Chain<A, B> {
     chain: iter::Chain<A, B>,
-    len: usize,
 }
 
 impl<A, B> Chain<A, B> {
@@ -219,10 +218,8 @@ impl<A, B> Chain<A, B> {
         where A: ExactSizeIterator,
               B: ExactSizeIterator<Item=A::Item>
     {
-        let len = a.len().checked_add(b.len()).expect("overflow");
         Chain {
             chain: a.chain(b),
-            len: len,
         }
     }
 }
@@ -234,14 +231,11 @@ impl<A, B> Iterator for Chain<A, B> // parameterized over the iterator types
     type Item = A::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.len != 0 {
-            self.len -= 1;
-        }
         self.chain.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
+        self.chain.size_hint()
     }
 }
 
@@ -249,9 +243,6 @@ impl<A, B> ExactSizeIterator for Chain<A, B>
     where A: ExactSizeIterator,
           B: ExactSizeIterator<Item=A::Item>
 {
-    fn len(&self) -> usize {
-        self.len
-    }
 }
 
 impl<A, B> DoubleEndedIterator for Chain<A, B>
@@ -259,9 +250,6 @@ impl<A, B> DoubleEndedIterator for Chain<A, B>
           B: DoubleEndedIterator<Item=A::Item>
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.len != 0 {
-            self.len -= 1;
-        }
         self.chain.next_back()
     }
 }

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -18,8 +18,13 @@ pub trait ProducerCallback<ITEM> {
 /// it.
 pub trait Producer: Send + Sized
 {
+    // Rust issue https://github.com/rust-lang/rust/issues/20671
+    // prevents us from declaring the DoubleEndedIterator and
+    // ExactSizeIterator constraints on a required IntoIterator trait,
+    // so we inline IntoIterator here until that issue is fixed.
     type Item;
     type IntoIter: Iterator<Item = Self::Item> + DoubleEndedIterator + ExactSizeIterator;
+
     fn into_iter(self) -> Self::IntoIter;
 
     /// Reports whether the producer has explicit weights.

--- a/src/par_iter/internal.rs
+++ b/src/par_iter/internal.rs
@@ -16,7 +16,12 @@ pub trait ProducerCallback<ITEM> {
 /// A producer which will produce a fixed number of items N. This is
 /// not queryable through the API; the consumer is expected to track
 /// it.
-pub trait Producer: IntoIterator + Send + Sized {
+pub trait Producer: Send + Sized
+{
+    type Item;
+    type IntoIter: Iterator<Item = Self::Item> + DoubleEndedIterator + ExactSizeIterator;
+    fn into_iter(self) -> Self::IntoIter;
+
     /// Reports whether the producer has explicit weights.
     fn weighted(&self) -> bool {
         false
@@ -36,7 +41,7 @@ pub trait Producer: IntoIterator + Send + Sized {
     fn fold_with<F>(self, folder: F) -> F
         where F: Folder<Self::Item>,
     {
-        folder.consume_iter(self)
+        folder.consume_iter(self.into_iter())
     }
 }
 

--- a/src/par_iter/mod.rs
+++ b/src/par_iter/mod.rs
@@ -28,6 +28,7 @@ use self::take::Take;
 use self::internal::*;
 use self::weight::Weight;
 use self::zip::ZipIter;
+use self::rev::Rev;
 
 pub use self::string::ParallelString;
 
@@ -58,6 +59,7 @@ pub mod vec;
 pub mod option;
 pub mod collections;
 pub mod noop;
+pub mod rev;
 
 #[cfg(test)]
 mod test;
@@ -891,5 +893,11 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
         where POSITION_OP: Fn(Self::Item) -> bool + Sync
     {
         self.position_any(predicate)
+    }
+
+    /// Produces a new iterator with the elements of this iterator in
+    /// reverse order.
+    fn rev(self) -> Rev<Self> {
+        Rev::new(self)
     }
 }

--- a/src/par_iter/option.rs
+++ b/src/par_iter/option.rs
@@ -112,6 +112,13 @@ pub struct OptionProducer<T: Send> {
 }
 
 impl<T: Send> Producer for OptionProducer<T> {
+    type Item = T;
+    type IntoIter = std::option::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.opt.into_iter()
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         len as f64
     }
@@ -123,14 +130,5 @@ impl<T: Send> Producer for OptionProducer<T> {
         } else {
             (self, none)
         }
-    }
-}
-
-impl<T: Send> IntoIterator for OptionProducer<T> {
-    type Item = T;
-    type IntoIter = std::option::IntoIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.opt.into_iter()
     }
 }

--- a/src/par_iter/range.rs
+++ b/src/par_iter/range.rs
@@ -71,6 +71,13 @@ macro_rules! indexed_range_impl {
         }
 
         impl Producer for RangeIter<$t> {
+
+            type Item = <Range<$t> as Iterator>::Item;
+            type IntoIter = Range<$t>;
+            fn into_iter(self) -> Self::IntoIter {
+                self.range
+            }
+
             fn cost(&mut self, len: usize) -> f64 {
                 len as f64
             }

--- a/src/par_iter/rev.rs
+++ b/src/par_iter/rev.rs
@@ -1,0 +1,112 @@
+use super::internal::*;
+use super::*;
+use std::iter;
+
+pub struct Rev<M> {
+    base: M,
+}
+
+impl<M> Rev<M> {
+    pub fn new(base: M) -> Rev<M> {
+        Rev { base: base }
+    }
+}
+
+impl<M> ParallelIterator for Rev<M>
+    where M: IndexedParallelIterator
+{
+    type Item = M::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+impl<M> BoundedParallelIterator for Rev<M>
+    where M: IndexedParallelIterator
+{
+    fn upper_bound(&mut self) -> usize {
+        self.len()
+    }
+
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+}
+
+impl<M> ExactParallelIterator for Rev<M>
+    where M: IndexedParallelIterator
+{
+    fn len(&mut self) -> usize {
+        self.base.len()
+    }
+}
+
+impl<M> IndexedParallelIterator for Rev<M>
+    where M: IndexedParallelIterator
+{
+    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        let len = self.base.len();
+        return self.base.with_producer(Callback { callback: callback, len: len });
+
+        struct Callback<CB> {
+            callback: CB,
+            len: usize,
+        }
+
+        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
+            where CB: ProducerCallback<ITEM>
+        {
+            type Output = CB::Output;
+            fn callback<P>(self, base: P) -> CB::Output
+                where P: Producer<Item = ITEM>,
+            {
+                let producer = RevProducer { base: base, len: self.len };
+                self.callback.callback(producer)
+            }
+        }
+    }
+}
+
+struct RevProducer<P> {
+    base: P,
+    len: usize,
+}
+
+impl<P> Producer for RevProducer<P>
+    where P: Producer,
+{
+    type Item = P::Item;
+    type IntoIter = iter::Rev<P::IntoIter>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.base.into_iter().rev()
+    }
+
+    fn weighted(&self) -> bool {
+        self.base.weighted()
+    }
+
+    fn cost(&mut self, items: usize) -> f64 {
+        self.base.cost(items)
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        let (left, right) = self.base.split_at(self.len - index);
+        (RevProducer {
+            base: right,
+            len: index,
+         },
+         RevProducer {
+             base: left,
+             len: self.len - index,
+         })
+    }
+}

--- a/src/par_iter/rev.rs
+++ b/src/par_iter/rev.rs
@@ -86,6 +86,7 @@ impl<P> Producer for RevProducer<P>
 {
     type Item = P::Item;
     type IntoIter = iter::Rev<P::IntoIter>;
+
     fn into_iter(self) -> Self::IntoIter {
         self.base.into_iter().rev()
     }

--- a/src/par_iter/slice.rs
+++ b/src/par_iter/slice.rs
@@ -130,6 +130,13 @@ pub struct SliceProducer<'data, T: 'data + Sync> {
 }
 
 impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T> {
+    type Item = &'data T;
+    type IntoIter = ::std::slice::Iter<'data, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slice.into_iter()
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         len as f64
     }
@@ -140,21 +147,19 @@ impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T> {
     }
 }
 
-impl<'data, T: 'data + Sync> IntoIterator for SliceProducer<'data, T> {
-    type Item = &'data T;
-    type IntoIter = ::std::slice::Iter<'data, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.slice.into_iter()
-    }
-}
-
 pub struct SliceChunksProducer<'data, T: 'data + Sync> {
     chunk_size: usize,
     slice: &'data [T],
 }
 
 impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
+    type Item = &'data [T];
+    type IntoIter = ::std::slice::Chunks<'data, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slice.chunks(self.chunk_size)
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         len as f64
     }
@@ -170,14 +175,5 @@ impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
              chunk_size: self.chunk_size,
              slice: right,
          })
-    }
-}
-
-impl<'data, T: 'data + Sync> IntoIterator for SliceChunksProducer<'data, T> {
-    type Item = &'data [T];
-    type IntoIter = ::std::slice::Chunks<'data, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.slice.chunks(self.chunk_size)
     }
 }

--- a/src/par_iter/slice_mut.rs
+++ b/src/par_iter/slice_mut.rs
@@ -130,6 +130,13 @@ pub struct SliceMutProducer<'data, T: 'data + Send> {
 }
 
 impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T> {
+    type Item = &'data mut T;
+    type IntoIter = ::std::slice::IterMut<'data, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slice.into_iter()
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         len as f64
     }
@@ -140,21 +147,19 @@ impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T> {
     }
 }
 
-impl<'data, T: 'data + Send> IntoIterator for SliceMutProducer<'data, T> {
-    type Item = &'data mut T;
-    type IntoIter = ::std::slice::IterMut<'data, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.slice.into_iter()
-    }
-}
-
 pub struct SliceChunksMutProducer<'data, T: 'data + Send> {
     chunk_size: usize,
     slice: &'data mut [T],
 }
 
 impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
+    type Item = &'data mut [T];
+    type IntoIter = ::std::slice::ChunksMut<'data, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.slice.chunks_mut(self.chunk_size)
+    }
+
     fn cost(&mut self, len: usize) -> f64 {
         len as f64
     }
@@ -170,14 +175,5 @@ impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
              chunk_size: self.chunk_size,
              slice: right,
          })
-    }
-}
-
-impl<'data, T: 'data + Send> IntoIterator for SliceChunksMutProducer<'data, T> {
-    type Item = &'data mut [T];
-    type IntoIter = ::std::slice::ChunksMut<'data, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.slice.chunks_mut(self.chunk_size)
     }
 }

--- a/src/par_iter/test.rs
+++ b/src/par_iter/test.rs
@@ -1274,3 +1274,14 @@ fn min_max_by() {
                    slice.iter().max_by_key(|x| x.0));
     }
 }
+
+#[test]
+fn check_rev() {
+    let a: Vec<usize> = (0..1024).rev().collect();
+    let b: Vec<usize> = (0..1024).collect();
+
+    assert!(a.par_iter()
+            .rev()
+            .zip(b)
+            .all(|(&a, b)| a == b));
+}

--- a/src/par_iter/weight.rs
+++ b/src/par_iter/weight.rs
@@ -90,6 +90,13 @@ pub struct WeightProducer<P> {
 }
 
 impl<P: Producer> Producer for WeightProducer<P> {
+    type Item = P::Item;
+    type IntoIter = P::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.base.into_iter()
+    }
+
     fn weighted(&self) -> bool {
         true
     }
@@ -108,15 +115,6 @@ impl<P: Producer> Producer for WeightProducer<P> {
              base: right,
              weight: self.weight,
          })
-    }
-}
-
-impl<P: Producer> IntoIterator for WeightProducer<P> {
-    type Item = P::Item;
-    type IntoIter = P::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.base.into_iter()
     }
 }
 

--- a/src/par_iter/zip.rs
+++ b/src/par_iter/zip.rs
@@ -120,6 +120,13 @@ pub struct ZipProducer<A: Producer, B: Producer> {
 }
 
 impl<A: Producer, B: Producer> Producer for ZipProducer<A, B> {
+    type Item = (A::Item, B::Item);
+    type IntoIter = iter::Zip<A::IntoIter, B::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.a.into_iter().zip(self.b.into_iter())
+    }
+
     fn weighted(&self) -> bool {
         self.a.weighted() || self.b.weighted()
     }
@@ -140,14 +147,5 @@ impl<A: Producer, B: Producer> Producer for ZipProducer<A, B> {
              a: a_right,
              b: b_right,
          })
-    }
-}
-
-impl<A: Producer, B: Producer> IntoIterator for ZipProducer<A, B> {
-    type Item = (A::Item, B::Item);
-    type IntoIter = iter::Zip<A::IntoIter, B::IntoIter>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.a.into_iter().zip(self.b)
     }
 }


### PR DESCRIPTION
Fixes #150, using the approach @nikomatsakis suggested. A few notes on problems mentioned in that issue:
* Producer iterator types are required to implement `ExactSizeIterator` as well as `DoubleEndedIterator` (should be fine since producers are based on exact-size parallel iterators anyway).
* We were able to use `Range` inside `enumerate()` after all: since the iterators usable by `enumerate()` are required to be exact-size, their max index is actually `usize::MAX - 1`.
* I wrote a wrapper around `Chain` to make it an `ExactSizeIterator`. This isn't actually correct if adding the lengths of the iterators overflows, but it will work for most cases. This was already an issue anyway, since the same issue could cause issues for `Chain` as an `IndexedParallelIterator`