### PR TITLE
Add `ParallelIterator: Send` to join `Chain`

### DIFF
--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -25,7 +25,7 @@ pub fn new<I, P>(base: I, filter_op: P) -> Filter<I, P>
 
 impl<I, P> ParallelIterator for Filter<I, P>
     where I: ParallelIterator,
-          P: Fn(&I::Item) -> bool + Sync
+          P: Fn(&I::Item) -> bool + Sync + Send
 {
     type Item = I::Item;
 

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -25,7 +25,7 @@ pub fn new<I, P>(base: I, filter_op: P) -> FilterMap<I, P>
 
 impl<I, P, R> ParallelIterator for FilterMap<I, P>
     where I: ParallelIterator,
-          P: Fn(I::Item) -> Option<R> + Sync,
+          P: Fn(I::Item) -> Option<R> + Sync + Send,
           R: Send
 {
     type Item = R;

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -25,7 +25,7 @@ pub fn new<I, F>(base: I, map_op: F) -> FlatMap<I, F>
 
 impl<I, F, PI> ParallelIterator for FlatMap<I, F>
     where I: ParallelIterator,
-          F: Fn(I::Item) -> PI + Sync,
+          F: Fn(I::Item) -> PI + Sync + Send,
           PI: IntoParallelIterator
 {
     type Item = PI::Item;

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -3,8 +3,8 @@ use super::*;
 
 pub fn fold<U, I, ID, F>(base: I, identity: ID, fold_op: F) -> Fold<I, ID, F>
     where I: ParallelIterator,
-          F: Fn(U, I::Item) -> U + Sync,
-          ID: Fn() -> U + Sync,
+          F: Fn(U, I::Item) -> U + Sync + Send,
+          ID: Fn() -> U + Sync + Send,
           U: Send
 {
     Fold {
@@ -27,8 +27,8 @@ pub struct Fold<I, ID, F> {
 
 impl<U, I, ID, F> ParallelIterator for Fold<I, ID, F>
     where I: ParallelIterator,
-          F: Fn(U, I::Item) -> U + Sync,
-          ID: Fn() -> U + Sync,
+          F: Fn(U, I::Item) -> U + Sync + Send,
+          ID: Fn() -> U + Sync + Send,
           U: Send
 {
     type Item = U;
@@ -151,7 +151,7 @@ pub struct FoldWith<I, U, F> {
 
 impl<U, I, F> ParallelIterator for FoldWith<I, U, F>
     where I: ParallelIterator,
-          F: Fn(U, I::Item) -> U + Sync,
+          F: Fn(U, I::Item) -> U + Sync + Send,
           U: Send + Clone
 {
     type Item = U;

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -30,7 +30,7 @@ pub fn new<I, F>(base: I, inspect_op: F) -> Inspect<I, F>
 
 impl<I, F> ParallelIterator for Inspect<I, F>
     where I: ParallelIterator,
-          F: Fn(&I::Item) + Sync
+          F: Fn(&I::Item) + Sync + Send
 {
     type Item = I::Item;
 
@@ -48,7 +48,7 @@ impl<I, F> ParallelIterator for Inspect<I, F>
 
 impl<I, F> IndexedParallelIterator for Inspect<I, F>
     where I: IndexedParallelIterator,
-          F: Fn(&I::Item) + Sync
+          F: Fn(&I::Item) + Sync + Send
 {
     fn drive<C>(self, consumer: C) -> C::Result
         where C: Consumer<Self::Item>

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -29,7 +29,7 @@ pub fn new<I, F>(base: I, map_op: F) -> Map<I, F>
 
 impl<I, F, R> ParallelIterator for Map<I, F>
     where I: ParallelIterator,
-          F: Fn(I::Item) -> R + Sync,
+          F: Fn(I::Item) -> R + Sync + Send,
           R: Send
 {
     type Item = F::Output;
@@ -48,7 +48,7 @@ impl<I, F, R> ParallelIterator for Map<I, F>
 
 impl<I, F, R> IndexedParallelIterator for Map<I, F>
     where I: IndexedParallelIterator,
-          F: Fn(I::Item) -> R + Sync,
+          F: Fn(I::Item) -> R + Sync + Send,
           R: Send
 {
     fn drive<C>(self, consumer: C) -> C::Result

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -30,7 +30,7 @@ pub fn new<I, T, F>(base: I, item: T, map_op: F) -> MapWith<I, T, F>
 impl<I, T, F, R> ParallelIterator for MapWith<I, T, F>
     where I: ParallelIterator,
           T: Send + Clone,
-          F: Fn(&mut T, I::Item) -> R + Sync,
+          F: Fn(&mut T, I::Item) -> R + Sync + Send,
           R: Send
 {
     type Item = R;
@@ -50,7 +50,7 @@ impl<I, T, F, R> ParallelIterator for MapWith<I, T, F>
 impl<I, T, F, R> IndexedParallelIterator for MapWith<I, T, F>
     where I: IndexedParallelIterator,
           T: Send + Clone,
-          F: Fn(&mut T, I::Item) -> R + Sync,
+          F: Fn(&mut T, I::Item) -> R + Sync + Send,
           R: Send
 {
     fn drive<C>(self, consumer: C) -> C::Result

--- a/src/iter/splitter.rs
+++ b/src/iter/splitter.rs
@@ -24,7 +24,7 @@ pub struct Split<D, S> {
 
 impl<D, S> ParallelIterator for Split<D, S>
     where D: Send,
-          S: Fn(D) -> (D, Option<D>) + Sync
+          S: Fn(D) -> (D, Option<D>) + Sync + Send
 {
     type Item = D;
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -16,7 +16,7 @@ pub trait ParallelSlice<T: Sync> {
     /// Returns a parallel iterator over subslices separated by elements that
     /// match the separator.
     fn par_split<P>(&self, separator: P) -> Split<T, P>
-        where P: Fn(&T) -> bool + Sync
+        where P: Fn(&T) -> bool + Sync + Send
     {
         Split {
             slice: self.as_parallel_slice(),
@@ -60,7 +60,7 @@ pub trait ParallelSliceMut<T: Send> {
     /// Returns a parallel iterator over mutable subslices separated by
     /// elements that match the separator.
     fn par_split_mut<P>(&mut self, separator: P) -> SplitMut<T, P>
-        where P: Fn(&T) -> bool + Sync
+        where P: Fn(&T) -> bool + Sync + Send
     {
         SplitMut {
             slice: self.as_parallel_slice_mut(),
@@ -451,7 +451,7 @@ pub struct Split<'data, T: 'data, P> {
 }
 
 impl<'data, T, P> ParallelIterator for Split<'data, T, P>
-    where P: Fn(&T) -> bool + Sync,
+    where P: Fn(&T) -> bool + Sync + Send,
           T: Sync
 {
     type Item = &'data [T];
@@ -509,7 +509,7 @@ pub struct SplitMut<'data, T: 'data, P> {
 }
 
 impl<'data, T, P> ParallelIterator for SplitMut<'data, T, P>
-    where P: Fn(&T) -> bool + Sync,
+    where P: Fn(&T) -> bool + Sync + Send,
           T: Send
 {
     type Item = &'data mut [T];

--- a/src/str.rs
+++ b/src/str.rs
@@ -7,7 +7,7 @@
 //! Note: [`ParallelString::par_split()`] and [`par_split_terminator()`]
 //! reference a `Pattern` trait which is not visible outside this crate.
 //! This trait is intentionally kept private, for use only by Rayon itself.
-//! It is implemented for `char` and any `F: Fn(char) -> bool + Sync`.
+//! It is implemented for `char` and any `F: Fn(char) -> bool + Sync + Send`.
 //!
 //! [`ParallelString::par_split()`]: trait.ParallelString.html#method.par_split
 //! [`par_split_terminator()`]: trait.ParallelString.html#method.par_split_terminator
@@ -58,7 +58,7 @@ pub trait ParallelString {
     /// given character or predicate, similar to `str::split`.
     ///
     /// Note: the `Pattern` trait is private, for use only by Rayon itself.
-    /// It is implemented for `char` and any `F: Fn(char) -> bool + Sync`.
+    /// It is implemented for `char` and any `F: Fn(char) -> bool + Sync + Send`.
     fn par_split<P: Pattern>(&self, separator: P) -> Split<P> {
         Split::new(self.as_parallel_string(), separator)
     }
@@ -69,7 +69,7 @@ pub trait ParallelString {
     /// substring after a trailing terminator.
     ///
     /// Note: the `Pattern` trait is private, for use only by Rayon itself.
-    /// It is implemented for `char` and any `F: Fn(char) -> bool + Sync`.
+    /// It is implemented for `char` and any `F: Fn(char) -> bool + Sync + Send`.
     fn par_split_terminator<P: Pattern>(&self, terminator: P) -> SplitTerminator<P> {
         SplitTerminator::new(self.as_parallel_string(), terminator)
     }
@@ -113,7 +113,7 @@ mod private {
     /// `std::str::pattern::{Pattern, Searcher}`.
     ///
     /// Implementing this trait is not permitted outside of `rayon`.
-    pub trait Pattern: Sized + Sync {
+    pub trait Pattern: Sized + Sync + Send {
         private_decl!{}
         fn find_in(&self, &str) -> Option<usize>;
         fn rfind_in(&self, &str) -> Option<usize>;
@@ -153,7 +153,7 @@ impl Pattern for char {
     }
 }
 
-impl<FN: Sync + Fn(char) -> bool> Pattern for FN {
+impl<FN: Sync + Send + Fn(char) -> bool> Pattern for FN {
     private_impl!{}
 
     fn find_in(&self, chars: &str) -> Option<usize> {


### PR DESCRIPTION
If the parallel iterators are themselves always `Send`, then we can use
`join` in implementing `Chain::drive` and `drive_unindexed`.  This
resolves the current sequence point between each side, as they can now
run in parallel if a thread is available to steal it.

The main fallout of that new requirement is that closures we accept must
now be `Send` too, in addition to the existing `Sync` requirement.  It's
not strictly necessary in all cases, like `for_each` that doesn't create
a parallel iterator itself, but it seems nicer to apply a consistent
requirement.

Fixes #342.