### PR TITLE
Fix #343: Rayon 0.7.0: unbounded spins in Sleep::no_work_found

### DIFF
--- a/rayon-core/src/sleep/mod.rs
+++ b/rayon-core/src/sleep/mod.rs
@@ -70,6 +70,7 @@ impl Sleep {
             thread::yield_now();
             yields + 1
         } else if yields == ROUNDS_UNTIL_SLEEPY {
+            thread::yield_now();
             if self.get_sleepy(worker_index) {
                 yields + 1
             } else {


### PR DESCRIPTION
Fix #343: Rayon 0.7.0: unbounded spins in Sleep::no_work_found
