### PR TITLE
Move `FromParallelIterator` directly into `mod iter`

### DIFF
--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -1,5 +1,4 @@
-use super::{ParallelIterator, ExactParallelIterator, IntoParallelIterator};
-use super::from_par_iter::FromParallelIterator;
+use super::{ParallelIterator, ExactParallelIterator, IntoParallelIterator, FromParallelIterator};
 use std::collections::LinkedList;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/iter/from_par_iter.rs
+++ b/src/iter/from_par_iter.rs
@@ -1,24 +1,9 @@
-use super::{IntoParallelIterator, ParallelIterator};
+use super::{FromParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{BuildHasher, Hash};
 use std::collections::LinkedList;
 use std::collections::{BinaryHeap, VecDeque};
-
-/// `FromParallelIterator` implements the conversion from a [`ParallelIterator`].
-/// By implementing `FromParallelIterator` for a type, you define how it will be
-/// created from an iterator.
-///
-/// `FromParallelIterator` is used through [`ParallelIterator`]'s [`collect()`] method.
-///
-/// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`collect()`]: trait.ParallelIterator.html#method.collect
-pub trait FromParallelIterator<T>
-    where T: Send
-{
-    fn from_par_iter<I>(par_iter: I) -> Self where I: IntoParallelIterator<Item = T>;
-}
-
 
 fn combine<I, START, COLL>(par_iter: I, make_start: START) -> COLL
     where I: IntoParallelIterator,

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -40,7 +40,6 @@ pub use self::filter_map::FilterMap;
 mod flat_map;
 pub use self::flat_map::FlatMap;
 mod from_par_iter;
-pub use self::from_par_iter::FromParallelIterator;
 pub mod internal;
 mod for_each;
 mod fold;
@@ -954,4 +953,18 @@ pub trait IndexedParallelIterator: ExactParallelIterator {
     ///
     /// [README]: README.md
     fn with_producer<CB: ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output;
+}
+
+/// `FromParallelIterator` implements the conversion from a [`ParallelIterator`].
+/// By implementing `FromParallelIterator` for a type, you define how it will be
+/// created from an iterator.
+///
+/// `FromParallelIterator` is used through [`ParallelIterator`]'s [`collect()`] method.
+///
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`collect()`]: trait.ParallelIterator.html#method.collect
+pub trait FromParallelIterator<T>
+    where T: Send
+{
+    fn from_par_iter<I>(par_iter: I) -> Self where I: IntoParallelIterator<Item = T>;
 }


### PR DESCRIPTION
Before, when this trait was under the private `mod from_par_iter`,
rustdoc copied its documentation to the reexport paths in both `iter`
and `prelude`.  It was the only thing in `prelude` that didn't *look*
like a reexport, and its relative links were broken in this path.

Now that `iter::FromParallelIterator` is the actual definition path, it
shows up as a proper reexport under the `prelude`.