### PR TITLE
Revert "bump rayon core release to v1.0.1 to reflect fix to #343"

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-core"
-version = "1.0.1"
+version = "1.0.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon"


### PR DESCRIPTION
Reverts nikomatsakis/rayon#349

That was hasty and I knew I would come to regret it. I only wanted to issue the fix for #343, but there have been other changes to rayon-core in the meantime, and I suspect a v1.1 release would be better for the total set.