### PR TITLE
Use the either crate for `Either`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.2", path = "rayon-core" }
+either = "1.1"
 
 [dev-dependencies]
 compiletest_rs = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ exclude = ["ci"]
 
 [dependencies]
 rayon-core = { version = "1.2", path = "rayon-core" }
-either = "1.1"
+
+# This is a public dependency!
+[dependencies.either]
+version = "1.0"
+default-features = false
 
 [dev-dependencies]
 compiletest_rs = "0.2.1"

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -9,7 +9,7 @@
 //! the code itself, the `internal` module and `README.md` file are a
 //! good place to start.
 
-use either::Either;
+pub use either::Either;
 use std::cmp::{self, Ordering};
 use std::iter::{Sum, Product};
 use std::ops::Fn;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -9,6 +9,7 @@
 //! the code itself, the `internal` module and `README.md` file are a
 //! good place to start.
 
+use either::Either;
 use std::cmp::{self, Ordering};
 use std::iter::{Sum, Product};
 use std::ops::Fn;
@@ -74,12 +75,6 @@ mod unzip;
 
 #[cfg(test)]
 mod test;
-
-/// Represents a value of one of two possible types.
-pub enum Either<L, R> {
-    Left(L),
-    Right(R)
-}
 
 pub trait IntoParallelIterator {
     type Iter: ParallelIterator<Item = Self::Item>;

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1662,3 +1662,23 @@ fn check_partition_map() {
     assert_eq!(a, vec![1, 2, 3]);
     assert_eq!(b, "abcxyz");
 }
+
+#[test]
+fn check_either() {
+    type I = ::vec::IntoIter<i32>;
+    type E = Either<I, I>;
+
+    let v: Vec<i32> = (0..1024).collect();
+
+    // try iterating the left side
+    let left: E = Either::Left(v.clone().into_par_iter());
+    assert!(left.eq(v.clone()));
+
+    // try iterating the right side
+    let right: E = Either::Right(v.clone().into_par_iter());
+    assert!(right.eq(v.clone()));
+
+    // try an indexed iterator
+    let left: E = Either::Left(v.clone().into_par_iter());
+    assert!(left.enumerate().eq(v.clone().into_par_iter().enumerate()));
+}

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1682,3 +1682,20 @@ fn check_either() {
     let left: E = Either::Left(v.clone().into_par_iter());
     assert!(left.enumerate().eq(v.clone().into_par_iter().enumerate()));
 }
+
+#[test]
+fn check_either_extend() {
+    type E = Either<Vec<i32>, HashSet<i32>>;
+
+    let v: Vec<i32> = (0..1024).collect();
+
+    // try extending the left side
+    let mut left: E = Either::Left(vec![]);
+    left.par_extend(v.clone());
+    assert_eq!(left.as_ref(), Either::Left(&v));
+
+    // try extending the right side
+    let mut right: E = Either::Right(HashSet::default());
+    right.par_extend(v.clone());
+    assert_eq!(right, Either::Right(v.iter().cloned().collect()));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod slice;
 pub mod str;
 pub mod vec;
 
+mod par_either;
 mod test;
 
 pub use iter::split;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(feature = "unstable"), allow(warnings))]
 
 extern crate rayon_core;
+extern crate either;
 
 #[cfg(test)]
 extern crate rand;

--- a/src/par_either.rs
+++ b/src/par_either.rs
@@ -50,3 +50,20 @@ impl<L, R> IndexedParallelIterator for Either<L, R>
         }
     }
 }
+
+
+/// `Either<L, R>` can be extended if both `L` and `R` are parallel extendable.
+impl<L, R, T> ParallelExtend<T> for Either<L, R>
+    where L: ParallelExtend<T>,
+          R: ParallelExtend<T>,
+          T: Send
+{
+    fn par_extend<I>(&mut self, par_iter: I)
+        where I: IntoParallelIterator<Item = T>
+    {
+        match self.as_mut() {
+            Left(collection) => collection.par_extend(par_iter),
+            Right(collection) => collection.par_extend(par_iter),
+        }
+    }
+}

--- a/src/par_either.rs
+++ b/src/par_either.rs
@@ -1,7 +1,6 @@
-use either::Either::{self, Left, Right};
-
 use iter::*;
 use iter::internal::*;
+use iter::Either::{Left, Right};
 
 /// `Either<L, R>` is a parallel iterator if both `L` and `R` are parallel iterators.
 impl<L, R> ParallelIterator for Either<L, R>

--- a/src/par_either.rs
+++ b/src/par_either.rs
@@ -1,0 +1,52 @@
+use either::Either::{self, Left, Right};
+
+use iter::*;
+use iter::internal::*;
+
+/// `Either<L, R>` is a parallel iterator if both `L` and `R` are parallel iterators.
+impl<L, R> ParallelIterator for Either<L, R>
+    where L: ParallelIterator,
+          R: ParallelIterator<Item = L::Item>
+{
+    type Item = L::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: UnindexedConsumer<Self::Item>
+    {
+        match self {
+            Left(iter) => iter.drive_unindexed(consumer),
+            Right(iter) => iter.drive_unindexed(consumer),
+        }
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        self.as_mut().either(L::opt_len, R::opt_len)
+    }
+}
+
+impl<L, R> IndexedParallelIterator for Either<L, R>
+    where L: IndexedParallelIterator,
+          R: IndexedParallelIterator<Item = L::Item>
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        match self {
+            Left(iter) => iter.drive(consumer),
+            Right(iter) => iter.drive(consumer),
+        }
+    }
+
+    fn len(&mut self) -> usize {
+        self.as_mut().either(L::len, R::len)
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        match self {
+            Left(iter) => iter.with_producer(callback),
+            Right(iter) => iter.with_producer(callback),
+        }
+    }
+}


### PR DESCRIPTION
We added a bare `Either` type for `partition_map`, but that's not really a type that belongs in Rayon.  The `either` crate has a stable implementation of `Either` for everyone to share.

While we're at it, `Either` implements pass-throughs for `Iterator` and `Extend`, so we can do the same for `ParallelIterator` and `ParallelExtend`.