### PR TITLE
Remove redundant split_off_left() calls

### DIFF
--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -67,10 +67,11 @@ impl<'f, T, U, C, F> Consumer<T> for FlatMapConsumer<'f, C, F>
     type Reducer = C::Reducer;
     type Result = C::Result;
 
-    fn split_at(self, _index: usize) -> (Self, Self, C::Reducer) {
-        (FlatMapConsumer::new(self.base.split_off_left(), self.map_op),
-         FlatMapConsumer::new(self.base.split_off_left(), self.map_op),
-         self.base.to_reducer())
+    fn split_at(self, index: usize) -> (Self, Self, C::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (FlatMapConsumer::new(left, self.map_op),
+         FlatMapConsumer::new(right, self.map_op),
+         reducer)
     }
 
     fn into_folder(self) -> Self::Folder {

--- a/src/iter/for_each.rs
+++ b/src/iter/for_each.rs
@@ -23,7 +23,7 @@ impl<'f, F, T> Consumer<T> for ForEachConsumer<'f, F>
     type Result = ();
 
     fn split_at(self, _index: usize) -> (Self, Self, NoopReducer) {
-        (self.split_off_left(), self.split_off_left(), NoopReducer)
+        (self.split_off_left(), self, NoopReducer)
     }
 
     fn into_folder(self) -> Self {


### PR DESCRIPTION
In `FlatMapConsumer::split_at`, we can just pass it down to the base
consumer's `split_at`.  Avoiding the double `split_off_left()` here
might improve the indexing resolution of `find_first`/`last`, but is
otherwise just a small optimization.

In `ForEachConsumer::split_at`, we only need one `split_off_left()` to
get a copy of `self`, and then we can just use `self` for the second.