### PR TITLE
mock up `breadth_first` and `spawn_tail`

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 [dependencies]
 rand = "0.3"
 num_cpus = "1.2"
-coco = "0.1.0"
+coco = "0.1.1"
 libc = "0.2.16"
 lazy_static = "0.2.2"
 futures = { version = "0.1.7", optional = true }

--- a/rayon-core/src/join/mod.rs
+++ b/rayon-core/src/join/mod.rs
@@ -65,7 +65,7 @@ pub fn join<A, B, RA, RB>(oper_a: A, oper_b: B) -> (RA, RB)
         // pushed on top of it in the stack, and we will have to pop
         // those off to get to it.
         while !job_b.latch.probe() {
-            if let Some(job) = worker_thread.pop() {
+            if let Some(job) = worker_thread.take_local_job() {
                 if job == job_b_ref {
                     // Found it! Let's run it.
                     //

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -336,13 +336,6 @@ pub fn initialize(config: Configuration) -> Result<(), Box<Error>> {
     Ok(())
 }
 
-/// This is a debugging API not really intended for end users. It will
-/// dump some performance statistics out using `println`.
-#[cfg(feature = "unstable")]
-pub fn dump_stats() {
-    dump_stats!();
-}
-
 impl fmt::Debug for Configuration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let Configuration { ref num_threads, ref get_thread_name,

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -247,17 +247,26 @@ impl Configuration {
         self
     }
 
-    /// Configure worker threads to execute spawned jobs in a
-    /// "breadth-first" fashion.  Typically, when a worker thread is
+    /// Suggest to worker threads that they execute spawned jobs in a
+    /// "breadth-first" fashion. Typically, when a worker thread is
     /// idle or blocked, it will attempt to execute the job from the
     /// *top* of its local deque of work (i.e., the job most recently
-    /// spawned).  If this flag is set to true, however, workers will
+    /// spawned). If this flag is set to true, however, workers will
     /// prefer to execute in a *breadth-first* fashion -- that is,
     /// they will search for jobs at the *bottom* of their local
-    /// deque.
+    /// deque. (At present, workers *always* steal from the bottom of
+    /// other worker's deques, regardless of the setting of this
+    /// flag.)
     ///
-    /// At present, workers *always* steal from the bottom of other
-    /// worker's deques, regardless of the setting of this flag.
+    /// If you think of the tasks as a tree, where a parent task
+    /// spawns its children in the tree, then this flag loosely
+    /// corresponds to doing a breadth-first traversal of the tree,
+    /// whereas the default would be to do a depth-first traversal.
+    ///
+    /// **Note that this is an "execution hint".** Rayon's task
+    /// execution is highly dynamic and the precise order in which
+    /// independent tasks are executed is not intended to be
+    /// guaranteed.
     pub fn breadth_first(mut self) -> Self {
         self.breadth_first = true;
         self

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -63,6 +63,8 @@ mod unwind;
 mod util;
 
 pub use thread_pool::ThreadPool;
+pub use thread_pool::current_thread_index;
+pub use thread_pool::current_thread_has_pending_tasks;
 pub use join::join;
 pub use scope::{scope, Scope};
 #[cfg(feature = "unstable")]
@@ -73,9 +75,10 @@ pub use spawn::spawn_future;
 pub use future::RayonFuture;
 
 /// Returns the number of threads in the current registry. If this
-/// code is executing within the Rayon thread-pool, then this will be
-/// the number of threads for the current thread-pool. Otherwise, it
-/// will be the number of threads for the global thread-pool.
+/// code is executing within a Rayon thread-pool, then this will be
+/// the number of threads for the thread-pool of the current
+/// thread. Otherwise, it will be the number of threads for the global
+/// thread-pool.
 ///
 /// This can be useful when trying to judge how many times to split
 /// parallel work (the parallel iterator traits use this value

--- a/rayon-core/src/log.rs
+++ b/rayon-core/src/log.rs
@@ -9,7 +9,6 @@
 //! variable, which is still supported for backwards compatibility.
 
 use std::env;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 
 #[derive(Debug)]
 pub enum Event {
@@ -54,32 +53,5 @@ lazy_static! {
 macro_rules! log {
     ($event:expr) => {
         if ::log::DUMP_LOGS { if *::log::LOG_ENV { println!("{:?}", $event); } }
-    }
-}
-
-pub static STOLEN_JOB: AtomicUsize = ATOMIC_USIZE_INIT;
-
-macro_rules! stat_stolen {
-    () => {
-        ::log::STOLEN_JOB.fetch_add(1, ::std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-pub static POPPED_JOB: AtomicUsize = ATOMIC_USIZE_INIT;
-
-macro_rules! stat_popped {
-    () => {
-        ::log::POPPED_JOB.fetch_add(1, ::std::sync::atomic::Ordering::SeqCst);
-    }
-}
-
-macro_rules! dump_stats {
-    () => {
-        {
-            let stolen = ::log::STOLEN_JOB.load(::std::sync::atomic::Ordering::SeqCst);
-            println!("Jobs stolen: {:?}", stolen);
-            let popped = ::log::POPPED_JOB.load(::std::sync::atomic::Ordering::SeqCst);
-            println!("Jobs popped: {:?}", popped);
-        }
     }
 }

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -353,9 +353,6 @@ pub struct WorkerThread {
     /// the "worker" half of our local deque
     worker: Worker<JobRef>,
 
-    /// a "stealer" half of our local deque; used in BFS mode
-    stealer: Stealer<JobRef>,
-
     index: usize,
 
     /// are these workers configured to steal breadth-first or not?
@@ -431,7 +428,7 @@ impl WorkerThread {
         if !self.breadth_first {
             self.worker.pop()
         } else {
-            self.stealer.steal()
+            self.worker.steal()
         }
     }
 
@@ -537,7 +534,6 @@ unsafe fn main_loop(worker: Worker<JobRef>,
                     breadth_first: bool) {
     let worker_thread = WorkerThread {
         worker: worker,
-        stealer: registry.thread_infos[index].stealer.clone(),
         breadth_first: breadth_first,
         index: index,
         rng: UnsafeCell::new(rand::weak_rng()),

--- a/rayon-core/src/registry.rs
+++ b/rayon-core/src/registry.rs
@@ -414,11 +414,6 @@ impl WorkerThread {
         self.worker.len() == 0
     }
 
-    #[inline]
-    pub fn breadth_first(&self) -> bool {
-        self.breadth_first
-    }
-
     /// Attempts to obtain a "local" job -- typically this means
     /// popping from the top of the stack, though if we are configured
     /// for breadth-first execution, it would mean dequeuing from the

--- a/rayon-core/src/scope/mod.rs
+++ b/rayon-core/src/scope/mod.rs
@@ -284,40 +284,6 @@ impl<'scope> Scope<'scope> {
         }
     }
 
-    /// If `body` would be the next task to execute, then invoke it directly;
-    /// otherwise, spawn normally. This is an optimization that you can use for
-    /// final task that a given thread will spawn into a scope before completing.
-    ///
-    /// The precise behavior depends on whether we are in DFS or BFS
-    /// mode.  If this thread is in depth-first mode, then this is
-    /// equivalent to just invoking `body()` directly. Otherwise, in
-    /// bread-first mode, check if the local deque is empty. If so,
-    /// then there are no higher-priority tasks, so just call `body()`
-    /// directly.  Otherwise, spawn normally.
-    ///
-    /// If you know that your threads are in depth-first mode, you are
-    /// better off just calling `body()` directly than using this
-    /// function.
-    pub fn spawn_tail<BODY>(&self, body: BODY)
-        where BODY: FnOnce(&Scope<'scope>) + 'scope
-    {
-        let worker_thread = WorkerThread::current();
-
-        // we must always be in a worker thread, since the scope is
-        // neither send nor sync, and hence only travels between
-        // threads when we pass the pointer to spawned tasks.
-        debug_assert!(!WorkerThread::current().is_null());
-
-        unsafe {
-            let worker_thread = &*worker_thread;
-            if !worker_thread.breadth_first() || worker_thread.local_deque_is_empty() {
-                body(self)
-            } else {
-                self.spawn(body);
-            }
-        }
-    }
-
     #[cfg(feature = "unstable")]
     pub fn spawn_future<F>(&self, future: F) -> RayonFuture<F::Item, F::Error>
         where F: Future + Send + 'scope


### PR DESCRIPTION
These introduce two new core APIs that were suggested by @bholley for use in Servo (Stylo, in particular). They are insta-stable because I would want to make a public release so that Servo can make use of them.

The APIs are:

- Introduce a new "breadth-first" scheduling mode that can be enabled per thread-pool. In breadth-first mode, both the current thread *and* stealer threads draw from the bottom of the deque. Depending on your workload, this may be desirable (in the case of stylo, it leads to better cache reuse). Users can opt into breadth-first mode by adjusting the configuration.
- Introduce a new `spawn_tail()` API that is intended to be used for the *last* task that will be spawned. It is intended as a slight optimization on calling `spawn` and then immediately returning from the scope, particularly in breadth-first mode. Specifically, it will invoke the closure directly if that closure would have been the next task that the local thread executes anyway.

These changes introduce an `if` into one of the main hot-paths of Rayon, so I was a bit nervous about performance. However, keep in mind that the `if` is 100% predictable in normal usage (i.e., if you don't mix breadth- and depth-first modes). Both @bholley and I did measurements that suggest basically zero impact on depth-first code. Also, using the newer modes leads to a 20% improvement in performance for Stylo. [The stylo measurements are documented here.](https://bugzilla.mozilla.org/show_bug.cgi?id=1365692#c20) My own measurements, gathered on my 8x2-core linux desktop, are visible here:

- [All measurements.](https://people-mozilla.org/~nmatsakis/rayon-bfs-points.svg)
- [Medians, normalized to 100.](https://people-mozilla.org/~nmatsakis/rayon-bfs-points-medians.svg)

In the median view, you can see *some* effect, but it is only a few percent, and I am not that confident in my measurement setup. =) Because of my inability to convince GNUplot to use colors etc in median mode (have to tinker with that more), it's a bit hard to tell which were affected; but if you hover the cursor over, you can see that `join_recursively`, `increment_all_max`, and `increment_all` are the ones that took more time, whereas `fibonacci` and `increment_all_min` took less time. All of these are micro-benchmarks.

I was considering putting these behind a cargo feature (perhaps one enabled by default), so that users could "opt-out" from having the `if`. This seems like a plausible path, but the measurements suggest to me that it's not necessary, and it seems better to avoid having "options" if we can (so as to reduce the need to measure an exponentially increasing number of combinations).