### PR TITLE
Benchmark the demo sorts with the new par_sort*

### DIFF
--- a/rayon-demo/src/quicksort/mod.rs
+++ b/rayon-demo/src/quicksort/mod.rs
@@ -27,14 +27,14 @@ use rand::{Rng, SeedableRng, XorShiftRng};
 use rayon;
 use std::time::Instant;
 
-trait Joiner {
+pub trait Joiner {
     fn is_parallel() -> bool;
     fn join<A,R_A,B,R_B>(oper_a: A, oper_b: B) -> (R_A, R_B)
         where A: FnOnce() -> R_A + Send, B: FnOnce() -> R_B + Send,
               R_A: Send, R_B: Send;
 }
 
-struct Parallel;
+pub struct Parallel;
 impl Joiner for Parallel {
     #[inline]
     fn is_parallel() -> bool {
@@ -66,7 +66,7 @@ impl Joiner for Sequential {
     }
 }
 
-fn quick_sort<J:Joiner, T:PartialOrd+Send>(v: &mut [T]) {
+pub fn quick_sort<J:Joiner, T:PartialOrd+Send>(v: &mut [T]) {
     if v.len() <= 1 {
         return;
     }

--- a/rayon-demo/src/sort.rs
+++ b/rayon-demo/src/sort.rs
@@ -122,3 +122,43 @@ sort!(par_sort_unstable, par_sort_unstable_random, gen_random, 50_000);
 sort!(par_sort_unstable, par_sort_unstable_big, gen_big_random, 50_000);
 sort_strings!(par_sort_unstable, par_sort_unstable_strings, gen_strings, 50_000);
 sort_expensive!(par_sort_unstable_by, par_sort_unstable_expensive, gen_random, 50_000);
+
+trait MergeSort {
+    fn demo_merge_sort(&mut self);
+}
+
+impl<T: Ord + Send + Copy> MergeSort for [T] {
+    fn demo_merge_sort(&mut self) {
+        super::mergesort::merge_sort(self);
+    }
+}
+
+sort!(demo_merge_sort, demo_merge_sort_ascending, gen_ascending, 50_000);
+sort!(demo_merge_sort, demo_merge_sort_descending, gen_descending, 50_000);
+sort!(demo_merge_sort, demo_merge_sort_mostly_ascending, gen_mostly_ascending, 50_000);
+sort!(demo_merge_sort, demo_merge_sort_mostly_descending, gen_mostly_descending, 50_000);
+sort!(demo_merge_sort, demo_merge_sort_random, gen_random, 50_000);
+sort!(demo_merge_sort, demo_merge_sort_big, gen_big_random, 50_000);
+sort_strings!(demo_merge_sort, demo_merge_sort_strings, gen_strings, 50_000);
+//sort_expensive!(demo_merge_sort_by, demo_merge_sort_expensive, gen_random, 50_000);
+
+trait QuickSort {
+    fn demo_quick_sort(&mut self);
+}
+
+impl<T: PartialOrd + Send> QuickSort for [T] {
+    fn demo_quick_sort(&mut self) {
+        use quicksort::{quick_sort, Parallel};
+        quick_sort::<Parallel, T>(self);
+    }
+}
+
+// ascending/descending sorts need better pivot choices to avoid stack overflow
+//sort!(demo_quick_sort, demo_quick_sort_ascending, gen_ascending, 50_000);
+//sort!(demo_quick_sort, demo_quick_sort_descending, gen_descending, 50_000);
+sort!(demo_quick_sort, demo_quick_sort_mostly_ascending, gen_mostly_ascending, 50_000);
+sort!(demo_quick_sort, demo_quick_sort_mostly_descending, gen_mostly_descending, 50_000);
+sort!(demo_quick_sort, demo_quick_sort_random, gen_random, 50_000);
+sort!(demo_quick_sort, demo_quick_sort_big, gen_big_random, 50_000);
+sort_strings!(demo_quick_sort, demo_quick_sort_strings, gen_strings, 50_000);
+//sort_expensive!(demo_quick_sort_by, demo_quick_sort_expensive, gen_random, 50_000);


### PR DESCRIPTION
This adds apples-to-apples benchmarks for the new `par_sort*` methods
against the existing `merge_sort` and `quick_sort` demo implementations.
We should have done this as homework for #379.

Results on i7-7700k (4 cores, disabled h/t) grouped by input:

```
test sort::demo_merge_sort_ascending           ... bench:     251,556 ns/iter (+/- 14,797) = 1590 MB/s
test sort::par_sort_ascending                  ... bench:      32,101 ns/iter (+/- 7,709) = 12460 MB/s
test sort::par_sort_unstable_ascending         ... bench:      25,748 ns/iter (+/- 142) = 15535 MB/s

test sort::demo_merge_sort_descending          ... bench:     178,367 ns/iter (+/- 12,319) = 2242 MB/s
test sort::par_sort_descending                 ... bench:      52,579 ns/iter (+/- 7,141) = 7607 MB/s
test sort::par_sort_unstable_descending        ... bench:      39,988 ns/iter (+/- 202) = 10003 MB/s

test sort::demo_merge_sort_mostly_ascending    ... bench:     355,825 ns/iter (+/- 50,276) = 1124 MB/s
test sort::demo_quick_sort_mostly_ascending    ... bench:   5,376,446 ns/iter (+/- 639,853) = 74 MB/s
test sort::par_sort_mostly_ascending           ... bench:     293,489 ns/iter (+/- 77,073) = 1362 MB/s
test sort::par_sort_unstable_mostly_ascending  ... bench:     130,483 ns/iter (+/- 9,115) = 3065 MB/s

test sort::demo_merge_sort_mostly_descending   ... bench:     388,445 ns/iter (+/- 172,137) = 1029 MB/s
test sort::demo_quick_sort_mostly_descending   ... bench:   5,352,742 ns/iter (+/- 425,614) = 74 MB/s
test sort::par_sort_mostly_descending          ... bench:     305,722 ns/iter (+/- 53,706) = 1308 MB/s
test sort::par_sort_unstable_mostly_descending ... bench:     142,376 ns/iter (+/- 21,269) = 2809 MB/s

test sort::demo_merge_sort_random              ... bench:   1,145,700 ns/iter (+/- 340,331) = 349 MB/s
test sort::demo_quick_sort_random              ... bench:     834,356 ns/iter (+/- 80,087) = 479 MB/s
test sort::par_sort_random                     ... bench:     710,419 ns/iter (+/- 115,595) = 563 MB/s
test sort::par_sort_unstable_random            ... bench:     336,660 ns/iter (+/- 24,187) = 1188 MB/s

test sort::demo_merge_sort_big                 ... bench:   4,731,787 ns/iter (+/- 467,657) = 1352 MB/s
test sort::demo_quick_sort_big                 ... bench:   3,756,053 ns/iter (+/- 673,374) = 1703 MB/s
test sort::par_sort_big                        ... bench:   4,823,355 ns/iter (+/- 344,354) = 1326 MB/s
test sort::par_sort_unstable_big               ... bench:   3,340,050 ns/iter (+/- 206,456) = 1916 MB/s

test sort::demo_merge_sort_strings             ... bench:   3,738,406 ns/iter (+/- 571,047) = 213 MB/s
test sort::demo_quick_sort_strings             ... bench:   4,203,240 ns/iter (+/- 301,409) = 190 MB/s
test sort::par_sort_strings                    ... bench:   3,102,987 ns/iter (+/- 155,723) = 257 MB/s
test sort::par_sort_unstable_strings           ... bench:   2,900,603 ns/iter (+/- 341,583) = 275 MB/s

```