### PR TITLE
Implement interleave()

### DIFF
--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -3,7 +3,6 @@ use super::*;
 use std::cmp;
 use std::iter;
 use std::usize;
-use rayon_core::join;
 
 /// `Interleave` is an iterator that interleaves elements of iterators
 /// `i` and `j` in one continuous iterator. This struct is created by

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -1,7 +1,5 @@
 use super::internal::*;
 use super::*;
-use std::cmp;
-use std::iter;
 use std::usize;
 
 /// `Interleave` is an iterator that interleaves elements of iterators

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -1,6 +1,7 @@
 use super::internal::*;
 use super::*;
 use std::usize;
+use std::cmp;
 
 /// `Interleave` is an iterator that interleaves elements of iterators
 /// `i` and `j` in one continuous iterator. This struct is created by

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -151,7 +151,11 @@ impl<I, J> Producer for InterleaveProducer<I, J>
     type IntoIter = InterleaveSeq<I::IntoIter, J::IntoIter>;
 
     fn into_iter(self) -> Self::IntoIter {
-        InterleaveSeq::new(self.i.into_iter(), self.j.into_iter())
+        InterleaveSeq {
+            i: self.i.into_iter(),
+            j: self.j.into_iter(),
+            flag: self.flag,
+        }
     }
 
     fn min_len(&self) -> usize {
@@ -217,15 +221,6 @@ pub struct InterleaveSeq<I, J> {
     i: I,
     j: J,
     flag: bool
-}
-
-impl<I, J> InterleaveSeq<I, J> {
-    fn new(i: I, j: J) -> InterleaveSeq<I, J>
-        where I: DoubleEndedIterator + ExactSizeIterator,
-              J: DoubleEndedIterator<Item = I::Item> + ExactSizeIterator<Item = I::Item>
-    {
-        InterleaveSeq { i: i, j: j, flag: false }
-    }
 }
 
 impl<I, J> Iterator for InterleaveSeq<I, J>

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -68,6 +68,7 @@ impl<I, J> IndexedParallelIterator for Interleave<I, J>
             callback: callback,
             i_len: i_len,
             j_len: j_len,
+            flag: self.flag,
             j: self.j
         });
 
@@ -75,6 +76,7 @@ impl<I, J> IndexedParallelIterator for Interleave<I, J>
             callback: CB,
             i_len: usize,
             j_len: usize,
+            flag: bool,
             j: J
         }
 
@@ -91,6 +93,7 @@ impl<I, J> IndexedParallelIterator for Interleave<I, J>
                     i_producer: i_producer,
                     i_len: self.i_len,
                     j_len: self.j_len,
+                    flag: self.flag,
                     callback: self.callback
                 })
             }
@@ -100,6 +103,7 @@ impl<I, J> IndexedParallelIterator for Interleave<I, J>
             callback: CB,
             i_len: usize,
             j_len: usize,
+            flag: bool,
             i_producer: I
         }
 
@@ -112,7 +116,7 @@ impl<I, J> IndexedParallelIterator for Interleave<I, J>
             fn callback<J>(self, j_producer: J) -> Self::Output
                 where J: Producer<Item = I::Item>
             {
-                let producer = InterleaveProducer::new(self.i_producer, j_producer, self.i_len, self.j_len, false);
+                let producer = InterleaveProducer::new(self.i_producer, j_producer, self.i_len, self.j_len, self.flag);
                 self.callback.callback(producer)
             }
         }

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -235,8 +235,8 @@ pub struct InterleaveSeq<I, J> {
 /// (instead of calling itertools directly), because we also need to
 /// implement `DoubledEndedIterator` and `ExactSizeIterator`.
 impl<I, J> Iterator for InterleaveSeq<I, J>
-    where I: Iterator + ExactSizeIterator,
-          J: Iterator<Item = I::Item> + ExactSizeIterator
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
 {
     type Item = I::Item;
 
@@ -258,7 +258,7 @@ impl<I, J> Iterator for InterleaveSeq<I, J>
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (ih, jh) = (self.i.size_hint(), self.j.size_hint());
-        let min = ih.0.checked_add(jh.0).unwrap_or(usize::MAX);
+        let min = ih.0.saturating_add(jh.0);
         let max = match (ih.1, jh.1) {
             (Some(x), Some(y)) => x.checked_add(y),
             _=> None

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -25,8 +25,7 @@ pub fn new<I, J>(i: I, j: J) -> Interleave<I, J>
     where I: IndexedParallelIterator,
           J: IndexedParallelIterator<Item = I::Item>
 {
-    let flag = false;
-    Interleave { i, j, flag }
+    Interleave { i: i, j: j, flag: false }
 }
 
 impl<I, J> ParallelIterator for Interleave<I, J>
@@ -135,7 +134,7 @@ impl<I, J> InterleaveProducer<I, J>
           J: Producer<Item = I::Item>
 {
     fn new(i: I, j: J, i_len: usize, j_len: usize, flag: bool) -> InterleaveProducer<I, J> {
-        InterleaveProducer { i, j, i_len, j_len, flag }
+        InterleaveProducer { i: i, j: j, i_len: i_len, j_len: j_len, flag: flag }
     }
 }
 

--- a/src/iter/interleave.rs
+++ b/src/iter/interleave.rs
@@ -1,0 +1,290 @@
+use super::internal::*;
+use super::*;
+use std::cmp;
+use std::iter;
+use std::usize;
+use rayon_core::join;
+
+/// `Interleave` is an iterator that interleaves elements of iterators
+/// `i` and `j` in one continuous iterator. This struct is created by
+/// the [`interleave()`] method on [`IndexedParallelIterator`]
+///
+/// [`interleave()`]: trait.IndexedParallelIterator.html#method.interleave
+/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct Interleave<I, J>
+    where I: IndexedParallelIterator,
+          J: IndexedParallelIterator<Item = I::Item>
+{
+    i: I,
+    j: J,
+    flag: bool,
+}
+
+/// Create a new `Interleave` iterator
+///
+/// NB: a free fn because it is NOT part of the end-user API.
+pub fn new<I, J>(i: I, j: J) -> Interleave<I, J>
+    where I: IndexedParallelIterator,
+          J: IndexedParallelIterator<Item = I::Item>
+{
+    let flag = false;
+    Interleave { i, j, flag }
+}
+
+impl<I, J> ParallelIterator for Interleave<I, J>
+    where I: IndexedParallelIterator,
+          J: IndexedParallelIterator<Item = I::Item>
+{
+    type Item = I::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+        where C: Consumer<I::Item>
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&mut self) -> Option<usize> {
+        Some(self.len())
+    }
+}
+
+impl<I, J> IndexedParallelIterator for Interleave<I, J>
+    where I: IndexedParallelIterator,
+          J: IndexedParallelIterator<Item = I::Item>,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+        where C: Consumer<Self::Item>
+    {
+        bridge(self, consumer)
+    }
+
+    fn len(&mut self) -> usize {
+        self.i.len() + self.j.len()
+    }
+
+    fn with_producer<CB>(mut self, callback: CB) -> CB::Output
+        where CB: ProducerCallback<Self::Item>
+    {
+        let (i_len, j_len) = (self.i.len(), self.j.len());
+        return self.i.with_producer(CallbackI {
+            callback: callback,
+            i_len: i_len,
+            j_len: j_len,
+            j: self.j
+        });
+
+        struct CallbackI<CB, J> {
+            callback: CB,
+            i_len: usize,
+            j_len: usize,
+            j: J
+        }
+
+        impl<CB, J> ProducerCallback<J::Item> for CallbackI<CB, J>
+            where J: IndexedParallelIterator,
+                  CB: ProducerCallback<J::Item>
+        {
+            type Output = CB::Output;
+
+            fn callback<I>(self, i_producer: I) -> Self::Output
+                where I: Producer<Item = J::Item>
+            {
+                self.j.with_producer(CallbackJ {
+                    i_producer: i_producer,
+                    i_len: self.i_len,
+                    j_len: self.j_len,
+                    callback: self.callback
+                })
+            }
+        }
+
+        struct CallbackJ<CB, I> {
+            callback: CB,
+            i_len: usize,
+            j_len: usize,
+            i_producer: I
+        }
+
+        impl<CB, I> ProducerCallback<I::Item> for CallbackJ<CB, I>
+            where I: Producer,
+                  CB: ProducerCallback<I::Item>
+        {
+            type Output = CB::Output;
+
+            fn callback<J>(self, j_producer: J) -> Self::Output
+                where J: Producer<Item = I::Item>
+            {
+                let producer = InterleaveProducer::new(self.i_producer, j_producer, self.i_len, self.j_len, false);
+                self.callback.callback(producer)
+            }
+        }
+    }
+}
+
+pub struct InterleaveProducer<I, J>
+    where I: Producer,
+          J: Producer<Item = I::Item>
+{
+    i: I,
+    j: J,
+    i_len: usize,
+    j_len: usize,
+    flag: bool,
+}
+
+impl<I, J> InterleaveProducer<I, J>
+    where I: Producer,
+          J: Producer<Item = I::Item>
+{
+    fn new(i: I, j: J, i_len: usize, j_len: usize, flag: bool) -> InterleaveProducer<I, J> {
+        InterleaveProducer { i, j, i_len, j_len, flag }
+    }
+}
+
+impl<I, J> Producer for InterleaveProducer<I, J>
+    where I: Producer,
+          J: Producer<Item = I::Item>
+{
+    type Item = I::Item;
+    type IntoIter = InterleaveSeq<I::IntoIter, J::IntoIter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        InterleaveSeq::new(self.i.into_iter(), self.j.into_iter())
+    }
+
+    fn min_len(&self) -> usize {
+        cmp::max(self.i.min_len(), self.j.min_len())
+    }
+
+    fn max_len(&self) -> usize {
+        cmp::min(self.i.max_len(), self.j.max_len())
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        // Switch on state
+        let even = index%2 == 0;
+        let idx = index >> 1;
+
+        // We know 0 < index <= self.i_len + self.j_len
+        // Find a, b satisfying the following conditions:
+        // (1) 0 < a <= self.i_len
+        // (2) 0 < b <= self.j_len
+        // (3) a + b == index
+        // assert!(index <= self.i_len + self.j_len);
+
+        let odd_offset = |flag| if flag { 0 } else { 1 };
+
+        // desired split
+        let (i_idx, j_idx) = (idx + odd_offset(even || self.flag),
+                              idx + odd_offset(even || !self.flag));
+
+        let (i_split, j_split) = if self.i_len >= i_idx && self.j_len >= j_idx {
+            (i_idx, j_idx)
+        } else if self.i_len >= i_idx {
+            // j too short
+            (index - self.j_len, self.j_len)
+        } else {
+            // i too short
+            (self.i_len, index - self.i_len)
+        };
+
+        let trailing_flag = even == self.flag;
+        let (i_left, i_right) = self.i.split_at(i_split);
+        let (j_left, j_right) = self.j.split_at(j_split);
+
+        (InterleaveProducer::new(
+            i_left,
+            j_left,
+            i_split,
+            j_split,
+            self.flag
+        ), InterleaveProducer::new(
+            i_right,
+            j_right,
+            self.i_len - i_split,
+            self.j_len - j_split,
+            trailing_flag
+        ))
+    }
+}
+
+
+/// Wrapper for Interleave to implement DoubleEndedIterator and
+/// ExactSizeIterator
+pub struct InterleaveSeq<I, J> {
+    i: I,
+    j: J,
+    flag: bool
+}
+
+impl<I, J> InterleaveSeq<I, J> {
+    fn new(i: I, j: J) -> InterleaveSeq<I, J>
+        where I: DoubleEndedIterator + ExactSizeIterator,
+              J: DoubleEndedIterator<Item = I::Item> + ExactSizeIterator<Item = I::Item>
+    {
+        InterleaveSeq { i: i, j: j, flag: false }
+    }
+}
+
+impl<I, J> Iterator for InterleaveSeq<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.flag = !self.flag;
+        if self.flag {
+            match self.i.next() {
+                None => self.j.next(),
+                r => r
+            }
+        } else {
+            match self.j.next() {
+                None => self.i.next(),
+                r => r
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (ih, jh) = (self.i.size_hint(), self.j.size_hint());
+        let min = ih.0.checked_add(jh.0).unwrap_or(usize::MAX);
+        let max = match (ih.1, jh.1) {
+            (Some(x), Some(y)) => x.checked_add(y),
+            _=> None
+        };
+        (min, max)
+    }
+}
+
+// The implementation for DoubleEndedIterator requires
+// ExactSizeIterator to provide `next_back()`. The last element will
+// come from the iterator that runs out last (ie has the most elements
+// in it). If the iterators have the same number of elements, then the
+// last iterator will provide the last element.
+impl<I, J> DoubleEndedIterator for InterleaveSeq<I, J>
+    where I: DoubleEndedIterator + ExactSizeIterator,
+          J: DoubleEndedIterator<Item = I::Item> + ExactSizeIterator<Item = I::Item>
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<I::Item> {
+        if self.i.len() <= self.j.len() {
+            self.j.next_back()
+        } else {
+            self.i.next_back()
+        }
+    }
+}
+
+impl<I, J> ExactSizeIterator for InterleaveSeq<I, J>
+    where I: ExactSizeIterator,
+          J: ExactSizeIterator<Item = I::Item>
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.i.len() + self.j.len()
+    }
+}

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -59,6 +59,8 @@ mod map_with;
 pub use self::map_with::MapWith;
 mod zip;
 pub use self::zip::Zip;
+mod interleave;
+pub use self::interleave::Interleave;
 mod noop;
 mod rev;
 pub use self::rev::Rev;
@@ -807,6 +809,14 @@ pub trait IndexedParallelIterator: ParallelIterator {
               Z::Iter: IndexedParallelIterator
     {
         zip::new(self, zip_op.into_par_iter())
+    }
+
+    /// Interleave elements of this iterator and the other given iterator.
+    fn interleave<I>(self, other: I) -> Interleave<Self, I::Iter>
+        where I: IntoParallelIterator<Item = Self::Item>,
+              I::Iter: IndexedParallelIterator<Item = Self::Item>
+    {
+        interleave::new(self, other.into_par_iter())
     }
 
     /// Lexicographically compares the elements of this `ParallelIterator` with those of

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -811,7 +811,20 @@ pub trait IndexedParallelIterator: ParallelIterator {
         zip::new(self, zip_op.into_par_iter())
     }
 
-    /// Interleave elements of this iterator and the other given iterator.
+    /// Interleave elements of this iterator and the other given
+    /// iterator. Alternately yields elements from this iterator and
+    /// the given iterator, until both are exhausted. If one iterator
+    /// is exhausted before the other, the last elements are provided
+    /// from the other.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// use rayon::prelude::*;
+    /// let (x, y) = (vec![1, 2], vec![3, 4, 5, 6]);
+    /// let r: Vec<i32> = x.into_par_iter().interleave(y).collect();
+    /// assert_eq!(r, vec![1, 3, 2, 4, 5, 6]);
+    /// ```
     fn interleave<I>(self, other: I) -> Interleave<Self, I::Iter>
         where I: IntoParallelIterator<Item = Self::Item>,
               I::Iter: IndexedParallelIterator<Item = Self::Item>

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1722,3 +1722,32 @@ fn check_either_extend() {
     right.par_extend(v.clone());
     assert_eq!(right, Either::Right(v.iter().cloned().collect()));
 }
+
+#[test]
+fn check_interleave_eq() {
+    let mut xs: Vec<usize> = (0..10).collect();
+    let mut ys: Vec<usize> = (10..20).collect();
+
+    //let b = a.par_iter().map(|&i| i + 1).collect_into(&mut b);
+    let mut b = vec![];
+    xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut b);
+
+    let c: Vec<usize> = (0..10).zip((10..20)).flat_map(|(i, j)| vec![i, j].into_iter()).collect();
+    assert_eq!(b, c);
+}
+
+#[test]
+fn check_interleave_uneven() {
+
+    let cases: Vec<(Vec<usize>, Vec<usize>, Vec<usize>)> = vec![
+        ((0..9).collect(), vec![10], vec![0, 10, 1, 2, 3, 4, 5, 6, 7, 8]),
+        (vec![10], (0..9).collect(), vec![10, 0, 1, 2, 3, 4, 5, 6, 7, 8]),
+        ((0..5).collect(), (5..10).collect(), (0..5).zip((5..10)).flat_map(|(i, j)| vec![i, j].into_iter()).collect()),
+    ];
+
+    for (i, (xs, ys, expected)) in cases.into_iter().enumerate() {
+        let mut res = vec![];
+        xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut res);
+        assert_eq!(expected, res);
+    }
+}

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1728,7 +1728,6 @@ fn check_interleave_eq() {
     let mut xs: Vec<usize> = (0..10).collect();
     let mut ys: Vec<usize> = (10..20).collect();
 
-    //let b = a.par_iter().map(|&i| i + 1).collect_into(&mut b);
     let mut b = vec![];
     xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut b);
 
@@ -1743,11 +1742,13 @@ fn check_interleave_uneven() {
         ((0..9).collect(), vec![10], vec![0, 10, 1, 2, 3, 4, 5, 6, 7, 8]),
         (vec![10], (0..9).collect(), vec![10, 0, 1, 2, 3, 4, 5, 6, 7, 8]),
         ((0..5).collect(), (5..10).collect(), (0..5).zip((5..10)).flat_map(|(i, j)| vec![i, j].into_iter()).collect()),
+        (vec![], (0..9).collect(), (0..9).collect()),
+        ((0..9).collect(), vec![], (0..9).collect())
     ];
 
     for (i, (xs, ys, expected)) in cases.into_iter().enumerate() {
         let mut res = vec![];
         xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut res);
-        assert_eq!(expected, res);
+        assert_eq!(expected, res, "Case {} failed", i+1);
     }
 }

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1728,11 +1728,11 @@ fn check_interleave_eq() {
     let xs: Vec<usize> = (0..10).collect();
     let ys: Vec<usize> = (10..20).collect();
 
-    let mut b = vec![];
-    xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut b);
+    let mut actual = vec![];
+    xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut actual);
 
-    let c: Vec<usize> = (0..10).zip((10..20)).flat_map(|(i, j)| vec![i, j].into_iter()).collect();
-    assert_eq!(b, c);
+    let expected: Vec<usize> = (0..10).zip((10..20)).flat_map(|(i, j)| vec![i, j].into_iter()).collect();
+    assert_eq!(expected, actual);
 }
 
 #[test]

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1725,8 +1725,8 @@ fn check_either_extend() {
 
 #[test]
 fn check_interleave_eq() {
-    let mut xs: Vec<usize> = (0..10).collect();
-    let mut ys: Vec<usize> = (10..20).collect();
+    let xs: Vec<usize> = (0..10).collect();
+    let ys: Vec<usize> = (10..20).collect();
 
     let mut b = vec![];
     xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut b);

--- a/src/iter/test.rs
+++ b/src/iter/test.rs
@@ -1737,18 +1737,22 @@ fn check_interleave_eq() {
 
 #[test]
 fn check_interleave_uneven() {
-
     let cases: Vec<(Vec<usize>, Vec<usize>, Vec<usize>)> = vec![
         ((0..9).collect(), vec![10], vec![0, 10, 1, 2, 3, 4, 5, 6, 7, 8]),
         (vec![10], (0..9).collect(), vec![10, 0, 1, 2, 3, 4, 5, 6, 7, 8]),
         ((0..5).collect(), (5..10).collect(), (0..5).zip((5..10)).flat_map(|(i, j)| vec![i, j].into_iter()).collect()),
         (vec![], (0..9).collect(), (0..9).collect()),
-        ((0..9).collect(), vec![], (0..9).collect())
+        ((0..9).collect(), vec![], (0..9).collect()),
+        ((0..50).collect(), (50..100).collect(), (0..50).zip((50..100)).flat_map(|(i, j)| vec![i, j].into_iter()).collect()),
     ];
 
     for (i, (xs, ys, expected)) in cases.into_iter().enumerate() {
         let mut res = vec![];
         xs.par_iter().interleave(&ys).map(|&i| i).collect_into(&mut res);
-        assert_eq!(expected, res, "Case {} failed", i+1);
+        assert_eq!(expected, res, "Case {} failed", i);
+
+        res.truncate(0);
+        xs.par_iter().interleave(&ys).rev().map(|&i| i).collect_into(&mut res);
+        assert_eq!(expected.into_iter().rev().collect::<Vec<usize>>(), res, "Case {} reversed failed", i);
     }
 }


### PR DESCRIPTION
For parity with itertools, interleave() should alternately produce
elements from two given iterators. Once one of the iterators run out,
elements should just be drawn from the other until both are exhausted.

This is from #384