### PR TITLE
Refactor slice extensions into a ParallelSlice trait

### DIFF
--- a/src/iter/collections.rs
+++ b/src/iter/collections.rs
@@ -1,6 +1,6 @@
 use super::{IntoParallelIterator, ParallelIterator};
 use super::chain::Chain;
-use slice::{SliceIter, SliceIterMut};
+use slice::{Iter, IterMut};
 use vec::IntoIter as VecIter;
 use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
 use std::iter::FromIterator;
@@ -85,7 +85,7 @@ vectorized!{ impl<T> IntoParallelIterator for VecDeque<T> }
 
 impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {
     type Item = &'a T;
-    type Iter = Chain<SliceIter<'a, T>, SliceIter<'a, T>>;
+    type Iter = Chain<Iter<'a, T>, Iter<'a, T>>;
 
     fn into_par_iter(self) -> Self::Iter {
         let (a, b) = self.as_slices();
@@ -95,7 +95,7 @@ impl<'a, T: Sync> IntoParallelIterator for &'a VecDeque<T> {
 
 impl<'a, T: Send> IntoParallelIterator for &'a mut VecDeque<T> {
     type Item = &'a mut T;
-    type Iter = Chain<SliceIterMut<'a, T>, SliceIterMut<'a, T>>;
+    type Iter = Chain<IterMut<'a, T>, IterMut<'a, T>>;
 
     fn into_par_iter(self) -> Self::Iter {
         let (a, b) = self.as_mut_slices();

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -112,46 +112,6 @@ impl<'data, I: 'data + ?Sized> IntoParallelRefMutIterator<'data> for I
     }
 }
 
-/// Parallel extension for chunks of a collection.
-///
-/// Implementing this trait is not permitted outside of `rayon`.
-pub trait ToParallelChunks<'data> {
-    type Iter: ParallelIterator<Item = &'data [Self::Item]>;
-    type Item: Sync + 'data;
-
-    /// Returns a parallel iterator over at most `size` elements of
-    /// `self` at a time. The chunks do not overlap.
-    ///
-    /// The policy for how a collection is divided into chunks is not
-    /// dictated here (e.g. a B-tree-like collection may by necessity
-    /// produce many chunks with fewer than `size` elements), but an
-    /// implementation should strive to maximize chunk size when
-    /// possible.
-    fn par_chunks(&'data self, size: usize) -> Self::Iter;
-
-    private_decl!{}
-}
-
-/// Parallel extension for mutable chunks of a collection.
-///
-/// Implementing this trait is not permitted outside of `rayon`.
-pub trait ToParallelChunksMut<'data> {
-    type Iter: ParallelIterator<Item = &'data mut [Self::Item]>;
-    type Item: Send + 'data;
-
-    /// Returns a parallel iterator over at most `size` elements of
-    /// `self` at a time. The chunks are mutable and do not overlap.
-    ///
-    /// The policy for how a collection is divided into chunks is not
-    /// dictated here (e.g. a B-tree-like collection may by necessity
-    /// produce many chunks with fewer than `size` elements), but an
-    /// implementation should strive to maximize chunk size when
-    /// possible.
-    fn par_chunks_mut(&'data mut self, size: usize) -> Self::Iter;
-
-    private_decl!{}
-}
-
 /// The `ParallelIterator` interface.
 pub trait ParallelIterator: Sized {
     type Item: Send;

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -906,6 +906,22 @@ pub fn check_chunks_mut() {
 }
 
 #[test]
+pub fn check_windows() {
+    let a: Vec<i32> = (0..1024).collect();
+    let par: Vec<_> = a.par_windows(2).collect();
+    let seq: Vec<_> = a.windows(2).collect();
+    assert_eq!(par, seq);
+
+    let par: Vec<_> = a.par_windows(100).collect();
+    let seq: Vec<_> = a.windows(100).collect();
+    assert_eq!(par, seq);
+
+    let par: Vec<_> = a.par_windows(1_000_000).collect();
+    let seq: Vec<_> = a.windows(1_000_000).collect();
+    assert_eq!(par, seq);
+}
+
+#[test]
 pub fn check_options() {
     let mut a = vec![None, Some(1), None, None, Some(2), Some(4)];
 

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -919,6 +919,16 @@ pub fn check_windows() {
     let par: Vec<_> = a.par_windows(1_000_000).collect();
     let seq: Vec<_> = a.windows(1_000_000).collect();
     assert_eq!(par, seq);
+
+    let par: Vec<_> = a.par_windows(2)
+        .chain(a.par_windows(1_000_000))
+        .zip(a.par_windows(2))
+        .collect();
+    let seq: Vec<_> = a.windows(2)
+        .chain(a.windows(1_000_000))
+        .zip(a.windows(2))
+        .collect();
+    assert_eq!(par, seq);
 }
 
 #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,8 +10,5 @@ pub use iter::IntoParallelRefIterator;
 pub use iter::IntoParallelRefMutIterator;
 pub use iter::IndexedParallelIterator;
 pub use iter::ParallelIterator;
-pub use iter::ToParallelChunks;
-pub use iter::ToParallelChunksMut;
-pub use slice::{SliceIter, ChunksIter, SliceIterMut, ChunksMutIter};
+pub use slice::ParallelSlice;
 pub use str::ParallelString;
-

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -27,21 +27,27 @@ pub trait ParallelSlice<T> {
 impl<T> ParallelSlice<T> for [T] {
     private_impl!{}
 
-    fn par_windows(&self, window_size: usize) -> Windows<T> where T: Sync {
+    fn par_windows(&self, window_size: usize) -> Windows<T>
+        where T: Sync
+    {
         Windows {
             window_size: window_size,
             slice: self,
         }
     }
 
-    fn par_chunks(&self, chunk_size: usize) -> Chunks<T> where T: Sync {
+    fn par_chunks(&self, chunk_size: usize) -> Chunks<T>
+        where T: Sync
+    {
         Chunks {
             chunk_size: chunk_size,
             slice: self,
         }
     }
 
-    fn par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<T> where T: Send {
+    fn par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<T>
+        where T: Send
+    {
         ChunksMut {
             chunk_size: chunk_size,
             slice: self,
@@ -193,9 +199,9 @@ impl<'data, T: Sync + 'data> IndexedParallelIterator for Chunks<'data, T> {
         where CB: ProducerCallback<Self::Item>
     {
         callback.callback(ChunksProducer {
-            chunk_size: self.chunk_size,
-            slice: self.slice,
-        })
+                              chunk_size: self.chunk_size,
+                              slice: self.slice,
+                          })
     }
 }
 
@@ -271,9 +277,9 @@ impl<'data, T: Sync + 'data> IndexedParallelIterator for Windows<'data, T> {
         where CB: ProducerCallback<Self::Item>
     {
         callback.callback(WindowsProducer {
-            window_size: self.window_size,
-            slice: self.slice,
-        })
+                              window_size: self.window_size,
+                              slice: self.slice,
+                          })
     }
 }
 
@@ -412,9 +418,9 @@ impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMut<'data, T> {
         where CB: ProducerCallback<Self::Item>
     {
         callback.callback(ChunksMutProducer {
-            chunk_size: self.chunk_size,
-            slice: self.slice,
-        })
+                              chunk_size: self.chunk_size,
+                              slice: self.slice,
+                          })
     }
 }
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -4,6 +4,7 @@
 
 use iter::*;
 use iter::internal::*;
+use std::cmp;
 
 /// Parallel extensions for slices.
 ///
@@ -297,7 +298,8 @@ impl<'data, T: 'data + Sync> Producer for WindowsProducer<'data, T> {
     }
 
     fn split_at(self, index: usize) -> (Self, Self) {
-        let left = &self.slice[..index + (self.window_size - 1)];
+        let left_index = cmp::min(self.slice.len(), index + (self.window_size - 1));
+        let left = &self.slice[..left_index];
         let right = &self.slice[index..];
         (WindowsProducer {
              window_size: self.window_size,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -13,36 +13,36 @@ pub trait ParallelSlice<T> {
 
     /// Returns a parallel iterator over all contiguous windows of
     /// length `size`. The windows overlap.
-    fn par_windows(&self, size: usize) -> WindowsIter<T> where T: Sync;
+    fn par_windows(&self, size: usize) -> Windows<T> where T: Sync;
 
     /// Returns a parallel iterator over at most `size` elements of
     /// `self` at a time. The chunks do not overlap.
-    fn par_chunks(&self, size: usize) -> ChunksIter<T> where T: Sync;
+    fn par_chunks(&self, size: usize) -> Chunks<T> where T: Sync;
 
     /// Returns a parallel iterator over at most `size` elements of
     /// `self` at a time. The chunks are mutable and do not overlap.
-    fn par_chunks_mut(&mut self, size: usize) -> ChunksMutIter<T> where T: Send;
+    fn par_chunks_mut(&mut self, size: usize) -> ChunksMut<T> where T: Send;
 }
 
 impl<T> ParallelSlice<T> for [T] {
     private_impl!{}
 
-    fn par_windows(&self, window_size: usize) -> WindowsIter<T> where T: Sync {
-        WindowsIter {
+    fn par_windows(&self, window_size: usize) -> Windows<T> where T: Sync {
+        Windows {
             window_size: window_size,
             slice: self,
         }
     }
 
-    fn par_chunks(&self, chunk_size: usize) -> ChunksIter<T> where T: Sync {
-        ChunksIter {
+    fn par_chunks(&self, chunk_size: usize) -> Chunks<T> where T: Sync {
+        Chunks {
             chunk_size: chunk_size,
             slice: self,
         }
     }
 
-    fn par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMutIter<T> where T: Send {
-        ChunksMutIter {
+    fn par_chunks_mut(&mut self, chunk_size: usize) -> ChunksMut<T> where T: Send {
+        ChunksMut {
             chunk_size: chunk_size,
             slice: self,
         }
@@ -51,47 +51,47 @@ impl<T> ParallelSlice<T> for [T] {
 
 impl<'data, T: Sync + 'data> IntoParallelIterator for &'data [T] {
     type Item = &'data T;
-    type Iter = SliceIter<'data, T>;
+    type Iter = Iter<'data, T>;
 
     fn into_par_iter(self) -> Self::Iter {
-        SliceIter { slice: self }
+        Iter { slice: self }
     }
 }
 
 impl<'data, T: Sync + 'data> IntoParallelIterator for &'data Vec<T> {
     type Item = &'data T;
-    type Iter = SliceIter<'data, T>;
+    type Iter = Iter<'data, T>;
 
     fn into_par_iter(self) -> Self::Iter {
-        SliceIter { slice: self }
+        Iter { slice: self }
     }
 }
 
 impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut [T] {
     type Item = &'data mut T;
-    type Iter = SliceIterMut<'data, T>;
+    type Iter = IterMut<'data, T>;
 
     fn into_par_iter(self) -> Self::Iter {
-        SliceIterMut { slice: self }
+        IterMut { slice: self }
     }
 }
 
 impl<'data, T: Send + 'data> IntoParallelIterator for &'data mut Vec<T> {
     type Item = &'data mut T;
-    type Iter = SliceIterMut<'data, T>;
+    type Iter = IterMut<'data, T>;
 
     fn into_par_iter(self) -> Self::Iter {
-        SliceIterMut { slice: self }
+        IterMut { slice: self }
     }
 }
 
 
 /// Parallel iterator over immutable items in a slice
-pub struct SliceIter<'data, T: 'data + Sync> {
+pub struct Iter<'data, T: 'data + Sync> {
     slice: &'data [T],
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> ParallelIterator for Iter<'data, T> {
     type Item = &'data T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -105,7 +105,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for SliceIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> BoundedParallelIterator for Iter<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -117,25 +117,25 @@ impl<'data, T: Sync + 'data> BoundedParallelIterator for SliceIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> ExactParallelIterator for Iter<'data, T> {
     fn len(&mut self) -> usize {
         self.slice.len()
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for SliceIter<'data, T> {
+impl<'data, T: Sync + 'data> IndexedParallelIterator for Iter<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(SliceProducer { slice: self.slice })
+        callback.callback(IterProducer { slice: self.slice })
     }
 }
 
-struct SliceProducer<'data, T: 'data + Sync> {
+struct IterProducer<'data, T: 'data + Sync> {
     slice: &'data [T],
 }
 
-impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T> {
+impl<'data, T: 'data + Sync> Producer for IterProducer<'data, T> {
     type Item = &'data T;
     type IntoIter = ::std::slice::Iter<'data, T>;
 
@@ -145,18 +145,18 @@ impl<'data, T: 'data + Sync> Producer for SliceProducer<'data, T> {
 
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.slice.split_at(index);
-        (SliceProducer { slice: left }, SliceProducer { slice: right })
+        (IterProducer { slice: left }, IterProducer { slice: right })
     }
 }
 
 
 /// Parallel iterator over immutable non-overlapping chunks of a slice
-pub struct ChunksIter<'data, T: 'data + Sync> {
+pub struct Chunks<'data, T: 'data + Sync> {
     chunk_size: usize,
     slice: &'data [T],
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for ChunksIter<'data, T> {
+impl<'data, T: Sync + 'data> ParallelIterator for Chunks<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -170,7 +170,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for ChunksIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for ChunksIter<'data, T> {
+impl<'data, T: Sync + 'data> BoundedParallelIterator for Chunks<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -182,29 +182,29 @@ impl<'data, T: Sync + 'data> BoundedParallelIterator for ChunksIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for ChunksIter<'data, T> {
+impl<'data, T: Sync + 'data> ExactParallelIterator for Chunks<'data, T> {
     fn len(&mut self) -> usize {
         (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for ChunksIter<'data, T> {
+impl<'data, T: Sync + 'data> IndexedParallelIterator for Chunks<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(SliceChunksProducer {
+        callback.callback(ChunksProducer {
             chunk_size: self.chunk_size,
             slice: self.slice,
         })
     }
 }
 
-struct SliceChunksProducer<'data, T: 'data + Sync> {
+struct ChunksProducer<'data, T: 'data + Sync> {
     chunk_size: usize,
     slice: &'data [T],
 }
 
-impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
+impl<'data, T: 'data + Sync> Producer for ChunksProducer<'data, T> {
     type Item = &'data [T];
     type IntoIter = ::std::slice::Chunks<'data, T>;
 
@@ -215,11 +215,11 @@ impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
     fn split_at(self, index: usize) -> (Self, Self) {
         let elem_index = index * self.chunk_size;
         let (left, right) = self.slice.split_at(elem_index);
-        (SliceChunksProducer {
+        (ChunksProducer {
              chunk_size: self.chunk_size,
              slice: left,
          },
-         SliceChunksProducer {
+         ChunksProducer {
              chunk_size: self.chunk_size,
              slice: right,
          })
@@ -228,12 +228,12 @@ impl<'data, T: 'data + Sync> Producer for SliceChunksProducer<'data, T> {
 
 
 /// Parallel iterator over immutable overlapping windows of a slice
-pub struct WindowsIter<'data, T: 'data + Sync> {
+pub struct Windows<'data, T: 'data + Sync> {
     window_size: usize,
     slice: &'data [T],
 }
 
-impl<'data, T: Sync + 'data> ParallelIterator for WindowsIter<'data, T> {
+impl<'data, T: Sync + 'data> ParallelIterator for Windows<'data, T> {
     type Item = &'data [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -247,7 +247,7 @@ impl<'data, T: Sync + 'data> ParallelIterator for WindowsIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for WindowsIter<'data, T> {
+impl<'data, T: Sync + 'data> BoundedParallelIterator for Windows<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -259,30 +259,30 @@ impl<'data, T: Sync + 'data> BoundedParallelIterator for WindowsIter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for WindowsIter<'data, T> {
+impl<'data, T: Sync + 'data> ExactParallelIterator for Windows<'data, T> {
     fn len(&mut self) -> usize {
         assert!(self.window_size >= 1);
         self.slice.len().saturating_sub(self.window_size - 1)
     }
 }
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for WindowsIter<'data, T> {
+impl<'data, T: Sync + 'data> IndexedParallelIterator for Windows<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(SliceWindowsProducer {
+        callback.callback(WindowsProducer {
             window_size: self.window_size,
             slice: self.slice,
         })
     }
 }
 
-struct SliceWindowsProducer<'data, T: 'data + Sync> {
+struct WindowsProducer<'data, T: 'data + Sync> {
     window_size: usize,
     slice: &'data [T],
 }
 
-impl<'data, T: 'data + Sync> Producer for SliceWindowsProducer<'data, T> {
+impl<'data, T: 'data + Sync> Producer for WindowsProducer<'data, T> {
     type Item = &'data [T];
     type IntoIter = ::std::slice::Windows<'data, T>;
 
@@ -293,11 +293,11 @@ impl<'data, T: 'data + Sync> Producer for SliceWindowsProducer<'data, T> {
     fn split_at(self, index: usize) -> (Self, Self) {
         let left = &self.slice[..index + (self.window_size - 1)];
         let right = &self.slice[index..];
-        (SliceWindowsProducer {
+        (WindowsProducer {
              window_size: self.window_size,
              slice: left,
          },
-         SliceWindowsProducer {
+         WindowsProducer {
              window_size: self.window_size,
              slice: right,
          })
@@ -306,11 +306,11 @@ impl<'data, T: 'data + Sync> Producer for SliceWindowsProducer<'data, T> {
 
 
 /// Parallel iterator over mutable items in a slice
-pub struct SliceIterMut<'data, T: 'data + Send> {
+pub struct IterMut<'data, T: 'data + Send> {
     slice: &'data mut [T],
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> ParallelIterator for IterMut<'data, T> {
     type Item = &'data mut T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -324,7 +324,7 @@ impl<'data, T: Send + 'data> ParallelIterator for SliceIterMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> BoundedParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> BoundedParallelIterator for IterMut<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -336,25 +336,25 @@ impl<'data, T: Send + 'data> BoundedParallelIterator for SliceIterMut<'data, T> 
     }
 }
 
-impl<'data, T: Send + 'data> ExactParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> ExactParallelIterator for IterMut<'data, T> {
     fn len(&mut self) -> usize {
         self.slice.len()
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for SliceIterMut<'data, T> {
+impl<'data, T: Send + 'data> IndexedParallelIterator for IterMut<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(SliceMutProducer { slice: self.slice })
+        callback.callback(IterMutProducer { slice: self.slice })
     }
 }
 
-struct SliceMutProducer<'data, T: 'data + Send> {
+struct IterMutProducer<'data, T: 'data + Send> {
     slice: &'data mut [T],
 }
 
-impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T> {
+impl<'data, T: 'data + Send> Producer for IterMutProducer<'data, T> {
     type Item = &'data mut T;
     type IntoIter = ::std::slice::IterMut<'data, T>;
 
@@ -364,18 +364,18 @@ impl<'data, T: 'data + Send> Producer for SliceMutProducer<'data, T> {
 
     fn split_at(self, index: usize) -> (Self, Self) {
         let (left, right) = self.slice.split_at_mut(index);
-        (SliceMutProducer { slice: left }, SliceMutProducer { slice: right })
+        (IterMutProducer { slice: left }, IterMutProducer { slice: right })
     }
 }
 
 
 /// Parallel iterator over mutable non-overlapping chunks of a slice
-pub struct ChunksMutIter<'data, T: 'data + Send> {
+pub struct ChunksMut<'data, T: 'data + Send> {
     chunk_size: usize,
     slice: &'data mut [T],
 }
 
-impl<'data, T: Send + 'data> ParallelIterator for ChunksMutIter<'data, T> {
+impl<'data, T: Send + 'data> ParallelIterator for ChunksMut<'data, T> {
     type Item = &'data mut [T];
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -389,7 +389,7 @@ impl<'data, T: Send + 'data> ParallelIterator for ChunksMutIter<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMutIter<'data, T> {
+impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMut<'data, T> {
     fn upper_bound(&mut self) -> usize {
         ExactParallelIterator::len(self)
     }
@@ -401,29 +401,29 @@ impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMutIter<'data, T>
     }
 }
 
-impl<'data, T: Send + 'data> ExactParallelIterator for ChunksMutIter<'data, T> {
+impl<'data, T: Send + 'data> ExactParallelIterator for ChunksMut<'data, T> {
     fn len(&mut self) -> usize {
         (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
 }
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMutIter<'data, T> {
+impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMut<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
-        callback.callback(SliceChunksMutProducer {
+        callback.callback(ChunksMutProducer {
             chunk_size: self.chunk_size,
             slice: self.slice,
         })
     }
 }
 
-struct SliceChunksMutProducer<'data, T: 'data + Send> {
+struct ChunksMutProducer<'data, T: 'data + Send> {
     chunk_size: usize,
     slice: &'data mut [T],
 }
 
-impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
+impl<'data, T: 'data + Send> Producer for ChunksMutProducer<'data, T> {
     type Item = &'data mut [T];
     type IntoIter = ::std::slice::ChunksMut<'data, T>;
 
@@ -434,11 +434,11 @@ impl<'data, T: 'data + Send> Producer for SliceChunksMutProducer<'data, T> {
     fn split_at(self, index: usize) -> (Self, Self) {
         let elem_index = index * self.chunk_size;
         let (left, right) = self.slice.split_at_mut(elem_index);
-        (SliceChunksMutProducer {
+        (ChunksMutProducer {
              chunk_size: self.chunk_size,
              slice: left,
          },
-         SliceChunksMutProducer {
+         ChunksMutProducer {
              chunk_size: self.chunk_size,
              slice: right,
          })


### PR DESCRIPTION
I started with a simple refactoring, and kept going...

- The former `ToParallelChunks`/`Mut` are now just part of `ParallelSlice`.
- A new `par_windows` is a parallel version of the standard `windows`.
- The slice iterator *types* are no longer part of the prelude.  We usually just want traits here.
- The slice iterator types are now renamed to mirror those in `std::slice`
  - `Iter`, `IterMut`, `Chunks`, `ChunksMut`, `Windows`
- ~~The distinct producer types weren't necessary - just implement `Producer` on the iterators.~~
- The private producers are now named `IterProducer`, `IterMutProducer`, etc.
