### PR TITLE
Generalize the private trait marker and use it more

### DIFF
--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -1,6 +1,9 @@
 use super::internal::*;
 use super::*;
 
+/// Specifies a "map operator", transforming values into something else.
+///
+/// Implementing this trait is not permitted outside of `rayon`.
 pub trait MapOp<In>: Sync {
     type Output: Send;
     fn map(&self, value: In) -> Self::Output;

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -4,6 +4,7 @@ use super::*;
 pub trait MapOp<In>: Sync {
     type Output: Send;
     fn map(&self, value: In) -> Self::Output;
+    private_decl!{}
 }
 
 pub struct MapFn<F>(pub F);
@@ -16,6 +17,7 @@ impl<F, In, Out> MapOp<In> for MapFn<F>
     fn map(&self, value: In) -> Out {
         (self.0)(value)
     }
+    private_impl!{}
 }
 
 pub struct MapCloned;
@@ -27,6 +29,7 @@ impl<'a, T> MapOp<&'a T> for MapCloned
     fn map(&self, value: &'a T) -> T {
         value.clone()
     }
+    private_impl!{}
 }
 
 pub struct MapInspect<F>(pub F);
@@ -40,6 +43,7 @@ impl<F, In> MapOp<In> for MapInspect<F>
         (self.0)(&value);
         value
     }
+    private_impl!{}
 }
 
 /// ////////////////////////////////////////////////////////////////////////

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -112,6 +112,9 @@ impl<'data, I: 'data + ?Sized> IntoParallelRefMutIterator<'data> for I
     }
 }
 
+/// Parallel extension for chunks of a collection.
+///
+/// Implementing this trait is not permitted outside of `rayon`.
 pub trait ToParallelChunks<'data> {
     type Iter: ParallelIterator<Item = &'data [Self::Item]>;
     type Item: Sync + 'data;
@@ -129,6 +132,9 @@ pub trait ToParallelChunks<'data> {
     private_decl!{}
 }
 
+/// Parallel extension for mutable chunks of a collection.
+///
+/// Implementing this trait is not permitted outside of `rayon`.
 pub trait ToParallelChunksMut<'data> {
     type Iter: ParallelIterator<Item = &'data mut [Self::Item]>;
     type Item: Send + 'data;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -125,6 +125,8 @@ pub trait ToParallelChunks<'data> {
     /// implementation should strive to maximize chunk size when
     /// possible.
     fn par_chunks(&'data self, size: usize) -> Self::Iter;
+
+    private_decl!{}
 }
 
 pub trait ToParallelChunksMut<'data> {
@@ -140,6 +142,8 @@ pub trait ToParallelChunksMut<'data> {
     /// implementation should strive to maximize chunk size when
     /// possible.
     fn par_chunks_mut(&'data mut self, size: usize) -> Self::Iter;
+
+    private_decl!{}
 }
 
 /// The `ParallelIterator` interface.

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -28,6 +28,7 @@ use super::internal::*;
 pub trait ReduceOp<T>: Sync {
     fn start_value(&self) -> T;
     fn reduce(&self, value1: T, value2: T) -> T;
+    private_decl!{}
 }
 
 pub fn reduce<PI, R, T>(pi: PI, reduce_op: &R) -> T
@@ -133,6 +134,7 @@ macro_rules! sum_rule {
             fn reduce(&self, value1: $i, value2: $i) -> $i {
                 value1 + value2
             }
+            private_impl!{}
         }
     }
 }
@@ -165,6 +167,7 @@ macro_rules! product_rule {
             fn reduce(&self, value1: $i, value2: $i) -> $i {
                 value1 * value2
             }
+            private_impl!{}
         }
     }
 }
@@ -208,5 +211,7 @@ impl<'r, ID, OP, T> ReduceOp<T> for ReduceWithIdentityOp<'r, ID, OP>
     fn reduce(&self, value1: T, value2: T) -> T {
         (self.op)(value1, value2)
     }
+
+    private_impl!{}
 }
 

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -25,6 +25,8 @@ use super::internal::*;
 /// ```
 ///
 /// etc.
+///
+/// Implementing this trait is not permitted outside of `rayon`.
 pub trait ReduceOp<T>: Sync {
     fn start_value(&self) -> T;
     fn reduce(&self, value1: T, value2: T) -> T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ extern crate num_cpus;
 extern crate rand;
 extern crate rayon_core;
 
+#[macro_use]
+mod private;
+
 pub mod iter;
 pub mod option;
 pub mod prelude;

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,0 +1,26 @@
+//! The public parts of this private module are used to create traits
+//! that cannot be implemented outside of our own crate.  This way we
+//! can feel free to extend those traits without worrying about it
+//! being a breaking change for other implementations.
+
+
+/// If this type is pub but not publicly reachable, third parties
+/// can't name it and can't implement traits using it.
+pub struct PrivateMarker;
+
+macro_rules! private_decl {
+    () => {
+        /// This trait is private; this method exists to make it
+        /// impossible to implement outside the crate.
+        #[doc(hidden)]
+        fn __rayon_private__(&self) -> ::private::PrivateMarker;
+    }
+}
+
+macro_rules! private_impl {
+    () => {
+        fn __rayon_private__(&self) -> ::private::PrivateMarker {
+            ::private::PrivateMarker
+        }
+    }
+}

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -37,6 +37,8 @@ impl<'data, T: Sync + 'data> ToParallelChunks<'data> for [T] {
             slice: self,
         }
     }
+
+    private_impl!{}
 }
 
 impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
@@ -206,6 +208,8 @@ impl<'data, T: Send + 'data> ToParallelChunksMut<'data> for [T] {
             slice: self,
         }
     }
+
+    private_impl!{}
 }
 
 impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {

--- a/src/string.rs
+++ b/src/string.rs
@@ -8,12 +8,6 @@ use iter::*;
 use iter::internal::*;
 use std::cmp::min;
 
-mod private {
-    /// If this type is pub but not publically rechable, third parties can't
-    /// name it and can't implement traits using it.
-    pub struct PrivateMarker;
-}
-
 
 /// Test if a byte is the start of a UTF-8 character.
 /// (extracted from `str::is_char_boundary`)
@@ -41,10 +35,7 @@ fn find_char_midpoint(chars: &str) -> usize {
 
 /// Parallel extensions for strings.
 pub trait ParallelString {
-    /// This trait is private; this method exists to make it impossible
-    /// to implement outside the crate.
-    #[doc(hidden)]
-    fn private_parallel_string(&self) -> private::PrivateMarker;
+    private_decl!{}
 
     /// Returns a parallel iterator over the characters of a string.
     fn par_chars(&self) -> ParChars;
@@ -74,9 +65,7 @@ pub trait ParallelString {
 }
 
 impl ParallelString for str {
-    fn private_parallel_string(&self) -> private::PrivateMarker {
-        private::PrivateMarker
-    }
+    private_impl!{}
 
     fn par_chars(&self) -> ParChars {
         ParChars { chars: self }

--- a/src/string.rs
+++ b/src/string.rs
@@ -94,6 +94,7 @@ impl ParallelString for str {
 /// Pattern-matching trait for `ParallelString`, somewhat like a mix of
 /// `std::str::pattern::{Pattern, Searcher}`.
 pub trait Pattern: Sized + Sync {
+    private_decl!{}
     fn find_in(&self, &str) -> Option<usize>;
     fn rfind_in(&self, &str) -> Option<usize>;
     fn is_suffix_of(&self, &str) -> bool;
@@ -101,6 +102,8 @@ pub trait Pattern: Sized + Sync {
 }
 
 impl Pattern for char {
+    private_impl!{}
+
     fn find_in(&self, chars: &str) -> Option<usize> {
         chars.find(*self)
     }
@@ -125,6 +128,8 @@ impl Pattern for char {
 }
 
 impl<FN: Sync + Fn(char) -> bool> Pattern for FN {
+    private_impl!{}
+
     fn find_in(&self, chars: &str) -> Option<usize> {
         chars.find(self)
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -34,6 +34,8 @@ fn find_char_midpoint(chars: &str) -> usize {
 
 
 /// Parallel extensions for strings.
+///
+/// Implementing this trait is not permitted outside of `rayon`.
 pub trait ParallelString {
     private_decl!{}
 
@@ -93,6 +95,8 @@ impl ParallelString for str {
 
 /// Pattern-matching trait for `ParallelString`, somewhat like a mix of
 /// `std::str::pattern::{Pattern, Searcher}`.
+///
+/// Implementing this trait is not permitted outside of `rayon`.
 pub trait Pattern: Sized + Sync {
     private_decl!{}
     fn find_in(&self, &str) -> Option<usize>;


### PR DESCRIPTION
This moves the `private::PrivateMarker` to the top level, and adds `private_decl!{}` and `private_impl!{}` for us to apply this in a uniform way.

This marks several more traits as private using the new macros.  `string::Pattern` is only meant to be used by the already-private `ParallelString`.  I think `iter::MapOp`, and `iter::ReduceOp` should get completely hidden for #228, but we can at least close their implementations until then.  Similarly, I'd like the chunks traits to look more like `ParallelString`, but closing them off now is an incremental step.

I believe all remaining traits are desirable to leave open for outside implementations.