### PR TITLE
Introduce RAYON_NUM_THREADS and RAYON_LOG env vars

### DIFF
--- a/rayon-core/src/log.rs
+++ b/rayon-core/src/log.rs
@@ -1,8 +1,12 @@
 //! Debug Logging
 //!
-//! To use in a debug build, set the env var `RAYON_RS_LOG=1`.  In a
+//! To use in a debug build, set the env var `RAYON_LOG=1`.  In a
 //! release build, logs are compiled out. You will have to change
 //! `DUMP_LOGS` to be `true`.
+//!
+//! **Old environment variable:** `RAYON_LOG` is a one-to-one
+//! replacement of the now deprecated `RAYON_RS_LOG` environment
+//! variable, which is still supported for backwards compatibility.
 
 use std::env;
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
@@ -44,7 +48,7 @@ pub enum Event {
 pub const DUMP_LOGS: bool = cfg!(debug_assertions);
 
 lazy_static! {
-    pub static ref LOG_ENV: bool = env::var("RAYON_RS_LOG").is_ok();
+    pub static ref LOG_ENV: bool = env::var("RAYON_LOG").is_ok() || env::var("RAYON_RS_LOG").is_ok();
 }
 
 macro_rules! log {


### PR DESCRIPTION
I hope this PR doesn't appear like bikeshedding, but I believe `RAYON_RS_NUM_THREADS` is a better, more mnemonic name for the environment variable compared with `RAYON_RS_NUM_CPUS`.

Reasons:

1. It corresponds to what the environment variable is supposed to be controlling, namely the *number of threads*; from `rayon-core/src/lib.rs`:

```rust
pub struct Configuration {
    /// The number of threads in the rayon thread pool.
    /// If zero will use the RAYON_RS_NUM_CPUS environment variable.
    /// If RAYON_RS_NUM_CPUS is invalid or zero will use the default.
num_threads: usize,
...
}
```

2. The variable name would correspond to what OpenMP is using, which is `OMP_NUM_THREADS`. Since rayon is very likely going to be used for the same purposes that OpenMP is used in other languages, this would be a more natural name to remember (ok, `RAYON_NUM_THREADS` would be even better. :-) ).