### PR TITLE
Add a benchmark of `ParallelString::par_split`

### DIFF
--- a/rayon-demo/src/main.rs
+++ b/rayon-demo/src/main.rs
@@ -23,6 +23,7 @@ mod life;
 #[cfg(test)] mod fibonacci;
 #[cfg(test)] mod find;
 #[cfg(test)] mod join_microbench;
+#[cfg(test)] mod str_split;
 
 extern crate rayon; // all
 extern crate docopt; // all

--- a/rayon-demo/src/str_split.rs
+++ b/rayon-demo/src/str_split.rs
@@ -1,0 +1,52 @@
+//! Some microbenchmarks for splitting strings
+
+use rayon::prelude::*;
+use rand::{Rng, SeedableRng, XorShiftRng};
+use test::Bencher;
+
+lazy_static! {
+    static ref HAYSTACK: String = {
+        let mut rng = XorShiftRng::from_seed([0, 1, 2, 3]);
+        let mut bytes: Vec<u8> = "abcdefg ".bytes().cycle().take(1_000_000).collect();
+        rng.shuffle(&mut bytes);
+        String::from_utf8(bytes).unwrap()
+    };
+
+    static ref COUNT: usize = {
+        HAYSTACK.split(' ').count() 
+    };
+}
+
+fn get_string_count() -> (&'static str, usize) {
+    (&HAYSTACK, *COUNT)
+}
+
+#[bench]
+fn parallel_space_char(b: &mut Bencher) {
+    let (string, count) = get_string_count();
+    b.iter(|| assert_eq!(string.par_split(' ').count(), count))
+}
+
+#[bench]
+fn parallel_space_fn(b: &mut Bencher) {
+    let (string, count) = get_string_count();
+    b.iter(|| assert_eq!(string.par_split(|c| c == ' ').count(), count))
+}
+
+#[bench]
+fn serial_space_char(b: &mut Bencher) {
+    let (string, count) = get_string_count();
+    b.iter(|| assert_eq!(string.split(' ').count(), count))
+}
+
+#[bench]
+fn serial_space_fn(b: &mut Bencher) {
+    let (string, count) = get_string_count();
+    b.iter(|| assert_eq!(string.split(|c| c == ' ').count(), count))
+}
+
+#[bench]
+fn serial_space_str(b: &mut Bencher) {
+    let (string, count) = get_string_count();
+    b.iter(|| assert_eq!(string.split(" ").count(), count))
+}

--- a/src/str.rs
+++ b/src/str.rs
@@ -19,12 +19,14 @@ use split_producer::*;
 
 /// Test if a byte is the start of a UTF-8 character.
 /// (extracted from `str::is_char_boundary`)
+#[inline]
 fn is_char_boundary(b: u8) -> bool {
     // This is bit magic equivalent to: b < 128 || b >= 192
     (b as i8) >= -0x40
 }
 
 /// Find the index of a character boundary near the midpoint.
+#[inline]
 fn find_char_midpoint(chars: &str) -> usize {
     let mid = chars.len() / 2;
 
@@ -125,14 +127,17 @@ use self::private::Pattern;
 impl Pattern for char {
     private_impl!{}
 
+    #[inline]
     fn find_in(&self, chars: &str) -> Option<usize> {
         chars.find(*self)
     }
 
+    #[inline]
     fn rfind_in(&self, chars: &str) -> Option<usize> {
         chars.rfind(*self)
     }
 
+    #[inline]
     fn is_suffix_of(&self, chars: &str) -> bool {
         chars.ends_with(*self)
     }


### PR DESCRIPTION
I wasn't sure how well this actually performs, so a benchmark is in order.  I've added a few annotations to help inlining, but otherwise it seems to be pretty good!

     test str_split::parallel_space_char ... bench:     555,040 ns/iter (+/- 30,003)
     test str_split::parallel_space_fn   ... bench:     547,287 ns/iter (+/- 9,644)
     test str_split::serial_space_char   ... bench:   2,236,302 ns/iter (+/- 52,654)
     test str_split::serial_space_fn     ... bench:   2,235,842 ns/iter (+/- 79,746)
     test str_split::serial_space_str    ... bench:   2,714,414 ns/iter (+/- 61,583)

(on my i7-2600 with 4 cores / 8 threads)