### PR TITLE
Add zip_eq iterator adapter

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -809,7 +809,6 @@ pub trait IndexedParallelIterator: ParallelIterator {
     ///
     /// // we should never get here
     /// assert_eq!(1, zipped.len());
-    ///
     /// ```
     fn zip_eq<Z>(mut self, zip_op: Z) -> Zip<Self, Z::Iter>
         where Z: IntoParallelIterator,

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -791,6 +791,36 @@ pub trait IndexedParallelIterator: ParallelIterator {
         zip::new(self, zip_op.into_par_iter())
     }
 
+    /// Same as `Zip` but requires that both iterators be the same length.
+    ///
+    /// # Panics
+    /// Will panic if `self` and `zip_op` are not the same length.
+    ///
+    /// ```should_panic
+    /// use rayon::prelude::*;
+    ///
+    /// let one = [1u8];
+    /// let two = [2u8, 2];
+    /// let one_iter = one.par_iter();
+    /// let two_iter = two.par_iter();
+    ///
+    /// // this will panic
+    /// let zipped: Vec<(&u8, &u8)> = one_iter.zip_eq(two_iter).collect();
+    ///
+    /// // we should never get here
+    /// assert_eq!(1, zipped.len());
+    ///
+    /// ```
+    fn zip_eq<Z>(mut self, zip_op: Z) -> Zip<Self, Z::Iter>
+        where Z: IntoParallelIterator,
+              Z::Iter: IndexedParallelIterator
+    {
+        let mut zip_op_iter = zip_op.into_par_iter();
+        assert_eq!(self.len(), zip_op_iter.len());
+        zip::new(self, zip_op_iter)
+    }
+
+
     /// Lexicographically compares the elements of this `ParallelIterator` with those of
     /// another.
     fn cmp<I>(mut self, other: I) -> Ordering


### PR DESCRIPTION
This PR Implements a rayon version of zip_eq. Through discussion with Niko, I decided to implement it as an assertion on the length the inputs and return `Zip` rather than creating a thin wrapper around `Zip` to use as an extra type.

Implements part of #386.