### PR TITLE
Fix dependencies block in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ as:
 
 ```rust
 [dependencies]
-rayon = 0.8.1
+rayon = "0.8.1"
 ```
 
 and then add the following to to your `lib.rs`:


### PR DESCRIPTION
The version must be enclosed with double quotes, otherwise you get something like:

```
error: failed to parse manifest at `/home/stjepan/work/par-sort/Cargo.toml`

Caused by:
  could not parse input as TOML

Caused by:
  expected newline, found a period at line 10
```