### PR TITLE
use <> instead of () for url blocks :)

### DIFF
--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -1,5 +1,5 @@
 //!
-//! [Under construction](https://github.com/nikomatsakis/rayon/issues/231)
+//! [Under construction]<https://github.com/nikomatsakis/rayon/issues/231>
 //!
 //! ## Restricting multiple versions
 //!


### PR DESCRIPTION
well this just breaks my emacs since `()` is valid url characters.