### PR TITLE
Add a new `rayon::split` to create arbitrary parallel iterators

### DIFF
--- a/rayon-demo/src/quicksort/bench.rs
+++ b/rayon-demo/src/quicksort/bench.rs
@@ -26,3 +26,19 @@ fn quick_sort_seq_bench(b: &mut test::Bencher) {
     bench_harness(super::quick_sort::<Sequential, u32>, b);
 }
 
+#[bench]
+fn quick_sort_splitter(b: &mut test::Bencher) {
+    use rayon::iter::ParallelIterator;
+
+    bench_harness(|vec| {
+        ::rayon::split(vec, |vec| {
+            if vec.len() > 1 {
+                let mid = super::partition(vec);
+                let (left, right) = vec.split_at_mut(mid);
+                (left, Some(right))
+            } else {
+                (vec, None)
+            }
+        }).for_each(super::quick_sort::<Sequential, u32>)
+    }, b);
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -51,6 +51,8 @@ mod reduce;
 pub use self::reduce::{ReduceOp, SumOp, ProductOp};
 mod skip;
 pub use self::skip::Skip;
+mod splitter;
+pub use self::splitter::{split, ParallelSplit};
 mod take;
 pub use self::take::Take;
 mod map;

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -1,0 +1,66 @@
+use super::internal::*;
+use super::*;
+
+/// The `split` function takes arbitrary data and a closure that knows how to
+/// split it, and turns this into a `ParallelIterator`.
+pub fn split<DATA, SPLITTER>(data: DATA, splitter: SPLITTER) -> ParallelSplit<DATA, SPLITTER>
+    where DATA: Send,
+          SPLITTER: Fn(DATA) -> (DATA, Option<DATA>) + Sync
+{
+    ParallelSplit {
+        data: data,
+        splitter: splitter,
+    }
+}
+
+pub struct ParallelSplit<DATA, SPLITTER> {
+    data: DATA,
+    splitter: SPLITTER,
+}
+
+impl<DATA, SPLITTER> ParallelIterator for ParallelSplit<DATA, SPLITTER>
+    where DATA: Send,
+          SPLITTER: Fn(DATA) -> (DATA, Option<DATA>) + Sync
+{
+    type Item = DATA;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        let producer = ParallelSplitProducer {
+            data: self.data,
+            splitter: &self.splitter,
+        };
+        bridge_unindexed(producer, consumer)
+    }
+}
+
+struct ParallelSplitProducer<'a, DATA, SPLITTER: 'a> {
+    data: DATA,
+    splitter: &'a SPLITTER,
+}
+
+impl<'a, DATA, SPLITTER> UnindexedProducer for ParallelSplitProducer<'a, DATA, SPLITTER>
+    where DATA: Send,
+          SPLITTER: Fn(DATA) -> (DATA, Option<DATA>) + Sync
+{
+    type Item = DATA;
+
+    fn split(mut self) -> (Self, Option<Self>) {
+        let splitter = self.splitter;
+        let (left, right) = splitter(self.data);
+        self.data = left;
+        (self, right.map(|data| {
+            ParallelSplitProducer {
+                data: data,
+                splitter: splitter,
+            }
+        }))
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+        where F: Folder<Self::Item>
+    {
+        folder.consume(self.data)
+    }
+}

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1318,3 +1318,20 @@ fn divide_and_conquer<'scope>(scope: &Scope<'scope>, counter: &'scope AtomicUsiz
     }
 }
 
+#[test]
+fn check_split() {
+    use std::ops::Range;
+
+    let a = (0..1024).into_par_iter();
+
+    let b = split(0..1024, |Range { start, end }| {
+        let mid = (end - start) / 2;
+        if mid > start {
+            (start..mid, Some(mid..end))
+        } else {
+            (start..end, None)
+        }
+    }).flat_map(|range| range);
+
+    assert_eq!(a.collect::<Vec<_>>(), b.collect::<Vec<_>>());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod vec;
 
 mod test;
 
+pub use iter::split;
+
 pub use rayon_core::current_num_threads;
 pub use rayon_core::Configuration;
 pub use rayon_core::PanicHandler;

--- a/src/range.rs
+++ b/src/range.rs
@@ -126,15 +126,15 @@ macro_rules! unindexed_range_impl {
         impl UnindexedProducer for RangeIter<$t> {
             type Item = $t;
 
-            fn split(&mut self) -> Option<Self> {
+            fn split(mut self) -> (Self, Option<Self>) {
                 let index = self.len() / 2;
                 if index > 0 {
                     let mid = self.range.start.wrapping_add(index as $t);
                     let right = mid .. self.range.end;
                     self.range.end = mid;
-                    Some(RangeIter { range: right })
+                    (self, Some(RangeIter { range: right }))
                 } else {
-                    None
+                    (self, None)
                 }
             }
 


### PR DESCRIPTION
This takes two arguments, the data and a closure to split it, and
implements a `ParallelIterator`.  The data will be divided using the
usual `par_iter` splitting heuristics, then may be mapped, reduced, etc.
however is needed.

The `fibonacci` and `quicksort` demos have been updated with `split`
examples, where the former splits `n` into `n-2` and `n-1`, and the
latter performs a sorting partition before splitting its slice.