### PR TITLE
Add Windows CI(Appveyor) and enable unstable features in Travis on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ env:
 
 matrix:
   include:
+  - rust: stable
+    env: FEATURES=unstable
+    os: linux
+  - rust: stable
+    env: FEATURES=unstable
+    os: osx
   - rust: nightly
     env: FEATURES=unstable
     os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+environment:
+  RUST_MIN_STACK: 16777216
+  matrix:
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: 1.12.0
+
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: stable
+      FEATURES: unstable
+
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: beta
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: beta
+      FEATURES: unstable
+
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: nightly
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: nightly
+      FEATURES: unstable
+
+
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: 1.12.0
+
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: stable
+      FEATURES: unstable
+
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: beta
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: beta
+      FEATURES: unstable
+
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: nightly
+      FEATURES: unstable
+
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe --default-host %TARGET% --default-toolchain %CHANNEL% -y
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo build --features="%FEATURES%"
+  - if [%CHANNEL%]==[nightly] (
+      cargo test --features="%FEATURES%" -p rayon-core &&
+      cargo test --features="%FEATURES%" -p rayon-demo
+    )


### PR DESCRIPTION
I enabled the unstable feature on stable because it's unstable only for `Rayon`(doesn't contain Rust nightly features). At least in Appveyor, `1.12.0` with the unstable feature enabled fails to build - that's why there is no matrix for `1.12.0` + `FEATURES=unstable`.

You can see the status of these builds:
- Windows: https://ci.appveyor.com/project/lilianmoraru/rayon
- Linux/macOS: https://travis-ci.org/lilianmoraru/rayon

On Windows, nightly fails and I don't know why(I don't have a Windows machine to test locally).