### PR TITLE
Rename iter::ParallelSplit to iter::Split

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -49,7 +49,7 @@ mod reduce;
 mod skip;
 pub use self::skip::Skip;
 mod splitter;
-pub use self::splitter::{split, ParallelSplit};
+pub use self::splitter::{split, Split};
 mod take;
 pub use self::take::Take;
 mod map;


### PR DESCRIPTION
With all the other renaming lately, this one stood out as the last
iterator type with a redundant "Parallel" in its name.  While this one
doesn't have a sibling in `std::iter`, it still fits better with the
rest of our iterators when called `rayon::iter::Split`.