### PR TITLE
fix the documentation for Configuration::panic_handler

### DIFF
--- a/rayon-core/src/configuration.rs
+++ b/rayon-core/src/configuration.rs
@@ -96,9 +96,7 @@ impl Configuration {
         self
     }
 
-    /// Returns (and takes ownership of) the current panic handler.
-    /// After this call, no panic handler is registered in the
-    /// configuration anymore.
+    /// Returns a copy of the current panic handler.
     pub fn panic_handler(&self) -> Option<PanicHandler> {
         self.panic_handler.clone()
     }


### PR DESCRIPTION
The previous comment dates from a time when `Arc` was not used.