### PR TITLE
Remove bounded and exact iterators

### DIFF
--- a/rayon-demo/src/vec_collect.rs
+++ b/rayon-demo/src/vec_collect.rs
@@ -100,7 +100,7 @@ mod vec_i {
 
     const N: u32 = 4 * 1024 * 1024;
 
-    fn generate() -> impl ExactParallelIterator<Item=u32> {
+    fn generate() -> impl IndexedParallelIterator<Item=u32> {
         (0_u32..N)
             .into_par_iter()
     }

--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -98,25 +98,17 @@ macro_rules! delegate_indexed_iterator_item {
             impl $( $args )*
         }
 
-        impl $( $args )* BoundedParallelIterator for $iter < $( $i ),* > {
-            fn upper_bound(&mut self) -> usize {
-                self.inner.upper_bound()
-            }
-
+        impl $( $args )* IndexedParallelIterator for $iter < $( $i ),* > {
             fn drive<C>(self, consumer: C) -> C::Result
                 where C: Consumer<Self::Item>
             {
                 self.inner.drive(consumer)
             }
-        }
 
-        impl $( $args )* ExactParallelIterator for $iter < $( $i ),* > {
             fn len(&mut self) -> usize {
                 self.inner.len()
             }
-        }
 
-        impl $( $args )* IndexedParallelIterator for $iter < $( $i ),* > {
             fn with_producer<CB>(self, callback: CB) -> CB::Output
                 where CB: ProducerCallback<Self::Item>
             {

--- a/src/iter/README.md
+++ b/src/iter/README.md
@@ -207,7 +207,7 @@ would have to have. If we were going to write the `with_producer`
 method using a closure, it would have to look something like this:
 
 ```rust
-pub trait IndexedParallelIterator: ExactParallelIterator {
+pub trait IndexedParallelIterator: ParallelIterator {
     type Producer;
     fn with_producer<CB, R>(self, callback: CB) -> R
         where CB: FnOnce(Self::Producer) -> R;

--- a/src/iter/collect/mod.rs
+++ b/src/iter/collect/mod.rs
@@ -1,4 +1,4 @@
-use super::{ParallelIterator, ExactParallelIterator, IntoParallelIterator, FromParallelIterator};
+use super::{ParallelIterator, IndexedParallelIterator, IntoParallelIterator, FromParallelIterator};
 use std::collections::LinkedList;
 use std::slice;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -10,7 +10,7 @@ mod test;
 
 /// Collects the results of the exact iterator into the specified vector.
 pub fn collect_into<I, T>(mut pi: I, v: &mut Vec<T>)
-    where I: ExactParallelIterator<Item = T>,
+    where I: IndexedParallelIterator<Item = T>,
           T: Send
 {
     let mut collect = Collect::new(v, pi.len());
@@ -20,7 +20,7 @@ pub fn collect_into<I, T>(mut pi: I, v: &mut Vec<T>)
 
 /// Collects the results of the iterator into the specified vector.
 ///
-/// Technically, this only works for `ExactParallelIterator`, but we're faking a
+/// Technically, this only works for `IndexedParallelIterator`, but we're faking a
 /// bit of specialization here until Rust can do that natively.  Callers are
 /// using `opt_len` to find the length before calling this, and only exact
 /// iterators will return anything but `None` there.

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -38,29 +38,17 @@ impl<I> ParallelIterator for Enumerate<I>
     }
 }
 
-impl<I> BoundedParallelIterator for Enumerate<I>
-    where I: IndexedParallelIterator
-{
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
-
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        bridge(self, consumer)
-    }
-}
-
-impl<I> ExactParallelIterator for Enumerate<I>
-    where I: IndexedParallelIterator
-{
-    fn len(&mut self) -> usize {
-        self.base.len()
-    }
-}
-
 impl<I> IndexedParallelIterator for Enumerate<I>
     where I: IndexedParallelIterator
 {
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn len(&mut self) -> usize {
+        self.base.len()
+    }
+
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -102,7 +90,7 @@ impl<P> Producer for EnumerateProducer<P>
     type IntoIter = iter::Zip<Range<usize>, P::IntoIter>;
 
     fn into_iter(self) -> Self::IntoIter {
-        // Enumerate only works for ExactParallelIterators. Since those
+        // Enumerate only works for IndexedParallelIterators. Since those
         // have a max length of usize::MAX, their max index is
         // usize::MAX - 1, so the range 0..usize::MAX includes all
         // possible indices

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -37,22 +37,6 @@ impl<I, P> ParallelIterator for Filter<I, P>
     }
 }
 
-impl<I, P> BoundedParallelIterator for Filter<I, P>
-    where I: BoundedParallelIterator,
-          P: Fn(&I::Item) -> bool + Sync
-{
-    fn upper_bound(&mut self) -> usize {
-        self.base.upper_bound()
-    }
-
-    fn drive<C>(self, consumer: C) -> C::Result
-        where C: Consumer<Self::Item>
-    {
-        let consumer1 = FilterConsumer::new(consumer, &self.filter_op);
-        self.base.drive(consumer1)
-    }
-}
-
 /// ////////////////////////////////////////////////////////////////////////
 /// Consumer implementation
 

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -38,23 +38,6 @@ impl<I, P, R> ParallelIterator for FilterMap<I, P>
     }
 }
 
-impl<I, P, R> BoundedParallelIterator for FilterMap<I, P>
-    where I: BoundedParallelIterator,
-          P: Fn(I::Item) -> Option<R> + Sync,
-          R: Send
-{
-    fn upper_bound(&mut self) -> usize {
-        self.base.upper_bound()
-    }
-
-    fn drive<C>(self, consumer: C) -> C::Result
-        where C: Consumer<Self::Item>
-    {
-        let consumer = FilterMapConsumer::new(consumer, &self.filter_op);
-        self.base.drive(consumer)
-    }
-}
-
 /// ////////////////////////////////////////////////////////////////////////
 /// Consumer implementation
 

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -45,26 +45,6 @@ impl<U, I, ID, F> ParallelIterator for Fold<I, ID, F>
     }
 }
 
-impl<U, I, ID, F> BoundedParallelIterator for Fold<I, ID, F>
-    where I: BoundedParallelIterator,
-          F: Fn(U, I::Item) -> U + Sync,
-          ID: Fn() -> U + Sync,
-          U: Send
-{
-    fn upper_bound(&mut self) -> usize {
-        self.base.upper_bound()
-    }
-
-    fn drive<'c, C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        let consumer1 = FoldConsumer {
-            base: consumer,
-            fold_op: &self.fold_op,
-            identity: &self.identity,
-        };
-        self.base.drive(consumer1)
-    }
-}
-
 struct FoldConsumer<'c, C, ID: 'c, F: 'c> {
     base: C,
     fold_op: &'c F,

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -40,29 +40,17 @@ impl<I> ParallelIterator for MinLen<I>
     }
 }
 
-impl<I> BoundedParallelIterator for MinLen<I>
-    where I: IndexedParallelIterator
-{
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
-
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        bridge(self, consumer)
-    }
-}
-
-impl<I> ExactParallelIterator for MinLen<I>
-    where I: IndexedParallelIterator
-{
-    fn len(&mut self) -> usize {
-        self.base.len()
-    }
-}
-
 impl<I> IndexedParallelIterator for MinLen<I>
     where I: IndexedParallelIterator
 {
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn len(&mut self) -> usize {
+        self.base.len()
+    }
+
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -171,29 +159,17 @@ impl<I> ParallelIterator for MaxLen<I>
     }
 }
 
-impl<I> BoundedParallelIterator for MaxLen<I>
-    where I: IndexedParallelIterator
-{
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
-
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        bridge(self, consumer)
-    }
-}
-
-impl<I> ExactParallelIterator for MaxLen<I>
-    where I: IndexedParallelIterator
-{
-    fn len(&mut self) -> usize {
-        self.base.len()
-    }
-}
-
 impl<I> IndexedParallelIterator for MaxLen<I>
     where I: IndexedParallelIterator
 {
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn len(&mut self) -> usize {
+        self.base.len()
+    }
+
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -86,35 +86,21 @@ impl<I, F> ParallelIterator for Map<I, F>
     }
 }
 
-impl<I, F> BoundedParallelIterator for Map<I, F>
-    where I: BoundedParallelIterator,
+impl<I, F> IndexedParallelIterator for Map<I, F>
+    where I: IndexedParallelIterator,
           F: MapOp<I::Item>
 {
-    fn upper_bound(&mut self) -> usize {
-        self.base.upper_bound()
-    }
-
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         let consumer1 = MapConsumer::new(consumer, &self.map_op);
         self.base.drive(consumer1)
     }
-}
 
-impl<I, F> ExactParallelIterator for Map<I, F>
-    where I: ExactParallelIterator,
-          F: MapOp<I::Item>
-{
     fn len(&mut self) -> usize {
         self.base.len()
     }
-}
 
-impl<I, F> IndexedParallelIterator for Map<I, F>
-    where I: IndexedParallelIterator,
-          F: MapOp<I::Item>
-{
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -31,29 +31,17 @@ impl<I> ParallelIterator for Rev<I>
     }
 }
 
-impl<I> BoundedParallelIterator for Rev<I>
-    where I: IndexedParallelIterator
-{
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
-
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        bridge(self, consumer)
-    }
-}
-
-impl<I> ExactParallelIterator for Rev<I>
-    where I: IndexedParallelIterator
-{
-    fn len(&mut self) -> usize {
-        self.base.len()
-    }
-}
-
 impl<I> IndexedParallelIterator for Rev<I>
     where I: IndexedParallelIterator
 {
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn len(&mut self) -> usize {
+        self.base.len()
+    }
+
     fn with_producer<CB>(mut self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -39,29 +39,17 @@ impl<I> ParallelIterator for Skip<I>
     }
 }
 
-impl<I> ExactParallelIterator for Skip<I>
+impl<I> IndexedParallelIterator for Skip<I>
     where I: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.base.len() - self.n
     }
-}
-
-impl<I> BoundedParallelIterator for Skip<I>
-    where I: IndexedParallelIterator
-{
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
 
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
     }
-}
 
-impl<I> IndexedParallelIterator for Skip<I>
-    where I: IndexedParallelIterator
-{
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -38,29 +38,17 @@ impl<I> ParallelIterator for Take<I>
     }
 }
 
-impl<I> ExactParallelIterator for Take<I>
+impl<I> IndexedParallelIterator for Take<I>
     where I: IndexedParallelIterator
 {
     fn len(&mut self) -> usize {
         self.n
     }
-}
-
-impl<I> BoundedParallelIterator for Take<I>
-    where I: IndexedParallelIterator
-{
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
 
     fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
         bridge(self, consumer)
     }
-}
 
-impl<I> IndexedParallelIterator for Take<I>
-    where I: IndexedParallelIterator
-{
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -11,8 +11,6 @@ use std::collections::{BinaryHeap, VecDeque};
 use std::f64;
 use std::usize;
 
-fn is_bounded<T: ExactParallelIterator>(_: T) {}
-fn is_exact<T: ExactParallelIterator>(_: T) {}
 fn is_indexed<T: IndexedParallelIterator>(_: T) {}
 
 #[test]
@@ -118,10 +116,8 @@ pub fn execute_strings_split() {
 }
 
 #[test]
-pub fn check_map_exact_and_bounded() {
+pub fn check_map_indexed() {
     let a = [1, 2, 3];
-    is_bounded(a.par_iter().map(|x| x));
-    is_exact(a.par_iter().map(|x| x));
     is_indexed(a.par_iter().map(|x| x));
 }
 
@@ -337,33 +333,25 @@ pub fn check_drops() {
 }
 
 #[test]
-pub fn check_slice_exact_and_bounded() {
+pub fn check_slice_indexed() {
     let a = vec![1, 2, 3];
-    is_bounded(a.par_iter());
-    is_exact(a.par_iter());
     is_indexed(a.par_iter());
 }
 
 #[test]
-pub fn check_slice_mut_exact_and_bounded() {
+pub fn check_slice_mut_indexed() {
     let mut a = vec![1, 2, 3];
-    is_bounded(a.par_iter_mut());
-    is_exact(a.par_iter_mut());
     is_indexed(a.par_iter_mut());
 }
 
 #[test]
-pub fn check_vec_exact_and_bounded() {
+pub fn check_vec_indexed() {
     let a = vec![1, 2, 3];
-    is_bounded(a.clone().into_par_iter());
-    is_exact(a.clone().into_par_iter());
     is_indexed(a.clone().into_par_iter());
 }
 
 #[test]
-pub fn check_range_exact_and_bounded() {
-    is_bounded((1..5).into_par_iter());
-    is_exact((1..5).into_par_iter());
+pub fn check_range_indexed() {
     is_indexed((1..5).into_par_iter());
 }
 

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -35,34 +35,20 @@ impl<A, B> ParallelIterator for Zip<A, B>
     }
 }
 
-impl<A, B> BoundedParallelIterator for Zip<A, B>
+impl<A, B> IndexedParallelIterator for Zip<A, B>
     where A: IndexedParallelIterator,
           B: IndexedParallelIterator
 {
-    fn upper_bound(&mut self) -> usize {
-        self.len()
-    }
-
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<A, B> ExactParallelIterator for Zip<A, B>
-    where A: IndexedParallelIterator,
-          B: IndexedParallelIterator
-{
     fn len(&mut self) -> usize {
         cmp::min(self.a.len(), self.b.len())
     }
-}
 
-impl<A, B> IndexedParallelIterator for Zip<A, B>
-    where A: IndexedParallelIterator,
-          B: IndexedParallelIterator
-{
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/option.rs
+++ b/src/option.rs
@@ -53,28 +53,20 @@ impl<T: Send> ParallelIterator for IntoIter<T> {
     }
 }
 
-impl<T: Send> BoundedParallelIterator for IntoIter<T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<T: Send> IndexedParallelIterator for IntoIter<T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<T: Send> ExactParallelIterator for IntoIter<T> {
     fn len(&mut self) -> usize {
         match self.opt {
             Some(_) => 1,
             None => 0,
         }
     }
-}
 
-impl<T: Send> IndexedParallelIterator for IntoIter<T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,8 +2,6 @@
 //! The intention is that one can include `use rayon::prelude::*` and
 //! have easy access to the various traits and methods you will need.
 
-pub use iter::BoundedParallelIterator;
-pub use iter::ExactParallelIterator;
 pub use iter::FromParallelIterator;
 pub use iter::IntoParallelIterator;
 pub use iter::IntoParallelRefIterator;

--- a/src/range.rs
+++ b/src/range.rs
@@ -54,25 +54,17 @@ macro_rules! indexed_range_impl {
             }
         }
 
-        impl BoundedParallelIterator for Iter<$t> {
-            fn upper_bound(&mut self) -> usize {
-                ExactParallelIterator::len(self)
-            }
-
+        impl IndexedParallelIterator for Iter<$t> {
             fn drive<C>(self, consumer: C) -> C::Result
                 where C: Consumer<Self::Item>
             {
                 bridge(self, consumer)
             }
-        }
 
-        impl ExactParallelIterator for Iter<$t> {
             fn len(&mut self) -> usize {
                 self.range.len()
             }
-        }
 
-        impl IndexedParallelIterator for Iter<$t> {
             fn with_producer<CB>(self, callback: CB) -> CB::Output
                 where CB: ProducerCallback<Self::Item>
             {

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -112,25 +112,17 @@ impl<'data, T: Sync + 'data> ParallelIterator for Iter<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for Iter<'data, T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<'data, T: Sync + 'data> IndexedParallelIterator for Iter<'data, T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for Iter<'data, T> {
     fn len(&mut self) -> usize {
         self.slice.len()
     }
-}
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for Iter<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -177,25 +169,17 @@ impl<'data, T: Sync + 'data> ParallelIterator for Chunks<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for Chunks<'data, T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<'data, T: Sync + 'data> IndexedParallelIterator for Chunks<'data, T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for Chunks<'data, T> {
     fn len(&mut self) -> usize {
         (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
-}
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for Chunks<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -254,26 +238,18 @@ impl<'data, T: Sync + 'data> ParallelIterator for Windows<'data, T> {
     }
 }
 
-impl<'data, T: Sync + 'data> BoundedParallelIterator for Windows<'data, T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<'data, T: Sync + 'data> IndexedParallelIterator for Windows<'data, T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<'data, T: Sync + 'data> ExactParallelIterator for Windows<'data, T> {
     fn len(&mut self) -> usize {
         assert!(self.window_size >= 1);
         self.slice.len().saturating_sub(self.window_size - 1)
     }
-}
 
-impl<'data, T: Sync + 'data> IndexedParallelIterator for Windows<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -332,25 +308,17 @@ impl<'data, T: Send + 'data> ParallelIterator for IterMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> BoundedParallelIterator for IterMut<'data, T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<'data, T: Send + 'data> IndexedParallelIterator for IterMut<'data, T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<'data, T: Send + 'data> ExactParallelIterator for IterMut<'data, T> {
     fn len(&mut self) -> usize {
         self.slice.len()
     }
-}
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for IterMut<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {
@@ -397,25 +365,17 @@ impl<'data, T: Send + 'data> ParallelIterator for ChunksMut<'data, T> {
     }
 }
 
-impl<'data, T: Send + 'data> BoundedParallelIterator for ChunksMut<'data, T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMut<'data, T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<'data, T: Send + 'data> ExactParallelIterator for ChunksMut<'data, T> {
     fn len(&mut self) -> usize {
         (self.slice.len() + (self.chunk_size - 1)) / self.chunk_size
     }
-}
 
-impl<'data, T: Send + 'data> IndexedParallelIterator for ChunksMut<'data, T> {
     fn with_producer<CB>(self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -34,25 +34,17 @@ impl<T: Send> ParallelIterator for IntoIter<T> {
     }
 }
 
-impl<T: Send> BoundedParallelIterator for IntoIter<T> {
-    fn upper_bound(&mut self) -> usize {
-        ExactParallelIterator::len(self)
-    }
-
+impl<T: Send> IndexedParallelIterator for IntoIter<T> {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>
     {
         bridge(self, consumer)
     }
-}
 
-impl<T: Send> ExactParallelIterator for IntoIter<T> {
     fn len(&mut self) -> usize {
         self.vec.len()
     }
-}
 
-impl<T: Send> IndexedParallelIterator for IntoIter<T> {
     fn with_producer<CB>(mut self, callback: CB) -> CB::Output
         where CB: ProducerCallback<Self::Item>
     {


### PR DESCRIPTION
This reduces our iterator traits to just `ParallelIterator` and
`IndexedParallelIterator`.  The bounded and exact iterators had some
theoretical use, but in practice the only distinction we use today is
whether something can be indexed.

The `upper_bound` method is totally removed.  The rest of the methods in
the removed traits are now merged into `IndexedParallelIterator`.

Fixes #229.
Closes #259.