### PR TITLE
Fix the reduction order of flat_map

### DIFF
--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -138,7 +138,7 @@ impl<'m, ITEM, MAPPED_ITEM, C, MAP_OP> Folder<ITEM> for FlatMapFolder<'m, C, MAP
             None => Some(result),
             Some(previous) => {
                 let reducer = self.base.to_reducer();
-                Some(reducer.reduce(result, previous))
+                Some(reducer.reduce(previous, result))
             }
         };
 

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1251,6 +1251,16 @@ pub fn par_iter_collect_linked_list_flat_map_filter() {
 }
 
 #[test]
+pub fn par_iter_unindexed_flat_map() {
+    let b: Vec<i64> = (0_i64..1024)
+        .into_par_iter()
+        .flat_map(|i| Some(i))
+        .collect();
+    let c: Vec<i64> = (0_i64..1024).flat_map(|i| Some(i)).collect();
+    assert_eq!(b, c);
+}
+
+#[test]
 fn min_max() {
     let mut rng = XorShiftRng::from_seed([14159, 26535, 89793, 23846]);
     let a: Vec<i32> = rng.gen_iter().take(1024).collect();


### PR DESCRIPTION
Usually in `flat_map`, the cost is infinite, so `FlatMapFolder` doesn't
expect to ever see more than one item.  However, `UnindexedProducer` is
only using the thief splitter, never weights, so it doesn't notice the
cost and may in fact have multiple items in this fold.

It did handle this possibility just in case, but the order of the reduce
arguments were swapped, with the new result before the previous.  This
is easily seen with collect, where items show up in the wrong order.

(Generally, we require that ops are associative, but not commutative.)