### PR TITLE
Terminate new registries after panic or spawn errors

### DIFF
--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -22,7 +22,8 @@ impl ThreadPool {
     /// the configuration is not valid, returns a suitable `Err`
     /// result.  See `InitError` for more details.
     pub fn new(configuration: Configuration) -> Result<ThreadPool, Box<Error>> {
-        Ok(ThreadPool { registry: Registry::new(configuration) })
+        let registry = try!(Registry::new(configuration));
+        Ok(ThreadPool { registry: registry })
     }
 
     /// Executes `op` within the threadpool. Any attempts to use

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -1,8 +1,12 @@
 #![cfg(test)]
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use configuration::Configuration;
 use join;
 use super::ThreadPool;
+use unwind;
 
 #[test]
 #[should_panic(expected = "Hello, world!")]
@@ -56,4 +60,60 @@ fn sleeper_stop() {
     // once thread-pool is dropped, registry should terminate, which
     // should lead to worker threads stopping
     registry.wait_until_stopped();
+}
+
+fn count_handler() -> (Arc<AtomicUsize>, ::StartHandler) {
+    let count = Arc::new(AtomicUsize::new(0));
+    (count.clone(), Arc::new(move |_| { count.fetch_add(1, Ordering::SeqCst); }))
+}
+
+#[test]
+fn failed_thread_stack() {
+    use std::{thread, time};
+
+    let (start_count, start_handler) = count_handler();
+    let (exit_count, exit_handler) = count_handler();
+    let config = Configuration::new()
+        .set_stack_size(::std::usize::MAX)
+        .set_start_handler(start_handler)
+        .set_exit_handler(exit_handler);
+
+    let pool = ThreadPool::new(config);
+    assert!(pool.is_err(), "thread stack should have failed!");
+
+    // Give time for the internal cleanup to terminate.
+    thread::sleep(time::Duration::from_secs(1));
+
+    // With an impossible stack, we don't expect to see any threads.
+    assert_eq!(0, start_count.load(Ordering::SeqCst));
+    assert_eq!(0, exit_count.load(Ordering::SeqCst));
+}
+
+#[test]
+fn panic_thread_name() {
+    use std::{thread, time};
+
+    let (start_count, start_handler) = count_handler();
+    let (exit_count, exit_handler) = count_handler();
+    let config = Configuration::new()
+        .set_num_threads(10)
+        .set_start_handler(start_handler)
+        .set_exit_handler(exit_handler)
+        .set_thread_name(|i| {
+                             if i >= 5 {
+                                 panic!();
+                             }
+                             format!("panic_thread_name#{}", i)
+                         });
+
+    let pool = unwind::halt_unwinding(|| ThreadPool::new(config));
+    assert!(pool.is_err(), "thread-name panic should propagate!");
+
+    // Give time for the internal cleanup to terminate.
+    thread::sleep(time::Duration::from_secs(1));
+
+    // Assuming they're created in order, threads 0 through 4 should have
+    // been started already, and then terminated by the panic.
+    assert_eq!(5, start_count.load(Ordering::SeqCst));
+    assert_eq!(5, exit_count.load(Ordering::SeqCst));
 }


### PR DESCRIPTION
This adds a guard structure around the `Registry::new` thread startup,
which terminates the whole registry if we can't complete it.  It now
returns a boxed error if `Builder::spawn` fails, and should deal better
with any panics, like from the user's `thread_name` callback.

Fixes #205.