### PR TITLE
Add `install_future` to `ThreadPool`

### DIFF
--- a/rayon-core/src/future/mod.rs
+++ b/rayon-core/src/future/mod.rs
@@ -8,7 +8,6 @@
 use latch::{LatchProbe};
 #[allow(warnings)]
 use log::Event::*;
-use futures::{Async, Poll};
 use futures::executor;
 use futures::future::CatchUnwind;
 use futures::task::{self, Spawn, Task, Unpark};
@@ -23,7 +22,7 @@ use std::sync::atomic::Ordering::*;
 use std::sync::Mutex;
 use unwind;
 
-pub use futures::Future;
+pub use futures::{Async, Future, Poll};
 
 const STATE_PARKED: usize = 0;
 const STATE_UNPARKED: usize = 1;

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -18,6 +18,18 @@ fn panic_propagate() {
 }
 
 #[test]
+#[cfg(feature = "unstable")]
+#[should_panic(expected = "Bye, future world!")]
+fn panic_propagate_future() {
+    use future::Future;
+
+    let thread_pool = ThreadPool::new(Configuration::new()).unwrap();
+    thread_pool.install_future(|| {
+        panic!("Bye, future world!");
+    }).wait().unwrap();
+}
+
+#[test]
 fn workers_stop() {
     let registry;
 


### PR DESCRIPTION
Same as `install`, but non-blocking and returns a future