### PR TITLE
add test that drives the collect-consumer, producing too many values

### DIFF
--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -7,6 +7,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 mod consumer;
 use self::consumer::CollectConsumer;
 
+mod test;
+
 /// Collects the results of the exact iterator into the specified vector.
 pub fn collect_into<PAR_ITER, T>(mut pi: PAR_ITER, v: &mut Vec<T>)
     where PAR_ITER: ExactParallelIterator<Item = T>,

--- a/src/iter/collect/test.rs
+++ b/src/iter/collect/test.rs
@@ -1,0 +1,22 @@
+#![cfg(test)]
+
+// These tests are primarily targeting "abusive" producers that will
+// try to drive the "collect consumer" incorrectly. These should
+// result in panics.
+
+use iter::internal::*;
+use super::Collect;
+
+/// Promises to produce 2 items, but then produces 3.  Does not do any
+/// splits at all.
+#[test]
+#[should_panic(expected = "too many values")]
+fn produce_too_many_items() {
+    let mut v = vec![];
+    let mut collect = Collect::new(&mut v, 2);
+    let consumer = collect.as_consumer();
+    let mut folder = consumer.into_folder();
+    folder = folder.consume(22);
+    folder = folder.consume(23);
+    folder.consume(24);
+}


### PR DESCRIPTION
`CollectConsumer` uses unsafe code but is not intended to "trust"
the producers, which are not generally unsafe, so it should be
ready for anything.

cc #53