### PR TITLE
Add while_some; impl FromParallelIterator for Option/Result

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -67,6 +67,8 @@ mod cloned;
 pub use self::cloned::Cloned;
 mod inspect;
 pub use self::inspect::Inspect;
+mod while_some;
+pub use self::while_some::WhileSome;
 
 #[cfg(test)]
 mod test;
@@ -594,6 +596,15 @@ pub trait ParallelIterator: Sized {
         where P: Fn(Self::Item) -> bool + Sync
     {
         self.map(predicate).find_any(|&p| !p).is_none()
+    }
+
+    /// Creates an iterator over the `Some` items of this iterator, halting
+    /// as soon as any `None` is found.
+    fn while_some<T>(self) -> WhileSome<Self>
+        where Self: ParallelIterator<Item = Option<T>>,
+              T: Send
+    {
+        while_some::new(self)
     }
 
     /// Create a fresh collection containing all the element produced

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1111,6 +1111,28 @@ pub fn check_find_is_present() {
 }
 
 #[test]
+pub fn check_while_some() {
+    let value = (0_i32..2048)
+        .into_par_iter()
+        .map(Some)
+        .while_some()
+        .max();
+    assert_eq!(value, Some(2047));
+
+    let counter = AtomicUsize::new(0);
+    let value = (0_i32..2048)
+        .into_par_iter()
+        .map(|x| {
+                 counter.fetch_add(1, Ordering::SeqCst);
+                 if x < 1024 { Some(x) } else { None }
+             })
+        .while_some()
+        .max();
+    assert!(value < Some(1024));
+    assert!(counter.load(Ordering::SeqCst) < 2048); // should not have visited every single one
+}
+
+#[test]
 pub fn par_iter_collect() {
     let a: Vec<i32> = (0..1024).collect();
     let b: Vec<i32> = a.par_iter().map(|&i| i + 1).collect();

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1133,6 +1133,19 @@ pub fn check_while_some() {
 }
 
 #[test]
+pub fn par_iter_collect_option() {
+    let a: Option<Vec<_>> = (0_i32..2048).map(Some).collect();
+    let b: Option<Vec<_>> = (0_i32..2048).into_par_iter().map(Some).collect();
+    assert_eq!(a, b);
+
+    let c: Option<Vec<_>> = (0_i32..2048)
+        .into_par_iter()
+        .map(|x| if x == 1234 { None } else { Some(x) })
+        .collect();
+    assert_eq!(c, None);
+}
+
+#[test]
 pub fn par_iter_collect() {
     let a: Vec<i32> = (0..1024).collect();
     let b: Vec<i32> = a.par_iter().map(|&i| i + 1).collect();

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1146,6 +1146,25 @@ pub fn par_iter_collect_option() {
 }
 
 #[test]
+pub fn par_iter_collect_result() {
+    let a: Result<Vec<_>, ()> = (0_i32..2048).map(Ok).collect();
+    let b: Result<Vec<_>, ()> = (0_i32..2048).into_par_iter().map(Ok).collect();
+    assert_eq!(a, b);
+
+    let c: Result<Vec<_>, _> = (0_i32..2048)
+        .into_par_iter()
+        .map(|x| if x == 1234 { Err(x) } else { Ok(x) })
+        .collect();
+    assert_eq!(c, Err(1234));
+
+    let d: Result<Vec<_>, _> = (0_i32..2048)
+        .into_par_iter()
+        .map(|x| if x % 100 == 99 { Err(x) } else { Ok(x) })
+        .collect();
+    assert_eq!(d.map_err(|x| x % 100), Err(99));
+}
+
+#[test]
 pub fn par_iter_collect() {
     let a: Vec<i32> = (0..1024).collect();
     let b: Vec<i32> = a.par_iter().map(|&i| i + 1).collect();

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -1,0 +1,117 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use super::internal::*;
+use super::*;
+
+/// `WhileSome` is an iterator that yields the `Some` elements of an iterator,
+/// halting as soon as any `None` is produced.
+///
+/// This struct is created by the [`while_some()`] method on [`ParallelIterator`]
+///
+/// [`while_some()`]: trait.ParallelIterator.html#method.while_some
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+pub struct WhileSome<I: ParallelIterator> {
+    base: I,
+}
+
+/// Create a new `WhileSome` iterator.
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new<I>(base: I) -> WhileSome<I>
+    where I: ParallelIterator
+{
+    WhileSome { base: base }
+}
+
+impl<I, T> ParallelIterator for WhileSome<I>
+    where I: ParallelIterator<Item = Option<T>>,
+          T: Send
+{
+    type Item = T;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        let full = AtomicBool::new(false);
+        let consumer1 = WhileSomeConsumer {
+            base: consumer,
+            full: &full,
+        };
+        self.base.drive_unindexed(consumer1)
+    }
+}
+
+
+/// ////////////////////////////////////////////////////////////////////////
+/// Consumer implementation
+
+struct WhileSomeConsumer<'f, C> {
+    base: C,
+    full: &'f AtomicBool,
+}
+
+impl<'f, T, C> Consumer<Option<T>> for WhileSomeConsumer<'f, C>
+    where C: Consumer<T>,
+          T: Send
+{
+    type Folder = WhileSomeFolder<'f, C::Folder>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, Self::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (WhileSomeConsumer { base: left, ..self },
+         WhileSomeConsumer { base: right, ..self },
+         reducer)
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        WhileSomeFolder {
+            base: self.base.into_folder(),
+            full: self.full,
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.full.load(Ordering::Relaxed) || self.base.full()
+    }
+}
+
+impl<'f, T, C> UnindexedConsumer<Option<T>> for WhileSomeConsumer<'f, C>
+    where C: UnindexedConsumer<T>,
+          T: Send
+{
+    fn split_off_left(&self) -> Self {
+        WhileSomeConsumer { base: self.base.split_off_left(), ..*self }
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
+    }
+}
+
+struct WhileSomeFolder<'f, C> {
+    base: C,
+    full: &'f AtomicBool,
+}
+
+impl<'f, T, C> Folder<Option<T>> for WhileSomeFolder<'f, C>
+    where C: Folder<T>
+{
+    type Result = C::Result;
+
+    fn consume(mut self, item: Option<T>) -> Self {
+        match item {
+            Some(item) => self.base = self.base.consume(item),
+            None => self.full.store(true, Ordering::Relaxed),
+        }
+        self
+    }
+
+    fn complete(self) -> C::Result {
+        self.base.complete()
+    }
+
+    fn full(&self) -> bool {
+        self.full.load(Ordering::Relaxed) || self.base.full()
+    }
+}

--- a/src/option.rs
+++ b/src/option.rs
@@ -5,6 +5,7 @@
 use iter::*;
 use iter::internal::*;
 use std;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 impl<T: Send> IntoParallelIterator for Option<T> {
     type Item = T;
@@ -108,6 +109,35 @@ impl<T: Send> Producer for OptionProducer<T> {
             (none, self)
         } else {
             (self, none)
+        }
+    }
+}
+
+
+/// Collect an arbitrary `Option`-wrapped collection.
+///
+/// If any item is `None`, then all previous items collected are discarded,
+/// and it returns only `None`.
+impl<'a, C, T> FromParallelIterator<Option<T>> for Option<C>
+    where C: FromParallelIterator<T>,
+          T: Send
+{
+    fn from_par_iter<I>(par_iter: I) -> Self
+        where I: IntoParallelIterator<Item = Option<T>>
+    {
+        let found_none = AtomicBool::new(false);
+        let collection = par_iter
+            .into_par_iter()
+            .inspect(|item| if item.is_none() {
+                         found_none.store(true, Ordering::Relaxed);
+                     })
+            .while_some()
+            .collect();
+
+        if found_none.load(Ordering::Relaxed) {
+            None
+        } else {
+            Some(collection)
         }
     }
 }


### PR DESCRIPTION
The new `while_some` filters for `Some` values, and halts if it encounters any
`None`.  This is inspired by `Itertools::while_some`, although being parallel
means it doesn't consider the order.

Using this, we can implement a short-circuiting collect for `Option` and
`Result` like the standard library, returning just `None` or `Err` respectively
if any such item is found in the iterator.  Since this operates in parallel,
it's not deterministic which items will have already been visited, nor which
`Err` will be returned if there are multiple.