### PR TITLE
Fold should pass the full check to its base

### DIFF
--- a/src/iter/collect/consumer.rs
+++ b/src/iter/collect/consumer.rs
@@ -57,6 +57,10 @@ impl<'c, T: Send + 'c> Consumer<T> for CollectConsumer<'c, T> {
             target: self.target.into_iter(),
         }
     }
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
@@ -79,6 +83,10 @@ impl<'c, T: Send + 'c> Folder<T> for CollectFolder<'c, T> {
 
         // track total values written
         self.global_writes.fetch_add(self.local_writes, Ordering::Relaxed);
+    }
+
+    fn full(&self) -> bool {
+        false
     }
 }
 

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -73,6 +73,10 @@ impl<'r, U, T, C, ID, F> Consumer<T> for FoldConsumer<'r, C, ID, F>
             fold_op: self.fold_op,
         }
     }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
 }
 
 impl<'r, U, T, C, ID, F> UnindexedConsumer<T> for FoldConsumer<'r, C, ID, F>
@@ -113,5 +117,9 @@ impl<'r, C, ID, F, T> Folder<T> for FoldFolder<'r, C, ID, F>
 
     fn complete(self) -> C::Result {
         self.base.consume(self.item).complete()
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
     }
 }

--- a/src/iter/for_each.rs
+++ b/src/iter/for_each.rs
@@ -29,6 +29,10 @@ impl<'f, F, T> Consumer<T> for ForEachConsumer<'f, F>
     fn into_folder(self) -> Self {
         self
     }
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<'f, F, T> Folder<T> for ForEachConsumer<'f, F>
@@ -42,6 +46,10 @@ impl<'f, F, T> Folder<T> for ForEachConsumer<'f, F>
     }
 
     fn complete(self) {}
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<'f, F, T> UnindexedConsumer<T> for ForEachConsumer<'f, F>

--- a/src/iter/internal.rs
+++ b/src/iter/internal.rs
@@ -67,9 +67,7 @@ pub trait Consumer<Item>: Send + Sized {
 
     /// Hint whether this `Consumer` would like to stop processing
     /// further items, e.g. if a search has been completed.
-    fn full(&self) -> bool {
-        false
-    }
+    fn full(&self) -> bool;
 }
 
 pub trait Folder<Item>: Sized {
@@ -96,9 +94,7 @@ pub trait Folder<Item>: Sized {
 
     /// Hint whether this `Folder` would like to stop processing
     /// further items, e.g. if a search has been completed.
-    fn full(&self) -> bool {
-        false
-    }
+    fn full(&self) -> bool;
 }
 
 pub trait Reducer<Result> {

--- a/src/iter/noop.rs
+++ b/src/iter/noop.rs
@@ -20,6 +20,10 @@ impl<T> Consumer<T> for NoopConsumer {
     fn into_folder(self) -> Self {
         self
     }
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<T> Folder<T> for NoopConsumer {
@@ -30,6 +34,10 @@ impl<T> Folder<T> for NoopConsumer {
     }
 
     fn complete(self) {}
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<T> UnindexedConsumer<T> for NoopConsumer {

--- a/src/iter/product.rs
+++ b/src/iter/product.rs
@@ -43,6 +43,10 @@ impl<P, T> Consumer<T> for ProductConsumer<P>
     fn into_folder(self) -> Self::Folder {
         ProductFolder { product: iter::empty::<T>().product() }
     }
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<P, T> UnindexedConsumer<T> for ProductConsumer<P>
@@ -87,5 +91,9 @@ impl<P, T> Folder<T> for ProductFolder<P>
 
     fn complete(self) -> P {
         self.product
+    }
+
+    fn full(&self) -> bool {
+        false
     }
 }

--- a/src/iter/reduce.rs
+++ b/src/iter/reduce.rs
@@ -46,6 +46,10 @@ impl<'r, R, ID, T> Consumer<T> for ReduceConsumer<'r, R, ID>
             item: (self.identity)(),
         }
     }
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<'r, R, ID, T> UnindexedConsumer<T> for ReduceConsumer<'r, R, ID>
@@ -98,5 +102,9 @@ impl<'r, R, T> Folder<T> for ReduceFolder<'r, R, T>
 
     fn complete(self) -> T {
         self.item
+    }
+
+    fn full(&self) -> bool {
+        false
     }
 }

--- a/src/iter/sum.rs
+++ b/src/iter/sum.rs
@@ -43,6 +43,10 @@ impl<S, T> Consumer<T> for SumConsumer<S>
     fn into_folder(self) -> Self::Folder {
         SumFolder { sum: iter::empty::<T>().sum() }
     }
+
+    fn full(&self) -> bool {
+        false
+    }
 }
 
 impl<S, T> UnindexedConsumer<T> for SumConsumer<S>
@@ -87,5 +91,9 @@ impl<S, T> Folder<T> for SumFolder<S>
 
     fn complete(self) -> S {
         self.sum
+    }
+
+    fn full(&self) -> bool {
+        false
     }
 }

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -178,6 +178,18 @@ pub fn fold_map_reduce() {
 }
 
 #[test]
+pub fn fold_is_full() {
+    let counter = AtomicUsize::new(0);
+    let a = (0_i32..2048)
+        .into_par_iter()
+        .inspect(|_| { counter.fetch_add(1, Ordering::SeqCst); })
+        .fold(|| 0, |a, b| a + b)
+        .find_any(|_| true);
+    assert!(a.is_some());
+    assert!(counter.load(Ordering::SeqCst) < 2048); // should not have visited every single one
+}
+
+#[test]
 pub fn check_enumerate() {
     let a: Vec<usize> = (0..1024).rev().collect();
 


### PR DESCRIPTION
`FoldConsumer` and `FoldFolder` never got their `fn full`, probably
because these features were developed near the same time.  They just
need to pass the call down to their base consumer/folder.