### PR TITLE
Add `#[must_use]` attributes to iterator adaptors

### DIFF
--- a/src/iter/chain.rs
+++ b/src/iter/chain.rs
@@ -9,6 +9,7 @@ use rayon_core::join;
 ///
 /// [`chain()`]: trait.ParallelIterator.html#method.chain
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Chain<A, B>
     where A: ParallelIterator,
           B: ParallelIterator<Item = A::Item>
@@ -209,7 +210,7 @@ impl<A, B> Producer for ChainProducer<A, B>
 /// ////////////////////////////////////////////////////////////////////////
 /// Wrapper for Chain to implement ExactSizeIterator
 
-pub struct ChainSeq<A, B> {
+struct ChainSeq<A, B> {
     chain: iter::Chain<A, B>,
 }
 

--- a/src/iter/cloned.rs
+++ b/src/iter/cloned.rs
@@ -9,6 +9,7 @@ use std::iter;
 ///
 /// [`cloned()`]: trait.ParallelIterator.html#method.cloned
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Cloned<I: ParallelIterator> {
     base: I,
 }

--- a/src/iter/enumerate.rs
+++ b/src/iter/enumerate.rs
@@ -9,6 +9,7 @@ use std::usize;
 ///
 /// [`enumerate()`]: trait.ParallelIterator.html#method.enumerate
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Enumerate<I: IndexedParallelIterator> {
     base: I,
 }

--- a/src/iter/filter.rs
+++ b/src/iter/filter.rs
@@ -6,6 +6,7 @@ use super::*;
 ///
 /// [`filter()`]: trait.ParallelIterator.html#method.filter
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Filter<I: ParallelIterator, P> {
     base: I,
     filter_op: P,

--- a/src/iter/filter_map.rs
+++ b/src/iter/filter_map.rs
@@ -6,6 +6,7 @@ use super::*;
 ///
 /// [`filter_map()`]: trait.ParallelIterator.html#method.filter_map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FilterMap<I: ParallelIterator, P> {
     base: I,
     filter_op: P,

--- a/src/iter/flat_map.rs
+++ b/src/iter/flat_map.rs
@@ -6,6 +6,7 @@ use super::*;
 ///
 /// [`flap_map()`]: trait.ParallelIterator.html#method.flat_map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FlatMap<I: ParallelIterator, F> {
     base: I,
     map_op: F,

--- a/src/iter/fold.rs
+++ b/src/iter/fold.rs
@@ -19,6 +19,7 @@ pub fn fold<U, I, ID, F>(base: I, identity: ID, fold_op: F) -> Fold<I, ID, F>
 ///
 /// [`fold()`]: trait.ParallelIterator.html#method.fold
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Fold<I, ID, F> {
     base: I,
     identity: ID,
@@ -94,7 +95,7 @@ impl<'r, U, T, C, ID, F> UnindexedConsumer<T> for FoldConsumer<'r, C, ID, F>
     }
 }
 
-pub struct FoldFolder<'r, C, ID, F: 'r> {
+struct FoldFolder<'r, C, ID, F: 'r> {
     base: C,
     fold_op: &'r F,
     item: ID,
@@ -143,6 +144,7 @@ pub fn fold_with<U, I, F>(base: I, item: U, fold_op: F) -> FoldWith<I, U, F>
 ///
 /// [`fold_with()`]: trait.ParallelIterator.html#method.fold_with
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FoldWith<I, U, F> {
     base: I,
     item: U,

--- a/src/iter/inspect.rs
+++ b/src/iter/inspect.rs
@@ -11,6 +11,7 @@ use std::iter;
 ///
 /// [`inspect()`]: trait.ParallelIterator.html#method.inspect
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Inspect<I: ParallelIterator, F> {
     base: I,
     inspect_op: F,

--- a/src/iter/len.rs
+++ b/src/iter/len.rs
@@ -7,6 +7,7 @@ use std::cmp;
 ///
 /// [`min_len()`]: trait.IndexedParallelIterator.html#method.min_len
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MinLen<I: IndexedParallelIterator> {
     base: I,
     min: usize,
@@ -126,6 +127,7 @@ impl<P> Producer for MinLenProducer<P>
 ///
 /// [`max_len()`]: trait.IndexedParallelIterator.html#method.max_len
 /// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MaxLen<I: IndexedParallelIterator> {
     base: I,
     max: usize,

--- a/src/iter/map.rs
+++ b/src/iter/map.rs
@@ -10,6 +10,7 @@ use std::iter;
 ///
 /// [`map()`]: trait.ParallelIterator.html#method.map
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Map<I: ParallelIterator, F> {
     base: I,
     map_op: F,

--- a/src/iter/map_with.rs
+++ b/src/iter/map_with.rs
@@ -8,6 +8,7 @@ use super::*;
 ///
 /// [`map_with()`]: trait.ParallelIterator.html#method.map_with
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MapWith<I: ParallelIterator, T, F> {
     base: I,
     item: T,

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -2,6 +2,7 @@ use super::internal::*;
 use super::*;
 use std::iter;
 
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Rev<I: IndexedParallelIterator> {
     base: I,
 }

--- a/src/iter/skip.rs
+++ b/src/iter/skip.rs
@@ -8,6 +8,7 @@ use std::cmp::min;
 ///
 /// [`skip()`]: trait.ParallelIterator.html#method.skip
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Skip<I> {
     base: I,
     n: usize,

--- a/src/iter/take.rs
+++ b/src/iter/take.rs
@@ -7,6 +7,7 @@ use std::cmp::min;
 ///
 /// [`take()`]: trait.ParallelIterator.html#method.take
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Take<I> {
     base: I,
     n: usize,

--- a/src/iter/while_some.rs
+++ b/src/iter/while_some.rs
@@ -9,6 +9,7 @@ use super::*;
 ///
 /// [`while_some()`]: trait.ParallelIterator.html#method.while_some
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct WhileSome<I: ParallelIterator> {
     base: I,
 }

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -3,6 +3,7 @@ use super::*;
 use std::cmp;
 use std::iter;
 
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Zip<A: IndexedParallelIterator, B: IndexedParallelIterator> {
     a: A,
     b: B,

--- a/tests/compile-fail/must_use.rs
+++ b/tests/compile-fail/must_use.rs
@@ -1,0 +1,30 @@
+#![deny(unused_must_use)]
+
+extern crate rayon;
+
+// Check that we are flagged for ignoring `must_use` parallel adaptors.
+
+use rayon::prelude::*;
+
+fn main() {
+    let v: Vec<_> = (0..100).map(Some).collect();
+
+    v.par_iter().chain(&v);                 //~ ERROR unused result
+    v.par_iter().cloned();                  //~ ERROR unused result
+    v.par_iter().enumerate();               //~ ERROR unused result
+    v.par_iter().filter(|_| true);          //~ ERROR unused result
+    v.par_iter().filter_map(|x| *x);        //~ ERROR unused result
+    v.par_iter().flat_map(|x| *x);          //~ ERROR unused result
+    v.par_iter().fold(|| 0, |x, _| x);      //~ ERROR unused result
+    v.par_iter().fold_with(0, |x, _| x);    //~ ERROR unused result
+    v.par_iter().inspect(|_| {});           //~ ERROR unused result
+    v.par_iter().map(|x| x);                //~ ERROR unused result
+    v.par_iter().map_with(0, |_, x| x);     //~ ERROR unused result
+    v.par_iter().rev();                     //~ ERROR unused result
+    v.par_iter().skip(1);                   //~ ERROR unused result
+    v.par_iter().take(1);                   //~ ERROR unused result
+    v.par_iter().cloned().while_some();     //~ ERROR unused result
+    v.par_iter().with_max_len(1);           //~ ERROR unused result
+    v.par_iter().with_min_len(1);           //~ ERROR unused result
+    v.par_iter().zip(&v);                   //~ ERROR unused result
+}


### PR DESCRIPTION
This follows the example of the standard library, even so lazy as to
steal their exact message about laziness.

cc #365