### PR TITLE
Release rayon 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Simple work-stealing parallelism for Rust"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ as:
 
 ```rust
 [dependencies]
-rayon = "0.8.1"
+rayon = "0.8.2"
 ```
 
 and then add the following to to your `lib.rs`:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,13 @@
+# Release rayon 0.8.2
+
+- `ParallelSliceMut` now has six parallel sorting methods with the same
+  variations as the standard library.
+  - `par_sort`, `par_sort_by`, and `par_sort_by_key` perform stable sorts in
+    parallel, using the default order, a custom comparator, or a key extraction
+    function, respectively.
+  - `par_sort_unstable`, `par_sort_unstable_by`, and `par_sort_unstable_by_key`
+    perform unstable sorts with the same comparison options.
+
 # Release rayon 0.8.1 / rayon-core 1.2.0
 
 - The following core APIs are being stabilized:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
     function, respectively.
   - `par_sort_unstable`, `par_sort_unstable_by`, and `par_sort_unstable_by_key`
     perform unstable sorts with the same comparison options.
+  - Thanks to @stejpang!
 
 # Release rayon 0.8.1 / rayon-core 1.2.0
 


### PR DESCRIPTION
- `ParallelSliceMut` now has six parallel sorting methods with the same
  variations as the standard library.
  - `par_sort`, `par_sort_by`, and `par_sort_by_key` perform stable sorts in
    parallel, using the default order, a custom comparator, or a key extraction
    function, respectively.
  - `par_sort_unstable`, `par_sort_unstable_by`, and `par_sort_unstable_by_key`
    perform unstable sorts with the same comparison options.