### PR TITLE
Shorten type param names

### DIFF
--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -5,28 +5,28 @@ use std::ptr;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub struct CollectConsumer<'c, I: Send + 'c> {
+pub struct CollectConsumer<'c, T: Send + 'c> {
     /// Tracks how many items we successfully wrote. Used to guarantee
     /// safety in the face of panics or buggy parallel iterators.
     writes: &'c AtomicUsize,
 
     /// A slice covering the target memory, not yet initialized!
-    target: &'c mut [I],
+    target: &'c mut [T],
 }
 
-pub struct CollectFolder<'c, I: Send + 'c> {
+pub struct CollectFolder<'c, T: Send + 'c> {
     global_writes: &'c AtomicUsize,
     local_writes: usize,
 
     /// An iterator over the *uninitialized* target memory.
-    target: slice::IterMut<'c, I>,
+    target: slice::IterMut<'c, T>,
 }
 
 
-impl<'c, I: Send + 'c> CollectConsumer<'c, I> {
+impl<'c, T: Send + 'c> CollectConsumer<'c, T> {
     /// The target memory is considered uninitialized, and will be
     /// overwritten without dropping anything.
-    pub fn new(writes: &'c AtomicUsize, target: &'c mut [I]) -> CollectConsumer<'c, I> {
+    pub fn new(writes: &'c AtomicUsize, target: &'c mut [T]) -> CollectConsumer<'c, T> {
         CollectConsumer {
             writes: writes,
             target: target,
@@ -34,8 +34,8 @@ impl<'c, I: Send + 'c> CollectConsumer<'c, I> {
     }
 }
 
-impl<'c, I: Send + 'c> Consumer<I> for CollectConsumer<'c, I> {
-    type Folder = CollectFolder<'c, I>;
+impl<'c, T: Send + 'c> Consumer<T> for CollectConsumer<'c, T> {
+    type Folder = CollectFolder<'c, T>;
     type Reducer = NoopReducer;
     type Result = ();
 
@@ -55,7 +55,7 @@ impl<'c, I: Send + 'c> Consumer<I> for CollectConsumer<'c, I> {
         (CollectConsumer::new(writes, left), CollectConsumer::new(writes, right), NoopReducer)
     }
 
-    fn into_folder(self) -> CollectFolder<'c, I> {
+    fn into_folder(self) -> CollectFolder<'c, T> {
         CollectFolder {
             global_writes: self.writes,
             local_writes: 0,
@@ -64,10 +64,10 @@ impl<'c, I: Send + 'c> Consumer<I> for CollectConsumer<'c, I> {
     }
 }
 
-impl<'c, I: Send + 'c> Folder<I> for CollectFolder<'c, I> {
+impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
     type Result = ();
 
-    fn consume(mut self, item: I) -> CollectFolder<'c, I> {
+    fn consume(mut self, item: T) -> CollectFolder<'c, T> {
         // Compute target pointer and write to it. Safe because the iterator
         // does all the bounds checking; we're only avoiding the target drop.
         let head = self.target.next().expect("too many values pushed to consumer");
@@ -89,7 +89,7 @@ impl<'c, I: Send + 'c> Folder<I> for CollectFolder<'c, I> {
 
 /// Pretend to be unindexed for `special_collect_into`,
 /// but we should never actually get used that way...
-impl<'c, I: Send + 'c> UnindexedConsumer<I> for CollectConsumer<'c, I> {
+impl<'c, T: Send + 'c> UnindexedConsumer<T> for CollectConsumer<'c, T> {
     fn split_off_left(&self) -> Self {
         unreachable!("CollectConsumer must be indexed!")
     }
@@ -97,3 +97,4 @@ impl<'c, I: Send + 'c> UnindexedConsumer<I> for CollectConsumer<'c, I> {
         NoopReducer
     }
 }
+

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -8,8 +8,8 @@ mod consumer;
 use self::consumer::CollectConsumer;
 
 /// Collects the results of the exact iterator into the specified vector.
-pub fn collect_into<PAR_ITER, T>(mut pi: PAR_ITER, v: &mut Vec<T>)
-    where PAR_ITER: ExactParallelIterator<Item = T>,
+pub fn collect_into<I, T>(mut pi: I, v: &mut Vec<T>)
+    where I: ExactParallelIterator<Item = T>,
           T: Send
 {
     let mut collect = Collect::new(v, pi.len());
@@ -28,8 +28,8 @@ pub fn collect_into<PAR_ITER, T>(mut pi: PAR_ITER, v: &mut Vec<T>)
 /// *any* `ParallelIterator` here, and `CollectConsumer` has to also implement
 /// `UnindexedConsumer`.  That implementation panics `unreachable!` in case
 /// there's a bug where we actually do try to use this unindexed.
-fn special_collect_into<PAR_ITER, T>(pi: PAR_ITER, len: usize, v: &mut Vec<T>)
-    where PAR_ITER: ParallelIterator<Item = T>,
+fn special_collect_into<I, T>(pi: I, len: usize, v: &mut Vec<T>)
+    where I: ParallelIterator<Item = T>,
           T: Send
 {
     let mut collect = Collect::new(v, len);
@@ -90,8 +90,8 @@ impl<'c, T: Send + 'c> Collect<'c, T> {
 impl<T> FromParallelIterator<T> for Vec<T>
     where T: Send
 {
-    fn from_par_iter<PAR_ITER>(par_iter: PAR_ITER) -> Self
-        where PAR_ITER: IntoParallelIterator<Item = T>
+    fn from_par_iter<I>(par_iter: I) -> Self
+        where I: IntoParallelIterator<Item = T>
     {
         // See the vec_collect benchmarks in rayon-demo for different strategies.
         let mut par_iter = par_iter.into_par_iter();

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -9,23 +9,23 @@ use std::usize;
 ///
 /// [`enumerate()`]: trait.ParallelIterator.html#method.enumerate
 /// [`ParallelIterator`]: trait.ParallelIterator.html
-pub struct Enumerate<M: IndexedParallelIterator> {
-    base: M,
+pub struct Enumerate<I: IndexedParallelIterator> {
+    base: I,
 }
 
 /// Create a new `Enumerate` iterator.
 ///
 /// NB: a free fn because it is NOT part of the end-user API.
-pub fn new<M>(base: M) -> Enumerate<M>
-    where M: IndexedParallelIterator
+pub fn new<I>(base: I) -> Enumerate<I>
+    where I: IndexedParallelIterator
 {
     Enumerate { base: base }
 }
 
-impl<M> ParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator
+impl<I> ParallelIterator for Enumerate<I>
+    where I: IndexedParallelIterator
 {
-    type Item = (usize, M::Item);
+    type Item = (usize, I::Item);
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
@@ -38,8 +38,8 @@ impl<M> ParallelIterator for Enumerate<M>
     }
 }
 
-impl<M> BoundedParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator
+impl<I> BoundedParallelIterator for Enumerate<I>
+    where I: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -50,16 +50,16 @@ impl<M> BoundedParallelIterator for Enumerate<M>
     }
 }
 
-impl<M> ExactParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator
+impl<I> ExactParallelIterator for Enumerate<I>
+    where I: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.base.len()
     }
 }
 
-impl<M> IndexedParallelIterator for Enumerate<M>
-    where M: IndexedParallelIterator
+impl<I> IndexedParallelIterator for Enumerate<I>
+    where I: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -70,12 +70,12 @@ impl<M> IndexedParallelIterator for Enumerate<M>
             callback: CB,
         }
 
-        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
-            where CB: ProducerCallback<(usize, ITEM)>
+        impl<I, CB> ProducerCallback<I> for Callback<CB>
+            where CB: ProducerCallback<(usize, I)>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = ITEM>
+                where P: Producer<Item = I>
             {
                 let producer = EnumerateProducer {
                     base: base,
@@ -129,3 +129,4 @@ impl<P> Producer for EnumerateProducer<P>
          })
     }
 }
+

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -201,8 +201,8 @@ pub trait ParallelIterator: Sized {
     /// Applies `inspect_op` to a reference to each item of this iterator,
     /// producing a new iterator passing through the original items.  This is
     /// often useful for debugging to see what's happening in iterator stages.
-    fn inspect<INSPECT_OP>(self, inspect_op: INSPECT_OP) -> Map<Self, MapInspect<INSPECT_OP>>
-        where INSPECT_OP: Fn(&Self::Item) + Sync
+    fn inspect<OP>(self, inspect_op: OP) -> Map<Self, MapInspect<OP>>
+        where OP: Fn(&Self::Item) + Sync
     {
         map::new(self, MapInspect(inspect_op))
     }
@@ -431,13 +431,10 @@ pub trait ParallelIterator: Sized {
     ///                .sum();
     /// assert_eq!(sum, (0..22).sum()); // compare to sequential
     /// ```
-    fn fold<ITEM, ID, F>(self,
-                                              identity: ID,
-                                              fold_op: F)
-                                              -> fold::Fold<Self, ID, F>
-        where F: Fn(ITEM, Self::Item) -> ITEM + Sync,
-              ID: Fn() -> ITEM + Sync,
-              ITEM: Send
+    fn fold<T, ID, F>(self, identity: ID, fold_op: F) -> fold::Fold<Self, ID, F>
+        where F: Fn(T, Self::Item) -> T + Sync,
+              ID: Fn() -> T + Sync,
+              T: Send
     {
         fold::fold(self, identity, fold_op)
     }
@@ -556,8 +553,8 @@ pub trait ParallelIterator: Sized {
     }
 
     /// Takes two iterators and creates a new iterator over both.
-    fn chain<CHAIN>(self, chain: CHAIN) -> Chain<Self, CHAIN::Iter>
-        where CHAIN: IntoParallelIterator<Item = Self::Item>
+    fn chain<C>(self, chain: C) -> Chain<Self, C::Iter>
+        where C: IntoParallelIterator<Item = Self::Item>
     {
         chain::new(self, chain.into_par_iter())
     }

--- a/src/iter/noop.rs
+++ b/src/iter/noop.rs
@@ -8,7 +8,7 @@ impl NoopConsumer {
     }
 }
 
-impl<ITEM> Consumer<ITEM> for NoopConsumer {
+impl<T> Consumer<T> for NoopConsumer {
     type Folder = NoopConsumer;
     type Reducer = NoopReducer;
     type Result = ();
@@ -26,17 +26,17 @@ impl<ITEM> Consumer<ITEM> for NoopConsumer {
     }
 }
 
-impl<ITEM> Folder<ITEM> for NoopConsumer {
+impl<T> Folder<T> for NoopConsumer {
     type Result = ();
 
-    fn consume(self, _item: ITEM) -> Self {
+    fn consume(self, _item: T) -> Self {
         self
     }
 
     fn complete(self) {}
 }
 
-impl<ITEM> UnindexedConsumer<ITEM> for NoopConsumer {
+impl<T> UnindexedConsumer<T> for NoopConsumer {
     fn split_off_left(&self) -> Self {
         NoopConsumer
     }
@@ -51,3 +51,4 @@ pub struct NoopReducer;
 impl Reducer<()> for NoopReducer {
     fn reduce(self, _left: (), _right: ()) {}
 }
+

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -2,23 +2,23 @@ use super::internal::*;
 use super::*;
 use std::iter;
 
-pub struct Rev<M: IndexedParallelIterator> {
-    base: M,
+pub struct Rev<I: IndexedParallelIterator> {
+    base: I,
 }
 
 /// Create a new `Rev` iterator.
 ///
 /// NB: a free fn because it is NOT part of the end-user API.
-pub fn new<M>(base: M) -> Rev<M>
-    where M: IndexedParallelIterator
+pub fn new<I>(base: I) -> Rev<I>
+    where I: IndexedParallelIterator
 {
     Rev { base: base }
 }
 
-impl<M> ParallelIterator for Rev<M>
-    where M: IndexedParallelIterator
+impl<I> ParallelIterator for Rev<I>
+    where I: IndexedParallelIterator
 {
-    type Item = M::Item;
+    type Item = I::Item;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
@@ -31,8 +31,8 @@ impl<M> ParallelIterator for Rev<M>
     }
 }
 
-impl<M> BoundedParallelIterator for Rev<M>
-    where M: IndexedParallelIterator
+impl<I> BoundedParallelIterator for Rev<I>
+    where I: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -43,16 +43,16 @@ impl<M> BoundedParallelIterator for Rev<M>
     }
 }
 
-impl<M> ExactParallelIterator for Rev<M>
-    where M: IndexedParallelIterator
+impl<I> ExactParallelIterator for Rev<I>
+    where I: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.base.len()
     }
 }
 
-impl<M> IndexedParallelIterator for Rev<M>
-    where M: IndexedParallelIterator
+impl<I> IndexedParallelIterator for Rev<I>
+    where I: IndexedParallelIterator
 {
     fn with_producer<CB>(mut self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -68,12 +68,12 @@ impl<M> IndexedParallelIterator for Rev<M>
             len: usize,
         }
 
-        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
-            where CB: ProducerCallback<ITEM>
+        impl<T, CB> ProducerCallback<T> for Callback<CB>
+            where CB: ProducerCallback<T>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = ITEM>
+                where P: Producer<Item = T>
             {
                 let producer = RevProducer {
                     base: base,
@@ -120,3 +120,4 @@ impl<P> Producer for RevProducer<P>
          })
     }
 }
+

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -8,25 +8,25 @@ use std::cmp::min;
 ///
 /// [`skip()`]: trait.ParallelIterator.html#method.skip
 /// [`ParallelIterator`]: trait.ParallelIterator.html
-pub struct Skip<M> {
-    base: M,
+pub struct Skip<I> {
+    base: I,
     n: usize,
 }
 
 /// Create a new `Skip` iterator.
 ///
 /// NB: a free fn because it is NOT part of the end-user API.
-pub fn new<M>(mut base: M, n: usize) -> Skip<M>
-    where M: IndexedParallelIterator
+pub fn new<I>(mut base: I, n: usize) -> Skip<I>
+    where I: IndexedParallelIterator
 {
     let n = min(base.len(), n);
     Skip { base: base, n: n }
 }
 
-impl<M> ParallelIterator for Skip<M>
-    where M: IndexedParallelIterator
+impl<I> ParallelIterator for Skip<I>
+    where I: IndexedParallelIterator
 {
-    type Item = M::Item;
+    type Item = I::Item;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
@@ -39,16 +39,16 @@ impl<M> ParallelIterator for Skip<M>
     }
 }
 
-impl<M> ExactParallelIterator for Skip<M>
-    where M: IndexedParallelIterator
+impl<I> ExactParallelIterator for Skip<I>
+    where I: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.base.len() - self.n
     }
 }
 
-impl<M> BoundedParallelIterator for Skip<M>
-    where M: IndexedParallelIterator
+impl<I> BoundedParallelIterator for Skip<I>
+    where I: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -59,8 +59,8 @@ impl<M> BoundedParallelIterator for Skip<M>
     }
 }
 
-impl<M> IndexedParallelIterator for Skip<M>
-    where M: IndexedParallelIterator
+impl<I> IndexedParallelIterator for Skip<I>
+    where I: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -75,12 +75,12 @@ impl<M> IndexedParallelIterator for Skip<M>
             n: usize,
         }
 
-        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
-            where CB: ProducerCallback<ITEM>
+        impl<T, CB> ProducerCallback<T> for Callback<CB>
+            where CB: ProducerCallback<T>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = ITEM>
+                where P: Producer<Item = T>
             {
                 let (before_skip, after_skip) = base.split_at(self.n);
                 bridge_producer_consumer(self.n, before_skip, NoopConsumer::new());
@@ -89,3 +89,4 @@ impl<M> IndexedParallelIterator for Skip<M>
         }
     }
 }
+

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -3,9 +3,9 @@ use super::*;
 
 /// The `split` function takes arbitrary data and a closure that knows how to
 /// split it, and turns this into a `ParallelIterator`.
-pub fn split<DATA, SPLITTER>(data: DATA, splitter: SPLITTER) -> ParallelSplit<DATA, SPLITTER>
-    where DATA: Send,
-          SPLITTER: Fn(DATA) -> (DATA, Option<DATA>) + Sync
+pub fn split<D, S>(data: D, splitter: S) -> ParallelSplit<D, S>
+    where D: Send,
+          S: Fn(D) -> (D, Option<D>) + Sync
 {
     ParallelSplit {
         data: data,
@@ -13,16 +13,16 @@ pub fn split<DATA, SPLITTER>(data: DATA, splitter: SPLITTER) -> ParallelSplit<DA
     }
 }
 
-pub struct ParallelSplit<DATA, SPLITTER> {
-    data: DATA,
-    splitter: SPLITTER,
+pub struct ParallelSplit<D, S> {
+    data: D,
+    splitter: S,
 }
 
-impl<DATA, SPLITTER> ParallelIterator for ParallelSplit<DATA, SPLITTER>
-    where DATA: Send,
-          SPLITTER: Fn(DATA) -> (DATA, Option<DATA>) + Sync
+impl<D, S> ParallelIterator for ParallelSplit<D, S>
+    where D: Send,
+          S: Fn(D) -> (D, Option<D>) + Sync
 {
-    type Item = DATA;
+    type Item = D;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
@@ -35,16 +35,16 @@ impl<DATA, SPLITTER> ParallelIterator for ParallelSplit<DATA, SPLITTER>
     }
 }
 
-struct ParallelSplitProducer<'a, DATA, SPLITTER: 'a> {
-    data: DATA,
-    splitter: &'a SPLITTER,
+struct ParallelSplitProducer<'a, D, S: 'a> {
+    data: D,
+    splitter: &'a S,
 }
 
-impl<'a, DATA, SPLITTER> UnindexedProducer for ParallelSplitProducer<'a, DATA, SPLITTER>
-    where DATA: Send,
-          SPLITTER: Fn(DATA) -> (DATA, Option<DATA>) + Sync
+impl<'a, D, S> UnindexedProducer for ParallelSplitProducer<'a, D, S>
+    where D: Send,
+          S: Fn(D) -> (D, Option<D>) + Sync
 {
-    type Item = DATA;
+    type Item = D;
 
     fn split(mut self) -> (Self, Option<Self>) {
         let splitter = self.splitter;

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -7,25 +7,25 @@ use std::cmp::min;
 ///
 /// [`take()`]: trait.ParallelIterator.html#method.take
 /// [`ParallelIterator`]: trait.ParallelIterator.html
-pub struct Take<M> {
-    base: M,
+pub struct Take<I> {
+    base: I,
     n: usize,
 }
 
 /// Create a new `Take` iterator.
 ///
 /// NB: a free fn because it is NOT part of the end-user API.
-pub fn new<M>(mut base: M, n: usize) -> Take<M>
-    where M: IndexedParallelIterator
+pub fn new<I>(mut base: I, n: usize) -> Take<I>
+    where I: IndexedParallelIterator
 {
     let n = min(base.len(), n);
     Take { base: base, n: n }
 }
 
-impl<M> ParallelIterator for Take<M>
-    where M: IndexedParallelIterator
+impl<I> ParallelIterator for Take<I>
+    where I: IndexedParallelIterator
 {
-    type Item = M::Item;
+    type Item = I::Item;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
         where C: UnindexedConsumer<Self::Item>
@@ -38,16 +38,16 @@ impl<M> ParallelIterator for Take<M>
     }
 }
 
-impl<M> ExactParallelIterator for Take<M>
-    where M: IndexedParallelIterator
+impl<I> ExactParallelIterator for Take<I>
+    where I: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.n
     }
 }
 
-impl<M> BoundedParallelIterator for Take<M>
-    where M: IndexedParallelIterator
+impl<I> BoundedParallelIterator for Take<I>
+    where I: IndexedParallelIterator
 {
     fn upper_bound(&mut self) -> usize {
         self.len()
@@ -58,8 +58,8 @@ impl<M> BoundedParallelIterator for Take<M>
     }
 }
 
-impl<M> IndexedParallelIterator for Take<M>
-    where M: IndexedParallelIterator
+impl<I> IndexedParallelIterator for Take<I>
+    where I: IndexedParallelIterator
 {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
@@ -74,12 +74,12 @@ impl<M> IndexedParallelIterator for Take<M>
             n: usize,
         }
 
-        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
-            where CB: ProducerCallback<ITEM>
+        impl<T, CB> ProducerCallback<T> for Callback<CB>
+            where CB: ProducerCallback<T>
         {
             type Output = CB::Output;
             fn callback<P>(self, base: P) -> CB::Output
-                where P: Producer<Item = ITEM>
+                where P: Producer<Item = T>
             {
                 let (producer, _) = base.split_at(self.n);
                 self.callback.callback(producer)
@@ -87,3 +87,4 @@ impl<M> IndexedParallelIterator for Take<M>
         }
     }
 }
+

--- a/src/iter/weight.rs
+++ b/src/iter/weight.rs
@@ -65,13 +65,13 @@ impl<M: IndexedParallelIterator> IndexedParallelIterator for Weight<M> {
             callback: CB,
         }
 
-        impl<ITEM, CB> ProducerCallback<ITEM> for Callback<CB>
-            where CB: ProducerCallback<ITEM>
+        impl<I, CB> ProducerCallback<I> for Callback<CB>
+            where CB: ProducerCallback<I>
         {
             type Output = CB::Output;
 
             fn callback<P>(self, base: P) -> Self::Output
-                where P: Producer<Item = ITEM>
+                where P: Producer<Item = I>
             {
                 self.callback.callback(WeightProducer {
                     base: base,
@@ -135,8 +135,8 @@ impl<C> WeightConsumer<C> {
     }
 }
 
-impl<C, ITEM> Consumer<ITEM> for WeightConsumer<C>
-    where C: Consumer<ITEM>
+impl<C, I> Consumer<I> for WeightConsumer<C>
+    where C: Consumer<I>
 {
     type Folder = C::Folder;
     type Reducer = C::Reducer;
@@ -164,8 +164,8 @@ impl<C, ITEM> Consumer<ITEM> for WeightConsumer<C>
     }
 }
 
-impl<C, ITEM> UnindexedConsumer<ITEM> for WeightConsumer<C>
-    where C: UnindexedConsumer<ITEM>
+impl<C, I> UnindexedConsumer<I> for WeightConsumer<C>
+    where C: UnindexedConsumer<I>
 {
     fn split_off_left(&self) -> Self {
         WeightConsumer::new(self.base.split_off_left(), self.weight)


### PR DESCRIPTION
I picked the most obvious letters to me. Mapping operations; `F` for function, for anything that returns a bool; `P` for predicate, etc. I made sure to change the associated lifetimes to match up and fix any formatting changes. Let me know if there's anything you'd like to change. 

#249 