### PR TITLE
Use the standard Sum/Product traits

### DIFF
--- a/rayon-demo/src/pythagoras/mod.rs
+++ b/rayon-demo/src/pythagoras/mod.rs
@@ -22,7 +22,7 @@ fn par_euclid<FM, M, FN, N>(map_m: FM, map_n: FN) -> u32
           FN: Fn(Iter<u32>) -> N + Sync,
           N: ParallelIterator<Item=u32>,
 {
-    map_m((1u32 .. 2000).into_par_iter()).map(|m| {
+    map_m((1u32 .. 2000).into_par_iter()).map(|m| -> u32 {
         map_n((1 .. m).into_par_iter())
             .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
             .map(|n| 4000000 / (m*m + n*n))
@@ -32,7 +32,7 @@ fn par_euclid<FM, M, FN, N>(map_m: FM, map_n: FN) -> u32
 
 /// Same as par_euclid, without tweaking split lengths
 fn par_euclid_weightless() -> u32 {
-    (1u32 .. 2000).into_par_iter().map(|m| {
+    (1u32 .. 2000).into_par_iter().map(|m| -> u32 {
         (1 .. m).into_par_iter()
             .filter(|n| (m - n).is_odd() && m.gcd(n) == 1)
             .map(|n| 4000000 / (m*m + n*n))

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -65,6 +65,7 @@ pub use self::rev::Rev;
 mod len;
 pub use self::len::{MinLen, MaxLen};
 mod sum;
+mod product;
 
 #[cfg(test)]
 mod test;
@@ -430,10 +431,10 @@ pub trait ParallelIterator: Sized {
     /// Basically equivalent to `self.reduce(|| 1, |a, b| a * b)`,
     /// except that the type of `1` and the `*` operation may vary
     /// depending on the type of value being produced.
-    fn product(self) -> Self::Item
-        where Self::Item: Product
+    fn product<P>(self) -> P
+        where P: Send + Product<Self::Item> + Product
     {
-        reduce::reduce(self, reduce::PRODUCT)
+        product::product(self)
     }
 
     /// DEPRECATED
@@ -442,7 +443,7 @@ pub trait ParallelIterator: Sized {
     fn mul(self) -> Self::Item
         where Self::Item: Product
     {
-        reduce::reduce(self, reduce::PRODUCT)
+        product::product(self)
     }
 
     /// Computes the minimum of all the items in the iterator. If the

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -13,7 +13,7 @@
 
 use std::cmp::{self, Ordering};
 use std::iter::{Sum, Product};
-use std::ops::{Fn, Add, Mul};
+use std::ops::Fn;
 use self::internal::*;
 
 // There is a method to the madness here:
@@ -412,7 +412,7 @@ pub trait ParallelIterator: Sized {
     /// except that the type of `0` and the `+` operation may vary
     /// depending on the type of value being produced.
     fn sum(self) -> Self::Item
-        where Self::Item: Sum + Add<Output = Self::Item>
+        where Self::Item: Sum
     {
         reduce::reduce(self, reduce::SUM)
     }
@@ -430,7 +430,7 @@ pub trait ParallelIterator: Sized {
     /// except that the type of `1` and the `*` operation may vary
     /// depending on the type of value being produced.
     fn product(self) -> Self::Item
-        where Self::Item: Product + Mul<Output = Self::Item>
+        where Self::Item: Product
     {
         reduce::reduce(self, reduce::PRODUCT)
     }
@@ -439,7 +439,7 @@ pub trait ParallelIterator: Sized {
     #[deprecated(since = "v0.6.0",
         note = "name changed to `product()` to match sequential iterators")]
     fn mul(self) -> Self::Item
-        where Self::Item: Product + Mul<Output = Self::Item>
+        where Self::Item: Product
     {
         reduce::reduce(self, reduce::PRODUCT)
     }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -12,7 +12,8 @@
 //! good place to start.
 
 use std::cmp::{self, Ordering};
-use std::ops::Fn;
+use std::iter::{Sum, Product};
+use std::ops::{Fn, Add, Mul};
 use self::internal::*;
 
 // There is a method to the madness here:
@@ -45,7 +46,6 @@ mod for_each;
 mod fold;
 pub use self::fold::Fold;
 mod reduce;
-pub use self::reduce::{ReduceOp, SumOp, ProductOp};
 mod skip;
 pub use self::skip::Skip;
 mod splitter;
@@ -412,7 +412,7 @@ pub trait ParallelIterator: Sized {
     /// except that the type of `0` and the `+` operation may vary
     /// depending on the type of value being produced.
     fn sum(self) -> Self::Item
-        where SumOp: ReduceOp<Self::Item>
+        where Self::Item: Sum + Add<Output = Self::Item>
     {
         reduce::reduce(self, reduce::SUM)
     }
@@ -430,7 +430,7 @@ pub trait ParallelIterator: Sized {
     /// except that the type of `1` and the `*` operation may vary
     /// depending on the type of value being produced.
     fn product(self) -> Self::Item
-        where ProductOp: ReduceOp<Self::Item>
+        where Self::Item: Product + Mul<Output = Self::Item>
     {
         reduce::reduce(self, reduce::PRODUCT)
     }
@@ -439,7 +439,7 @@ pub trait ParallelIterator: Sized {
     #[deprecated(since = "v0.6.0",
         note = "name changed to `product()` to match sequential iterators")]
     fn mul(self) -> Self::Item
-        where ProductOp: ReduceOp<Self::Item>
+        where Self::Item: Product + Mul<Output = Self::Item>
     {
         reduce::reduce(self, reduce::PRODUCT)
     }

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -64,6 +64,7 @@ mod rev;
 pub use self::rev::Rev;
 mod len;
 pub use self::len::{MinLen, MaxLen};
+mod sum;
 
 #[cfg(test)]
 mod test;
@@ -388,7 +389,7 @@ pub trait ParallelIterator: Sized {
     /// let bytes = 0..22_u8; // series of u8 bytes
     /// let sum = bytes.into_par_iter()
     ///                .fold(|| 0_u32, |a: u32, b: u8| a + (b as u32))
-    ///                .sum();
+    ///                .sum::<u32>();
     /// assert_eq!(sum, (0..22).sum()); // compare to sequential
     /// ```
     fn fold<T, ID, F>(self, identity: ID, fold_op: F) -> fold::Fold<Self, ID, F>
@@ -411,10 +412,10 @@ pub trait ParallelIterator: Sized {
     /// Basically equivalent to `self.reduce(|| 0, |a, b| a + b)`,
     /// except that the type of `0` and the `+` operation may vary
     /// depending on the type of value being produced.
-    fn sum(self) -> Self::Item
-        where Self::Item: Sum
+    fn sum<S>(self) -> S
+        where S: Send + Sum<Self::Item> + Sum
     {
-        reduce::reduce(self, reduce::SUM)
+        sum::sum(self)
     }
 
     /// Multiplies all the items in the iterator.

--- a/src/iter/product.rs
+++ b/src/iter/product.rs
@@ -1,0 +1,91 @@
+use super::ParallelIterator;
+use super::internal::*;
+
+use std::iter::{self, Product};
+use std::marker::PhantomData;
+
+
+pub fn product<PI, P>(pi: PI) -> P
+    where PI: ParallelIterator,
+          P: Send + Product<PI::Item> + Product
+{
+    pi.drive_unindexed(ProductConsumer::new())
+}
+
+fn mul<T: Product>(left: T, right: T) -> T {
+    iter::once(left).chain(iter::once(right)).product()
+}
+
+
+struct ProductConsumer<P: Send> {
+    _marker: PhantomData<*const P>,
+}
+
+unsafe impl<P: Send> Send for ProductConsumer<P> {}
+
+impl<P: Send> ProductConsumer<P> {
+    fn new() -> ProductConsumer<P> {
+        ProductConsumer { _marker: PhantomData }
+    }
+}
+
+impl<P, T> Consumer<T> for ProductConsumer<P>
+    where P: Send + Product<T> + Product
+{
+    type Folder = ProductFolder<P>;
+    type Reducer = Self;
+    type Result = P;
+
+    fn split_at(self, _index: usize) -> (Self, Self, Self) {
+        (ProductConsumer::new(), ProductConsumer::new(), ProductConsumer::new())
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        ProductFolder { product: iter::empty::<T>().product() }
+    }
+}
+
+impl<P, T> UnindexedConsumer<T> for ProductConsumer<P>
+    where P: Send + Product<T> + Product
+{
+    fn split_off_left(&self) -> Self {
+        ProductConsumer::new()
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        ProductConsumer::new()
+    }
+}
+
+impl<P> Reducer<P> for ProductConsumer<P>
+    where P: Send + Product
+{
+    fn reduce(self, left: P, right: P) -> P {
+        mul(left, right)
+    }
+}
+
+
+struct ProductFolder<P> {
+    product: P,
+}
+
+impl<P, T> Folder<T> for ProductFolder<P>
+    where P: Product<T> + Product
+{
+    type Result = P;
+
+    fn consume(self, item: T) -> Self {
+        ProductFolder { product: mul(self.product, iter::once(item).product()) }
+    }
+
+    fn consume_iter<I>(self, iter: I) -> Self
+        where I: IntoIterator<Item = T>
+    {
+        ProductFolder { product: mul(self.product, iter.into_iter().product()) }
+    }
+
+    fn complete(self) -> P {
+        self.product
+    }
+}

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -1,7 +1,7 @@
 use super::ParallelIterator;
 use super::internal::*;
 
-use std::iter::{self, Sum, Product};
+use std::iter::{self, Product};
 
 /// Specifies a "reduce operator". This is the combination of a start
 /// value and a reduce function. The reduce function takes two items
@@ -134,30 +134,6 @@ impl<'r, R, T> Folder<T> for ReduceFolder<'r, R, T>
 
 /// ////////////////////////////////////////////////////////////////////////
 /// Specific operations
-
-pub struct SumOp;
-
-pub const SUM: &'static SumOp = &SumOp;
-
-impl<T> ReduceOp<T> for SumOp
-    where T: Sum
-{
-    fn start_value(&self) -> T {
-        iter::empty::<T>().sum()
-    }
-
-    fn reduce(&self, value1: T, value2: T) -> T {
-        iter::once(value1).chain(iter::once(value2)).sum()
-    }
-
-    fn reduce_iter<I>(&self, value: T, iter: I) -> T
-        where I: Iterator<Item = T>
-    {
-        iter::once(value).chain(iter).sum()
-    }
-
-    private_impl!{}
-}
 
 pub struct ProductOp;
 

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -1,6 +1,9 @@
 use super::ParallelIterator;
 use super::internal::*;
 
+use std::iter::{self, Sum, Product};
+use std::ops::{Add, Mul};
+
 /// Specifies a "reduce operator". This is the combination of a start
 /// value and a reduce function. The reduce function takes two items
 /// and computes a reduced version. The start value `S` is a kind of
@@ -125,67 +128,37 @@ pub struct SumOp;
 
 pub const SUM: &'static SumOp = &SumOp;
 
-macro_rules! sum_rule {
-    ($i:ty, $z:expr) => {
-        impl ReduceOp<$i> for SumOp {
-            #[inline]
-            fn start_value(&self) -> $i {
-                $z
-            }
-            #[inline]
-            fn reduce(&self, value1: $i, value2: $i) -> $i {
-                value1 + value2
-            }
-            private_impl!{}
-        }
+impl<T> ReduceOp<T> for SumOp
+    where T: Sum + Add<Output = T>
+{
+    fn start_value(&self) -> T {
+        iter::empty::<T>().sum()
     }
-}
 
-sum_rule!(i8, 0);
-sum_rule!(i16, 0);
-sum_rule!(i32, 0);
-sum_rule!(i64, 0);
-sum_rule!(isize, 0);
-sum_rule!(u8, 0);
-sum_rule!(u16, 0);
-sum_rule!(u32, 0);
-sum_rule!(u64, 0);
-sum_rule!(usize, 0);
-sum_rule!(f32, 0.0);
-sum_rule!(f64, 0.0);
+    fn reduce(&self, value1: T, value2: T) -> T {
+        value1 + value2
+    }
+
+    private_impl!{}
+}
 
 pub struct ProductOp;
 
 pub const PRODUCT: &'static ProductOp = &ProductOp;
 
-macro_rules! product_rule {
-    ($i:ty, $z:expr) => {
-        impl ReduceOp<$i> for ProductOp {
-            #[inline]
-            fn start_value(&self) -> $i {
-                $z
-            }
-            #[inline]
-            fn reduce(&self, value1: $i, value2: $i) -> $i {
-                value1 * value2
-            }
-            private_impl!{}
-        }
+impl<T> ReduceOp<T> for ProductOp
+    where T: Product + Mul<Output = T>
+{
+    fn start_value(&self) -> T {
+        iter::empty::<T>().product()
     }
-}
 
-product_rule!(i8, 1);
-product_rule!(i16, 1);
-product_rule!(i32, 1);
-product_rule!(i64, 1);
-product_rule!(isize, 1);
-product_rule!(u8, 1);
-product_rule!(u16, 1);
-product_rule!(u32, 1);
-product_rule!(u64, 1);
-product_rule!(usize, 1);
-product_rule!(f32, 1.0);
-product_rule!(f64, 1.0);
+    fn reduce(&self, value1: T, value2: T) -> T {
+        value1 * value2
+    }
+
+    private_impl!{}
+}
 
 pub struct ReduceWithIdentityOp<'r, ID: 'r, OP: 'r> {
     identity: &'r ID,

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -1,8 +1,6 @@
 use super::ParallelIterator;
 use super::internal::*;
 
-use std::iter::{self, Product};
-
 /// Specifies a "reduce operator". This is the combination of a start
 /// value and a reduce function. The reduce function takes two items
 /// and computes a reduced version. The start value `S` is a kind of
@@ -134,30 +132,6 @@ impl<'r, R, T> Folder<T> for ReduceFolder<'r, R, T>
 
 /// ////////////////////////////////////////////////////////////////////////
 /// Specific operations
-
-pub struct ProductOp;
-
-pub const PRODUCT: &'static ProductOp = &ProductOp;
-
-impl<T> ReduceOp<T> for ProductOp
-    where T: Product
-{
-    fn start_value(&self) -> T {
-        iter::empty::<T>().product()
-    }
-
-    fn reduce(&self, value1: T, value2: T) -> T {
-        iter::once(value1).chain(iter::once(value2)).product()
-    }
-
-    fn reduce_iter<I>(&self, value: T, iter: I) -> T
-        where I: Iterator<Item = T>
-    {
-        iter::once(value).chain(iter).product()
-    }
-
-    private_impl!{}
-}
 
 pub struct ReduceWithIdentityOp<'r, ID: 'r, OP: 'r> {
     identity: &'r ID,

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -2,7 +2,6 @@ use super::ParallelIterator;
 use super::internal::*;
 
 use std::iter::{self, Sum, Product};
-use std::ops::{Add, Mul};
 
 /// Specifies a "reduce operator". This is the combination of a start
 /// value and a reduce function. The reduce function takes two items
@@ -141,20 +140,20 @@ pub struct SumOp;
 pub const SUM: &'static SumOp = &SumOp;
 
 impl<T> ReduceOp<T> for SumOp
-    where T: Sum + Add<Output = T>
+    where T: Sum
 {
     fn start_value(&self) -> T {
         iter::empty::<T>().sum()
     }
 
     fn reduce(&self, value1: T, value2: T) -> T {
-        value1 + value2
+        iter::once(value1).chain(iter::once(value2)).sum()
     }
 
-    fn reduce_iter<I>(&self, value1: T, iter: I) -> T
+    fn reduce_iter<I>(&self, value: T, iter: I) -> T
         where I: Iterator<Item = T>
     {
-        value1 + iter.sum()
+        iter::once(value).chain(iter).sum()
     }
 
     private_impl!{}
@@ -165,20 +164,20 @@ pub struct ProductOp;
 pub const PRODUCT: &'static ProductOp = &ProductOp;
 
 impl<T> ReduceOp<T> for ProductOp
-    where T: Product + Mul<Output = T>
+    where T: Product
 {
     fn start_value(&self) -> T {
         iter::empty::<T>().product()
     }
 
     fn reduce(&self, value1: T, value2: T) -> T {
-        value1 * value2
+        iter::once(value1).chain(iter::once(value2)).product()
     }
 
     fn reduce_iter<I>(&self, value: T, iter: I) -> T
         where I: Iterator<Item = T>
     {
-        value * iter.product()
+        iter::once(value).chain(iter).product()
     }
 
     private_impl!{}

--- a/src/iter/sum.rs
+++ b/src/iter/sum.rs
@@ -1,0 +1,91 @@
+use super::ParallelIterator;
+use super::internal::*;
+
+use std::iter::{self, Sum};
+use std::marker::PhantomData;
+
+
+pub fn sum<PI, S>(pi: PI) -> S
+    where PI: ParallelIterator,
+          S: Send + Sum<PI::Item> + Sum
+{
+    pi.drive_unindexed(SumConsumer::new())
+}
+
+fn add<T: Sum>(left: T, right: T) -> T {
+    iter::once(left).chain(iter::once(right)).sum()
+}
+
+
+struct SumConsumer<S: Send> {
+    _marker: PhantomData<*const S>,
+}
+
+unsafe impl<S: Send> Send for SumConsumer<S> {}
+
+impl<S: Send> SumConsumer<S> {
+    fn new() -> SumConsumer<S> {
+        SumConsumer { _marker: PhantomData }
+    }
+}
+
+impl<S, T> Consumer<T> for SumConsumer<S>
+    where S: Send + Sum<T> + Sum
+{
+    type Folder = SumFolder<S>;
+    type Reducer = Self;
+    type Result = S;
+
+    fn split_at(self, _index: usize) -> (Self, Self, Self) {
+        (SumConsumer::new(), SumConsumer::new(), SumConsumer::new())
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        SumFolder { sum: iter::empty::<T>().sum() }
+    }
+}
+
+impl<S, T> UnindexedConsumer<T> for SumConsumer<S>
+    where S: Send + Sum<T> + Sum
+{
+    fn split_off_left(&self) -> Self {
+        SumConsumer::new()
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        SumConsumer::new()
+    }
+}
+
+impl<S> Reducer<S> for SumConsumer<S>
+    where S: Send + Sum
+{
+    fn reduce(self, left: S, right: S) -> S {
+        add(left, right)
+    }
+}
+
+
+struct SumFolder<S> {
+    sum: S,
+}
+
+impl<S, T> Folder<T> for SumFolder<S>
+    where S: Sum<T> + Sum
+{
+    type Result = S;
+
+    fn consume(self, item: T) -> Self {
+        SumFolder { sum: add(self.sum, iter::once(item).sum()) }
+    }
+
+    fn consume_iter<I>(self, iter: I) -> Self
+        where I: IntoIterator<Item = T>
+    {
+        SumFolder { sum: add(self.sum, iter.into_iter().sum()) }
+    }
+
+    fn complete(self) -> S {
+        self.sum
+    }
+}

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -128,7 +128,7 @@ pub fn check_map_exact_and_bounded() {
 #[test]
 pub fn map_sum() {
     let a: Vec<i32> = (0..1024).collect();
-    let r1 = a.par_iter().map(|&i| i + 1).sum();
+    let r1: i32 = a.par_iter().map(|&i| i + 1).sum();
     let r2 = a.iter().map(|&i| i + 1).fold(0, |a, b| a + b);
     assert_eq!(r1, r2);
 }
@@ -762,10 +762,7 @@ pub fn check_zip_range() {
 #[test]
 pub fn check_sum_filtered_ints() {
     let a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let par_sum_evens = a.par_iter()
-        .filter(|&x| (x & 1) == 0)
-        .map(|&x| x)
-        .sum();
+    let par_sum_evens: i32 = a.par_iter().filter(|&x| (x & 1) == 0).sum();
     let seq_sum_evens = a.iter()
         .filter(|&x| (x & 1) == 0)
         .map(|&x| x)
@@ -776,7 +773,7 @@ pub fn check_sum_filtered_ints() {
 #[test]
 pub fn check_sum_filtermap_ints() {
     let a: Vec<i32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let par_sum_evens =
+    let par_sum_evens: f32 =
         a.par_iter().filter_map(|&x| if (x & 1) == 0 { Some(x as f32) } else { None }).sum();
     let seq_sum_evens = a.iter()
         .filter_map(|&x| if (x & 1) == 0 { Some(x as f32) } else { None })
@@ -788,7 +785,7 @@ pub fn check_sum_filtermap_ints() {
 pub fn check_flat_map_nested_ranges() {
     // FIXME -- why are precise type hints required on the integers here?
 
-    let v = (0_i32..10)
+    let v: i32 = (0_i32..10)
         .into_par_iter()
         .flat_map(|i| (0_i32..10).into_par_iter().map(move |j| (i, j)))
         .map(|(i, j)| i * j)
@@ -808,24 +805,18 @@ pub fn check_empty_flat_map_sum() {
     let empty = &a[..0];
 
     // empty on the inside
-    let b = a.par_iter()
-        .flat_map(|_| empty)
-        .cloned()
-        .sum();
+    let b: i32 = a.par_iter().flat_map(|_| empty).sum();
     assert_eq!(b, 0);
 
     // empty on the outside
-    let c = empty.par_iter()
-        .flat_map(|_| a.par_iter())
-        .cloned()
-        .sum();
+    let c: i32 = empty.par_iter().flat_map(|_| a.par_iter()).sum();
     assert_eq!(c, 0);
 }
 
 #[test]
 pub fn check_chunks() {
     let a: Vec<i32> = vec![1, 5, 10, 4, 100, 3, 1000, 2, 10000, 1];
-    let par_sum_product_pairs =
+    let par_sum_product_pairs: i32 =
         a.par_chunks(2).map(|c| c.iter().map(|&x| x).fold(1, |i, j| i * j)).sum();
     let seq_sum_product_pairs =
         a.chunks(2).map(|c| c.iter().map(|&x| x).fold(1, |i, j| i * j)).fold(0, |i, j| i + j);
@@ -887,16 +878,8 @@ pub fn check_windows() {
 pub fn check_options() {
     let mut a = vec![None, Some(1), None, None, Some(2), Some(4)];
 
-    assert_eq!(7,
-               a.par_iter()
-                   .flat_map(|opt| opt)
-                   .cloned()
-                   .sum());
-    assert_eq!(7,
-               a.par_iter()
-                   .cloned()
-                   .flat_map(|opt| opt)
-                   .sum());
+    assert_eq!(7, a.par_iter().flat_map(|opt| opt).sum());
+    assert_eq!(7, a.par_iter().flat_map(|opt| opt).sum());
 
     a.par_iter_mut().flat_map(|opt| opt).for_each(|x| *x = *x * *x);
 
@@ -905,15 +888,11 @@ pub fn check_options() {
 
 #[test]
 pub fn check_results() {
-    let mut a = vec![Err(()), Ok(1), Err(()), Err(()), Ok(2), Ok(4)];
+    let mut a = vec![Err(()), Ok(1i32), Err(()), Err(()), Ok(2), Ok(4)];
 
-    assert_eq!(7,
-               a.par_iter()
-                   .flat_map(|res| res)
-                   .cloned()
-                   .sum());
+    assert_eq!(7, a.par_iter().flat_map(|res| res).sum());
 
-    assert_eq!(Err(()), a.par_iter().cloned().sum());
+    assert_eq!(Err::<i32, ()>(()), a.par_iter().cloned().sum());
     assert_eq!(Ok(7),
                a.par_iter()
                    .cloned()
@@ -938,7 +917,7 @@ pub fn check_binary_heap() {
 
     let a: BinaryHeap<i32> = (0..10).collect();
 
-    assert_eq!(45, a.par_iter().cloned().sum());
+    assert_eq!(45, a.par_iter().sum());
     assert_eq!(45, a.into_par_iter().sum());
 }
 
@@ -962,7 +941,7 @@ pub fn check_btree_set() {
 
     let a: BTreeSet<i32> = (0..10).collect();
 
-    assert_eq!(45, a.par_iter().cloned().sum());
+    assert_eq!(45, a.par_iter().sum());
     assert_eq!(45, a.into_par_iter().sum());
 }
 
@@ -986,7 +965,7 @@ pub fn check_hash_set() {
 
     let a: HashSet<i32> = (0..10).collect();
 
-    assert_eq!(45, a.par_iter().cloned().sum());
+    assert_eq!(45, a.par_iter().sum());
     assert_eq!(45, a.into_par_iter().sum());
 }
 
@@ -996,7 +975,7 @@ pub fn check_linked_list() {
 
     let mut a: LinkedList<i32> = (0..10).collect();
 
-    assert_eq!(45, a.par_iter().cloned().sum());
+    assert_eq!(45, a.par_iter().sum());
 
     a.par_iter_mut().for_each(|x| *x = -*x);
 
@@ -1013,7 +992,7 @@ pub fn check_vec_deque() {
     a.drain(..5);
     a.extend(0..5);
 
-    assert_eq!(45, a.par_iter().cloned().sum());
+    assert_eq!(45, a.par_iter().sum());
 
     a.par_iter_mut().for_each(|x| *x = -*x);
 

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -913,6 +913,20 @@ pub fn check_results() {
                    .cloned()
                    .sum());
 
+    assert_eq!(Err(()), a.par_iter().cloned().sum());
+    assert_eq!(Ok(7),
+               a.par_iter()
+                   .cloned()
+                   .filter(Result::is_ok)
+                   .sum());
+
+    assert_eq!(Err(()), a.par_iter().cloned().product());
+    assert_eq!(Ok(8),
+               a.par_iter()
+                   .cloned()
+                   .filter(Result::is_ok)
+                   .product());
+
     a.par_iter_mut().flat_map(|res| res).for_each(|x| *x = *x * *x);
 
     assert_eq!(21, a.into_par_iter().flat_map(|res| res).sum());

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -899,7 +899,7 @@ pub fn check_results() {
                    .filter(Result::is_ok)
                    .sum());
 
-    assert_eq!(Err(()), a.par_iter().cloned().product());
+    assert_eq!(Err::<i32, ()>(()), a.par_iter().cloned().product());
     assert_eq!(Ok(8),
                a.par_iter()
                    .cloned()


### PR DESCRIPTION
`SumOp` is replaced by `Sum + Add`, `ProductOp` by `Product + Mul`, and `ReduceOp` is now hidden.

Technically, we could get by without `Add`/`Mul`, but it's easier this way, and I find it unlikely that these would ever be missing from something that implements `Sum`/`Product`.

Fixes #252.