### PR TITLE
Split up the test of join returning Rc

### DIFF
--- a/tests/compile-fail/rc_return.rs
+++ b/tests/compile-fail/rc_return.rs
@@ -3,7 +3,6 @@ extern crate rayon;
 use std::rc::Rc;
 
 fn main() {
-    rayon::join(|| Rc::new(22), || Rc::new(23));
-    //~^ ERROR E0277
-    //~| ERROR E0277
+    rayon::join(|| Rc::new(22), || ()); //~ ERROR E0277
+    rayon::join(|| (), || Rc::new(23)); //~ ERROR E0277
 }


### PR DESCRIPTION
It seems that current rustc is now only reporting one error for `Rc`
returned in both `join` arguments.  We can split our test into two lines
to explicitly check the failure in each argument position.