### PR TITLE
add stack_size parameter to Configuration (fixes #179)

### DIFF
--- a/rayon-core/src/configuration.rs
+++ b/rayon-core/src/configuration.rs
@@ -55,6 +55,9 @@ pub struct Configuration {
 
     /// Closure to compute the name of a thread.
     get_thread_name: Option<Box<FnMut(usize) -> String>>,
+
+    /// The stack size for the created worker threads
+    stack_size: Option<usize>,
 }
 
 /// The type for a panic handling closure. Note that this same closure
@@ -68,6 +71,7 @@ impl Configuration {
             num_threads: None,
             get_thread_name: None,
             panic_handler: None,
+            stack_size: None,
         }
     }
 
@@ -124,6 +128,18 @@ impl Configuration {
         self.panic_handler = Some(panic_handler);
         self
     }
+
+    /// Get the stack size of the worker threads
+    pub fn stack_size(&self) -> Option<usize>{
+        self.stack_size
+    }
+
+    /// Set the stack size of the worker threads
+    pub fn set_stack_size(mut self, stack_size: usize) -> Self {
+        self.stack_size = Some(stack_size);
+        self
+    }
+
 
     /// Checks whether the configuration is valid.
     pub fn validate(&self) -> Result<(), InitError> {
@@ -183,7 +199,7 @@ pub fn dump_stats() {
 
 impl fmt::Debug for Configuration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let Configuration { ref num_threads, ref get_thread_name, ref panic_handler } = *self;
+        let Configuration { ref num_threads, ref get_thread_name, ref panic_handler, ref stack_size } = *self;
 
         // Just print `Some("<closure>")` or `None` to the debug
         // output.
@@ -197,6 +213,7 @@ impl fmt::Debug for Configuration {
          .field("num_threads", num_threads)
          .field("get_thread_name", &get_thread_name)
          .field("panic_handler", &panic_handler)
+         .field("stack_size", &stack_size)
          .finish()
     }
 }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -113,6 +113,9 @@ impl Registry {
             if let Some(name) = configuration.thread_name(index) {
                 b = b.name(name);
             }
+            if let Some(stack_size) = configuration.stack_size() {
+                b = b.stack_size(stack_size);
+            }
             // FIXME(#205) recover from this error
             b.spawn(move || unsafe { main_loop(worker, registry, index) }).unwrap();
         }

--- a/tests/run-pass/stack_overflow_crash.rs
+++ b/tests/run-pass/stack_overflow_crash.rs
@@ -1,0 +1,51 @@
+extern crate rayon;
+
+use rayon::*;
+
+use std::process::{self, Command};
+use std::env;
+
+#[cfg(target_os = "linux")]
+use std::os::unix::process::ExitStatusExt;
+
+
+
+fn force_stack_overflow(depth: u32) {
+    let buffer = [0u8; 1024*1024];
+    if depth > 0 {
+        force_stack_overflow(depth - 1);
+    }
+}
+
+fn main() {
+    if env::args().len() == 1 {
+        // first check that the recursivecall actually causes a stack overflow, and does not get optimized away
+        {
+            let status = Command::new(env::current_exe().unwrap())
+                .arg("8")
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), None);
+            #[cfg(target_os = "linux")]
+            assert!(status.signal() == Some(11 /*SIGABRT*/) || status.signal() == Some(6 /*SIGSEGV*/));
+        }
+
+
+        // now run with a larger stack and verify correct operation
+        {
+            let status = Command::new(env::current_exe().unwrap())
+                .arg("48")
+                .status()
+                .unwrap();
+            assert_eq!(status.code(), Some(0));
+            #[cfg(target_os = "linux")]
+            assert_eq!(status.signal(), None);
+        }
+    } else {
+        let stack_size_in_mb: usize = env::args().nth(1).unwrap().parse().unwrap();
+        let pool = ThreadPool::new(Configuration::new().set_stack_size(stack_size_in_mb * 1024 * 1024)).unwrap();
+        let index = pool.install(|| {
+            force_stack_overflow(32);
+        });
+    }
+}


### PR DESCRIPTION
Unfortunately I haven't been able to find a neat way to unit test this.
My first attempt was to force a stack overflow via recursion, but that segfaults the entire process (less than ideal for a unit test).
Using `getrlimit()` only seemed to return the system wide limits.
It might be possible to do something with pthread functions...

I checked via valgrind using the following command:

`valgrind --trace-children=yes --tool=drd --show-stack-usage=yes cargo test --lib -- --nocapture stack_size 2>&1 | grep stack`

Fixes #179 