### PR TITLE
RFC: stop using the `_async` terminology

### DIFF
--- a/rayon-core/src/future/mod.rs
+++ b/rayon-core/src/future/mod.rs
@@ -1,6 +1,6 @@
 //! Future support in Rayon. This module *primary* consists of
 //! internal APIs that are exposed through `Scope::spawn_future` and
-//! `spawn_future_async`.  However, the type `RayonFuture` is a public
+//! `::spawn_future`.  However, the type `RayonFuture` is a public
 //! type exposed to all users.
 //!
 //! See `README.md` for details.

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -56,7 +56,7 @@ mod future;
 mod scope;
 mod sleep;
 #[cfg(feature = "unstable")]
-mod spawn_async;
+mod spawn;
 mod test;
 mod thread_pool;
 mod unwind;
@@ -66,9 +66,9 @@ pub use thread_pool::ThreadPool;
 pub use join::join;
 pub use scope::{scope, Scope};
 #[cfg(feature = "unstable")]
-pub use spawn_async::spawn_async;
+pub use spawn::spawn;
 #[cfg(feature = "unstable")]
-pub use spawn_async::spawn_future_async;
+pub use spawn::spawn_future;
 #[cfg(feature = "unstable")]
 pub use future::RayonFuture;
 
@@ -198,7 +198,7 @@ impl Configuration {
     /// Normally, whenever Rayon catches a panic, it tries to
     /// propagate it to someplace sensible, to try and reflect the
     /// semantics of sequential execution. But in some cases,
-    /// particularly with the `spawn_async()` APIs, there is no
+    /// particularly with the `spawn()` APIs, there is no
     /// obvious place where we should propagate the panic to.
     /// In that case, this panic handler is invoked.
     ///

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -151,6 +151,10 @@ impl Registry {
         Ok(registry.clone())
     }
 
+    pub fn global() -> Arc<Registry> {
+        global_registry().clone()
+    }
+
     pub fn current() -> Arc<Registry> {
         unsafe {
             let worker_thread = WorkerThread::current();

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -293,10 +293,10 @@ impl Registry {
     /// since installing the thread-pool blocks until any joins/scopes
     /// complete, this ensures that joins/scopes are covered.
     ///
-    /// The exception is `spawn_async()`, which can create a job
-    /// outside of any blocking scope. In that case, the job itself
-    /// holds a terminate count and is responsible for invoking
-    /// `terminate()` when finished.
+    /// The exception is `::spawn()`, which can create a job outside
+    /// of any blocking scope. In that case, the job itself holds a
+    /// terminate count and is responsible for invoking `terminate()`
+    /// when finished.
     pub fn increment_terminate_count(&self) {
         self.terminate_latch.increment();
     }

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -26,6 +26,26 @@ impl ThreadPool {
         Ok(ThreadPool { registry: registry })
     }
 
+    /// Returns a handle to the global thread pool. This is the pool
+    /// that Rayon will use by default when you perform a `join()` or
+    /// `scope()` operatioon, if no other thread-pool is installed. If
+    /// no global thread-pool has yet been started when this function
+    /// is called, then the global thread-pool will be created (with
+    /// the default configuration). If you wish to configure the
+    /// global thread-pool differently, then you can use [the
+    /// `rayon::initialize()` function][f] to do so.
+    ///
+    /// [f]: fn.initialize.html
+    #[cfg(feature = "unstable")]
+    pub fn global() -> &'static Arc<ThreadPool> {
+        lazy_static! {
+            static ref DEFAULT_THREAD_POOL: Arc<ThreadPool> =
+                Arc::new(ThreadPool { registry: Registry::global() });
+        }
+
+        &DEFAULT_THREAD_POOL
+    }
+
     /// Executes `op` within the threadpool. Any attempts to use
     /// `join`, `scope`, or parallel iterators will then operate
     /// within that threadpool.
@@ -123,3 +143,4 @@ impl Drop for ThreadPool {
         self.registry.terminate();
     }
 }
+

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -6,7 +6,7 @@ use latch::LockLatch;
 use log::Event::*;
 use job::StackJob;
 #[cfg(feature = "unstable")]
-use spawn_async;
+use spawn;
 use std::sync::Arc;
 use std::error::Error;
 use registry::{Registry, WorkerThread};
@@ -97,24 +97,24 @@ impl ThreadPool {
         }
     }
 
-    /// Spawns an asynchronous task in this thread-pool. See
-    /// `spawn_async()` for more details.
+    /// Spawns a task in this thread-pool contained within the static
+    /// scope. See `spawn()` for more details.
     #[cfg(feature = "unstable")]
-    pub fn spawn_async<OP>(&self, op: OP)
+    pub fn spawn<OP>(&self, op: OP)
         where OP: FnOnce() + Send + 'static
     {
         // We assert that `self.registry` has not terminated.
-        unsafe { spawn_async::spawn_async_in(op, &self.registry) }
+        unsafe { spawn::spawn_in(op, &self.registry) }
     }
 
-    /// Spawns an asynchronous task in this thread-pool. See
-    /// `spawn_future_async()` for more details.
+    /// Spawns an future in this thread-pool within the static
+    /// scope. See `spawn_future()` for more details.
     #[cfg(feature = "unstable")]
-    pub fn spawn_future_async<F>(&self, future: F) -> RayonFuture<F::Item, F::Error>
+    pub fn spawn_future<F>(&self, future: F) -> RayonFuture<F::Item, F::Error>
         where F: Future + Send + 'static
     {
         // We assert that `self.registry` has not yet terminated.
-        unsafe { spawn_async::spawn_future_async_in(future, self.registry.clone()) }
+        unsafe { spawn::spawn_future_in(future, self.registry.clone()) }
     }
 }
 

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -132,8 +132,12 @@ impl ThreadPool {
         self.install(|| join(oper_a, oper_b))
     }
 
-    /// Execute `oper_a` and `oper_b` in the thread-pool and return
-    /// the results. Equivalent to `self.install(|| scope(...))`.
+    /// Creates a scope that executes within this thread-pool.
+    /// Equivalent to `self.install(|| scope(...))`.
+    ///
+    /// See also: [the `scope()` function][scope].
+    ///
+    /// [scope]: fn.scope.html
     #[cfg(feature = "unstable")]
     pub fn scope<'scope, OP, R>(&self, op: OP) -> R
         where OP: for<'s> FnOnce(&'s Scope<'scope>) -> R + 'scope + Send, R: Send
@@ -141,8 +145,14 @@ impl ThreadPool {
         self.install(|| scope(op))
     }
 
-    /// Spawns an asynchronous task in this thread-pool. See `spawn()`
-    /// for more details.
+    /// Spawns an asynchronous task in this thread-pool. This task will
+    /// run in the implicit, global scope, which means that it may outlast
+    /// the current stack frame -- therefore, it cannot capture any references
+    /// onto the stack (you will likely need a `move` closure).
+    ///
+    /// See the [`spawn()` method defined on scopes][spawn] for more details.
+    ///
+    /// [spawn]: struct.Scope.html#method.spawn
     #[cfg(feature = "unstable")]
     pub fn spawn<OP>(&self, op: OP)
         where OP: FnOnce() + Send + 'static

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub use rayon_core::ThreadPool;
 pub use rayon_core::join;
 pub use rayon_core::{scope, Scope};
 #[cfg(feature = "unstable")]
-pub use rayon_core::spawn_async;
+pub use rayon_core::spawn;
 #[cfg(feature = "unstable")]
-pub use rayon_core::spawn_future_async;
+pub use rayon_core::spawn_future;
 #[cfg(feature = "unstable")]
 pub use rayon_core::RayonFuture;


### PR DESCRIPTION
Between the `_async` and `_future` suffixes, there was quite a zoo of
possibilities:

- `Scope::spawn`
- `Scope::spawn_future`
- `::spawn_async`
- `::spawn_async_future`

After this PR, there are now two orthogonal concepts. First, what
**scope** are you spawning the task into? If you use the free-standing
 functions, like `rayon::spawn()`, or methods on a thread-pool, like
 `pool.spawn_future()`, that is the "static" or "global" scope, and
 hence no stack references are allowed. Otherwise, if you create a scope
 using `scope()`, then when you do `scope.spawn()` it is spawned into
 that scope.

Second, are you spawning a task for side-effects (`spawn()`) or to
produce a result (`spawn_future()`).

**NB:** Everything but `Scope::spawn()` remains "unstable" in this PR.