### PR TITLE
Make Chain work with specialized collect

### DIFF
--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1043,6 +1043,10 @@ pub fn check_chain() {
         .collect();
     let other: Vec<i32> = (0..100).filter(|x| x & 1 == 1).collect();
     assert_eq!(res, other);
+
+    // chain collect is ok with the "fake" specialization
+    let res: Vec<i32> = Some(1i32).into_par_iter().chain(None).collect();
+    assert_eq!(res, &[1]);
 }
 
 


### PR DESCRIPTION
Since `UnindexedConsumer: Consumer`, `Chain::drive_unindexed` can work just
fine with collect's consumer.  We know the length in this case, so we can
use the more precise `Consumer::split_at`, and this is fine for regular
unindexed consumers too.

This also adds a more explicit test of chain collect, as the prior fix and
testing in #176 didn't actually appear to exercise this case as intended.