### PR TITLE
Reduce use of the pub-in-private hack

### DIFF
--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -808,6 +808,29 @@ pub fn check_empty_flat_map_sum() {
 }
 
 #[test]
+pub fn check_slice_split() {
+    let v: Vec<_> = (0..1000).collect();
+    for m in 1..100 {
+        let a: Vec<_> = v.split(|x| x % m == 0).collect();
+        let b: Vec<_> = v.par_split(|x| x % m == 0).collect();
+        assert_eq!(a, b);
+    }
+
+    // same as std::slice::split() examples
+    let slice = [10, 40, 33, 20];
+    let v: Vec<_> = slice.par_split(|num| num % 3 == 0).collect();
+    assert_eq!(v, &[&slice[..2], &slice[3..]]);
+
+    let slice = [10, 40, 33];
+    let v: Vec<_> = slice.par_split(|num| num % 3 == 0).collect();
+    assert_eq!(v, &[&slice[..2], &slice[..0]]);
+
+    let slice = [10, 6, 33, 20];
+    let v: Vec<_> = slice.par_split(|num| num % 3 == 0).collect();
+    assert_eq!(v, &[&slice[..1], &slice[..0], &slice[3..]]);
+}
+
+#[test]
 pub fn check_chunks() {
     let a: Vec<i32> = vec![1, 5, 10, 4, 100, 3, 1000, 2, 10000, 1];
     let par_sum_product_pairs: i32 =

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -831,6 +831,24 @@ pub fn check_slice_split() {
 }
 
 #[test]
+pub fn check_slice_split_mut() {
+    let mut v1: Vec<_> = (0..1000).collect();
+    let mut v2 = v1.clone();
+    for m in 1..100 {
+        let a: Vec<_> = v1.split_mut(|x| x % m == 0).collect();
+        let b: Vec<_> = v2.par_split_mut(|x| x % m == 0).collect();
+        assert_eq!(a, b);
+    }
+
+    // same as std::slice::split_mut() example
+    let mut v = [10, 40, 30, 20, 60, 50];
+    v.par_split_mut(|num| num % 3 == 0).for_each(|group| {
+        group[0] = 1;
+    });
+    assert_eq!(v, [1, 40, 30, 1, 60, 1]);
+}
+
+#[test]
 pub fn check_chunks() {
     let a: Vec<i32> = vec![1, 5, 10, 4, 100, 3, 1000, 2, 10000, 1];
     let par_sum_product_pairs: i32 =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ mod delegate;
 #[macro_use]
 mod private;
 
+mod split_producer;
+
 pub mod collections;
 pub mod iter;
 pub mod option;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,4 +9,5 @@ pub use iter::IntoParallelRefMutIterator;
 pub use iter::IndexedParallelIterator;
 pub use iter::ParallelIterator;
 pub use slice::ParallelSlice;
+pub use slice::ParallelSliceMut;
 pub use str::ParallelString;

--- a/src/split_producer.rs
+++ b/src/split_producer.rs
@@ -1,0 +1,124 @@
+//! Common splitter for strings and slices
+//!
+//! This module is private, so these items are effectively `pub(super)`
+
+use iter::internal::{UnindexedProducer, Folder};
+
+/// Common producer for splitting on a predicate.
+pub struct SplitProducer<'p, P: 'p, V> {
+    data: V,
+    separator: &'p P,
+
+    /// Marks the endpoint beyond which we've already found no separators.
+    tail: usize,
+}
+
+/// Helper trait so `&str`, `&[T]`, and `&mut [T]` can share `SplitProducer`.
+pub trait Fissile<P>: Sized {
+    fn length(&self) -> usize;
+    fn midpoint(&self, end: usize) -> usize;
+    fn find(&self, separator: &P, start: usize, end: usize) -> Option<usize>;
+    fn rfind(&self, separator: &P, end: usize) -> Option<usize>;
+    fn split_once(self, index: usize) -> (Self, Self);
+    fn fold_splits<F>(self, separator: &P, folder: F, skip_last: bool) -> F
+        where F: Folder<Self>, Self: Send;
+}
+
+impl<'p, P, V> SplitProducer<'p, P, V>
+    where V: Fissile<P> + Send
+{
+    pub fn new(data: V, separator: &'p P) -> Self {
+        SplitProducer {
+            tail: data.length(),
+            data: data,
+            separator: separator,
+        }
+    }
+
+    /// Common `fold_with` implementation, integrating `SplitTerminator`'s
+    /// need to sometimes skip its final empty item.
+    pub fn fold_with<F>(self, folder: F, skip_last: bool) -> F
+        where F: Folder<V>
+    {
+        let SplitProducer { data, separator, tail } = self;
+
+        if tail == data.length() {
+            // No tail section, so just let `fold_splits` handle it.
+            data.fold_splits(separator, folder, skip_last)
+
+        } else if let Some(index) = data.rfind(separator, tail) {
+            // We found the last separator to complete the tail, so
+            // end with that slice after `fold_splits` finds the rest.
+            let (left, right) = data.split_once(index);
+            let folder = left.fold_splits(separator, folder, false);
+            if skip_last || folder.full() {
+                folder
+            } else {
+                folder.consume(right)
+            }
+
+        } else {
+            // We know there are no separators at all.  Return our whole data.
+            if skip_last {
+                folder
+            } else {
+                folder.consume(data)
+            }
+        }
+    }
+}
+
+impl<'p, P, V> UnindexedProducer for SplitProducer<'p, P, V>
+    where V: Fissile<P> + Send,
+          P: Sync,
+{
+    type Item = V;
+
+    fn split(self) -> (Self, Option<Self>) {
+        // Look forward for the separator, and failing that look backward.
+        let mid = self.data.midpoint(self.tail);
+        let index = self.data.find(self.separator, mid, self.tail)
+            .map(|i| mid + i)
+            .or_else(|| self.data.rfind(self.separator, mid));
+
+        if let Some(index) = index {
+            let len = self.data.length();
+            let (left, right) = self.data.split_once(index);
+
+            let (left_tail, right_tail) = if index < mid {
+                // If we scanned backwards to find the separator, everything in
+                // the right side is exhausted, with no separators left to find.
+                (index, 0)
+            } else {
+                let right_index = len - right.length();
+                (mid, self.tail - right_index)
+            };
+
+            // Create the left split before the separator.
+            let left = SplitProducer {
+                data: left,
+                tail: left_tail,
+                ..self
+            };
+
+            // Create the right split following the separator.
+            let right = SplitProducer {
+                data: right,
+                tail: right_tail,
+                ..self
+            };
+
+            (left, Some(right))
+
+        } else {
+            // The search is exhausted, no more separators...
+            (SplitProducer { tail: 0, ..self }, None)
+        }
+    }
+
+    fn fold_with<F>(self, folder: F) -> F
+        where F: Folder<Self::Item>
+    {
+        self.fold_with(folder, false)
+    }
+}


### PR DESCRIPTION
A recent thread on [internals] got me thinking whether we could avoid the `private_impl!{}` hack after all.  With a few extra constraints, this does work!

[internals]: https://internals.rust-lang.org/t/pre-rfc-do-not-allow-public-structs-in-private-modules/5156

With `ParallelString: Borrow<str>`, we can provide default implementations of all its methods, and should be free to add new methods the same way.  Then a blanket `impl` only has to meet the constraints, so there's also less repetition defining these methods.

Similarly `ParallelSlice<T: Sync>: Borrow<[T]>` works for slices, and a new `ParallelSliceMut<T: Send>: BorrowMut<[T]>` for mutable slices.  The latter is also added to the prelude.

I also considered `AsRef` and `AsMut`, which are very similar to borrows, but I decided against it for the single fact that strings implement both `AsRef<str>` and `AsRef<[u8]>`.  This would make it ambiguous if `ParallelString` and `ParallelSlice` shared any method names, and to drive that point home I went ahead and added `par_split` and `par_split_mut` on slices.

The only remaining `private_impl!{}` is in `rayon::str::Pattern`.  I don't think we can use a similar trick on that one, but the more I think about it, the more I think we should just hide `Pattern` altogether as pub-in-private itself.  Its API is not great, and not something we really want folks to call directly.  All users really need to know are which types implement it, and we can document that on the public splitter functions that use it.