### PR TITLE
Remove FromParallelIterator from the prelude

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -909,7 +909,8 @@ pub trait IndexedParallelIterator: ParallelIterator {
 /// By implementing `FromParallelIterator` for a type, you define how it will be
 /// created from an iterator.
 ///
-/// `FromParallelIterator` is used through [`ParallelIterator`]'s [`collect()`] method.
+/// `FromParallelIterator`'s `from_par_iter()` is rarely called explicitly,
+/// and is instead used through [`ParallelIterator`]'s [`collect()`] method.
 ///
 /// [`ParallelIterator`]: trait.ParallelIterator.html
 /// [`collect()`]: trait.ParallelIterator.html#method.collect

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,7 +2,6 @@
 //! The intention is that one can include `use rayon::prelude::*` and
 //! have easy access to the various traits and methods you will need.
 
-pub use iter::FromParallelIterator;
 pub use iter::IntoParallelIterator;
 pub use iter::IntoParallelRefIterator;
 pub use iter::IntoParallelRefMutIterator;


### PR DESCRIPTION
The standard prelude does not include `FromIterator`, expecting that
folks will usually interact with this only through `collect()`.  We can
say the same about `FromParallelIterator`.