### PR TITLE
Replace deque crate with coco

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 rand = "0.3"
 num_cpus = "1.2"
-deque = "0.3.1"
+coco = "0.1.0"
 libc = "0.2.16"
 lazy_static = "0.2.2"
 futures = { version = "0.1.7", optional = true }

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -35,7 +35,7 @@ use std::error::Error;
 use std::str::FromStr;
 use std::fmt;
 
-extern crate deque;
+extern crate coco;
 #[macro_use]
 extern crate lazy_static;
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
In #195 I've laid out problems with Crossbeam's current implementation of the Chase-Lev deque.
Coco is a new crate that will bring lock-free data structures and a better epoch-based GC. At the moment it provides a stack and a deque. It's deque outperforms Crossbeam's deque and collects garbage more eagerly.

Performance should be more-or-less identical to the `deque` crate.

cc @cuviper 

Benchmark:
```
name                                                     out ns/iter  out_coco ns/iter  diff ns/iter   diff %
factorial::factorial_iterator                            21,253,985   21,257,250               3,265    0.02%
factorial::factorial_join                                10,297,681   10,205,071             -92,610   -0.90%
factorial::factorial_par_iter                            9,651,910    9,797,147              145,237    1.50%
factorial::factorial_recursion                           11,890,503   11,900,548              10,045    0.08%
fibonacci::fibonacci_iterative                           6            6                            0    0.00%
fibonacci::fibonacci_join_1_2                            54,986,606   49,050,385          -5,936,221  -10.80%
fibonacci::fibonacci_join_2_1                            53,789,751   58,592,740           4,802,989    8.93%
fibonacci::fibonacci_recursive                           13,924,035   13,960,408              36,373    0.26%
fibonacci::fibonacci_split_iterative                     25,862       25,127                    -735   -2.84%
fibonacci::fibonacci_split_recursive                     5,394,624    5,204,821             -189,803   -3.52%
find::size1::parallel_find_common                        6,228        6,961                      733   11.77%
find::size1::parallel_find_first                         4,205        4,441                      236    5.61%
find::size1::parallel_find_last                          4,863,540    4,890,346               26,806    0.55%
find::size1::parallel_find_middle                        3,317,454    3,267,686              -49,768   -1.50%
find::size1::parallel_find_missing                       5,126,506    5,036,572              -89,934   -1.75%
find::size1::serial_find_common                          3,823        3,842                       19    0.50%
find::size1::serial_find_first                           1            1                            0    0.00%
find::size1::serial_find_last                            4,138,157    4,285,229              147,072    3.55%
find::size1::serial_find_middle                          2,721,780    2,757,419               35,639    1.31%
find::size1::serial_find_missing                         4,115,049    4,289,975              174,926    4.25%
join_microbench::increment_all                           39,872       37,966                  -1,906   -4.78%
join_microbench::increment_all_atomized                  3,391,818    3,374,890              -16,928   -0.50%
join_microbench::increment_all_max                       109,525      100,795                 -8,730   -7.97%
join_microbench::increment_all_min                       27,991       28,280                     289    1.03%
join_microbench::increment_all_serialized                39,688       40,167                     479    1.21%
join_microbench::join_recursively                        984,654      924,627                -60,027   -6.10%
map_collect::i_mod_10_to_i::with_collect                 7,208,396    7,232,544               24,148    0.33%
map_collect::i_mod_10_to_i::with_fold                    2,734,642    2,717,724              -16,918   -0.62%
map_collect::i_mod_10_to_i::with_fold_vec                3,015,475    3,145,995              130,520    4.33%
map_collect::i_mod_10_to_i::with_linked_list             16,716,570   16,796,317              79,747    0.48%
map_collect::i_mod_10_to_i::with_linked_list_vec         5,652,939    5,681,723               28,784    0.51%
map_collect::i_mod_10_to_i::with_linked_list_vec_sized   7,230,350    7,296,061               65,711    0.91%
map_collect::i_mod_10_to_i::with_mutex                   61,455,596   59,090,026          -2,365,570   -3.85%
map_collect::i_mod_10_to_i::with_mutex_vec               7,019,541    7,098,169               78,628    1.12%
map_collect::i_to_i::with_collect                        23,394,885   22,674,550            -720,335   -3.08%
map_collect::i_to_i::with_fold                           71,888,029   69,863,106          -2,024,923   -2.82%
map_collect::i_to_i::with_fold_vec                       71,054,467   71,250,805             196,338    0.28%
map_collect::i_to_i::with_linked_list                    35,527,371   35,937,437             410,066    1.15%
map_collect::i_to_i::with_linked_list_vec                33,872,213   34,066,951             194,738    0.57%
map_collect::i_to_i::with_linked_list_vec_sized          23,583,007   22,964,584            -618,423   -2.62%
map_collect::i_to_i::with_mutex                          106,479,600  105,804,478           -675,122   -0.63%
map_collect::i_to_i::with_mutex_vec                      39,232,074   39,870,999             638,925    1.63%
matmul::bench::bench_matmul_strassen                     7,793,233    7,854,551               61,318    0.79%
mergesort::bench::merge_sort_par_bench                   10,146,328   9,944,776             -201,552   -1.99%
mergesort::bench::merge_sort_seq_bench                   28,710,359   28,838,060             127,701    0.44%
nbody::bench::nbody_par                                  12,864,065   13,440,950             576,885    4.48%
nbody::bench::nbody_parreduce                            21,063,861   21,399,177             335,316    1.59%
nbody::bench::nbody_seq                                  27,119,941   27,092,713             -27,228   -0.10%
pythagoras::euclid_faux_serial                           31,913,006   31,913,957                 951    0.00%
pythagoras::euclid_parallel_full                         84,182,866   77,035,164          -7,147,702   -8.49%
pythagoras::euclid_parallel_one                          11,708,990   11,628,162             -80,828   -0.69%
pythagoras::euclid_parallel_outer                        11,646,541   11,644,041              -2,500   -0.02%
pythagoras::euclid_parallel_weightless                   11,841,485   11,733,211            -108,274   -0.91%
pythagoras::euclid_serial                                30,659,100   30,335,689            -323,411   -1.05%
quicksort::bench::quick_sort_par_bench                   17,312,512   17,640,500             327,988    1.89%
quicksort::bench::quick_sort_seq_bench                   40,393,062   40,370,522             -22,540   -0.06%
quicksort::bench::quick_sort_splitter                    17,824,600   17,862,967              38,367    0.22%
sieve::bench::sieve_chunks                               10,566,687   10,510,812             -55,875   -0.53%
sieve::bench::sieve_parallel                             6,813,268    6,721,096              -92,172   -1.35%
sieve::bench::sieve_serial                               25,814,131   22,513,468          -3,300,663  -12.79%
tsp::bench::dj10                                         14,192,993   14,352,864             159,871    1.13%
vec_collect::vec_i::with_collect                         5,071,243    4,928,118             -143,125   -2.82%
vec_collect::vec_i::with_collect_into                    5,276,253    5,076,184             -200,069   -3.79%
vec_collect::vec_i::with_collect_into_reused             2,941,029    2,829,375             -111,654   -3.80%
vec_collect::vec_i::with_fold                            32,547,385   31,030,220          -1,517,165   -4.66%
vec_collect::vec_i::with_linked_list_vec                 18,211,383   18,272,891              61,508    0.34%
vec_collect::vec_i::with_linked_list_vec_sized           14,042,766   13,806,275            -236,491   -1.68%
vec_collect::vec_i_filtered::with_collect                14,037,416   13,987,822             -49,594   -0.35%
vec_collect::vec_i_filtered::with_fold                   33,343,768   31,473,361          -1,870,407   -5.61%
vec_collect::vec_i_filtered::with_linked_list_vec        18,012,293   18,332,142             319,849    1.78%
vec_collect::vec_i_filtered::with_linked_list_vec_sized  13,806,275   13,715,935             -90,340   -0.65%
```