### PR TITLE
Hide map iterators behind standard names

### DIFF
--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -10,6 +10,9 @@ pub trait MapOp<In>: Sync {
     private_decl!{}
 }
 
+
+pub type Map<I, F> = BaseMap<I, MapFn<F>>;
+
 pub struct MapFn<F>(pub F);
 
 impl<F, In, Out> MapOp<In> for MapFn<F>
@@ -23,6 +26,9 @@ impl<F, In, Out> MapOp<In> for MapFn<F>
     private_impl!{}
 }
 
+
+pub type Cloned<I> = BaseMap<I, MapCloned>;
+
 pub struct MapCloned;
 
 impl<'a, T> MapOp<&'a T> for MapCloned
@@ -34,6 +40,9 @@ impl<'a, T> MapOp<&'a T> for MapCloned
     }
     private_impl!{}
 }
+
+
+pub type Inspect<I, F> = BaseMap<I, MapInspect<F>>;
 
 pub struct MapInspect<F>(pub F);
 
@@ -51,24 +60,24 @@ impl<F, In> MapOp<In> for MapInspect<F>
 
 /// ////////////////////////////////////////////////////////////////////////
 
-pub struct Map<I: ParallelIterator, F> {
+pub struct BaseMap<I: ParallelIterator, F> {
     base: I,
     map_op: F,
 }
 
-/// Create a new `Map` iterator.
+/// Create a new `BaseMap` iterator.
 ///
 /// NB: a free fn because it is NOT part of the end-user API.
-pub fn new<I, F>(base: I, map_op: F) -> Map<I, F>
+pub fn new<I, F>(base: I, map_op: F) -> BaseMap<I, F>
     where I: ParallelIterator
 {
-    Map {
+    BaseMap {
         base: base,
         map_op: map_op,
     }
 }
 
-impl<I, F> ParallelIterator for Map<I, F>
+impl<I, F> ParallelIterator for BaseMap<I, F>
     where I: ParallelIterator,
           F: MapOp<I::Item>
 {
@@ -86,7 +95,7 @@ impl<I, F> ParallelIterator for Map<I, F>
     }
 }
 
-impl<I, F> BoundedParallelIterator for Map<I, F>
+impl<I, F> BoundedParallelIterator for BaseMap<I, F>
     where I: BoundedParallelIterator,
           F: MapOp<I::Item>
 {
@@ -102,7 +111,7 @@ impl<I, F> BoundedParallelIterator for Map<I, F>
     }
 }
 
-impl<I, F> ExactParallelIterator for Map<I, F>
+impl<I, F> ExactParallelIterator for BaseMap<I, F>
     where I: ExactParallelIterator,
           F: MapOp<I::Item>
 {
@@ -111,7 +120,7 @@ impl<I, F> ExactParallelIterator for Map<I, F>
     }
 }
 
-impl<I, F> IndexedParallelIterator for Map<I, F>
+impl<I, F> IndexedParallelIterator for BaseMap<I, F>
     where I: IndexedParallelIterator,
           F: MapOp<I::Item>
 {

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -11,6 +11,12 @@ pub trait MapOp<In>: Sync {
 }
 
 
+/// `Map` is an iterator that transforms the elements of an underlying iterator.
+///
+/// This struct is created by the [`map()`] method on [`ParallelIterator`]
+///
+/// [`map()`]: trait.ParallelIterator.html#method.map
+/// [`ParallelIterator`]: trait.ParallelIterator.html
 pub type Map<I, F> = BaseMap<I, MapFn<F>>;
 
 pub struct MapFn<F>(pub F);
@@ -27,6 +33,12 @@ impl<F, In, Out> MapOp<In> for MapFn<F>
 }
 
 
+/// `Cloned` is an iterator that clones the elements of an underlying iterator.
+///
+/// This struct is created by the [`cloned()`] method on [`ParallelIterator`]
+///
+/// [`cloned()`]: trait.ParallelIterator.html#method.cloned
+/// [`ParallelIterator`]: trait.ParallelIterator.html
 pub type Cloned<I> = BaseMap<I, MapCloned>;
 
 pub struct MapCloned;
@@ -42,6 +54,13 @@ impl<'a, T> MapOp<&'a T> for MapCloned
 }
 
 
+/// `Inspect` is an iterator that calls a function with a reference to each
+/// element before yielding it.
+///
+/// This struct is created by the [`inspect()`] method on [`ParallelIterator`]
+///
+/// [`inspect()`]: trait.ParallelIterator.html#method.inspect
+/// [`ParallelIterator`]: trait.ParallelIterator.html
 pub type Inspect<I, F> = BaseMap<I, MapInspect<F>>;
 
 pub struct MapInspect<F>(pub F);

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -53,7 +53,7 @@ pub use self::splitter::{split, ParallelSplit};
 mod take;
 pub use self::take::Take;
 mod map;
-pub use self::map::{Map, MapOp, MapFn, MapCloned, MapInspect};
+pub use self::map::{Map, Cloned, Inspect};
 mod weight;
 pub use self::weight::Weight;
 mod zip;
@@ -144,29 +144,29 @@ pub trait ParallelIterator: Sized {
 
     /// Applies `map_op` to each item of this iterator, producing a new
     /// iterator with the results.
-    fn map<F, R>(self, map_op: F) -> Map<Self, MapFn<F>>
+    fn map<F, R>(self, map_op: F) -> Map<Self, F>
         where F: Fn(Self::Item) -> R + Sync,
               R: Send
     {
-        map::new(self, MapFn(map_op))
+        map::new(self, map::MapFn(map_op))
     }
 
     /// Creates an iterator which clones all of its elements.  This may be
     /// useful when you have an iterator over `&T`, but you need `T`.
-    fn cloned<'a, T>(self) -> Map<Self, MapCloned>
+    fn cloned<'a, T>(self) -> Cloned<Self>
         where T: 'a + Clone + Send,
               Self: ParallelIterator<Item = &'a T>
     {
-        map::new(self, MapCloned)
+        map::new(self, map::MapCloned)
     }
 
     /// Applies `inspect_op` to a reference to each item of this iterator,
     /// producing a new iterator passing through the original items.  This is
     /// often useful for debugging to see what's happening in iterator stages.
-    fn inspect<OP>(self, inspect_op: OP) -> Map<Self, MapInspect<OP>>
+    fn inspect<OP>(self, inspect_op: OP) -> Inspect<Self, OP>
         where OP: Fn(&Self::Item) + Sync
     {
-        map::new(self, MapInspect(inspect_op))
+        map::new(self, map::MapInspect(inspect_op))
     }
 
     /// Applies `filter_op` to each item of this iterator, producing a new


### PR DESCRIPTION
This creates type aliases exported as `rayon::iter::{Cloned, Inspect, Map}`, matching `std::iter`.  They still refer to the implementation details of the shared base type, but that's in the private `mod map`.

It's not quite as clean as having truly distinct types, which would require separate parallel iterator implementations, but the effect on the API surface is similar.  They can only be named by these aliases, so we should be free to update that implementation later if we like.