### PR TITLE
Disable accidental publish for the unpublished crates

### DIFF
--- a/ci/alt-core/Cargo.toml
+++ b/ci/alt-core/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.0.0"
 authors = ["Josh Stone <cuviper@gmail.com>"]
 links = "rayon-core"
 build = "build.rs"
+publish = false
 
 [dependencies]

--- a/ci/highlander/Cargo.toml
+++ b/ci/highlander/Cargo.toml
@@ -3,6 +3,7 @@ authors = ["Josh Stone <cuviper@gmail.com>"]
 name = "highlander"
 description = "There Can Be Only One"
 version = "0.0.0"
+publish = false
 
 [dependencies]
 

--- a/rayon-demo/Cargo.toml
+++ b/rayon-demo/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "rayon-demo"
-version = "0.1.0"
+version = "0.0.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
+publish = false
 
 [dependencies]
 rayon = { path = "../" }


### PR DESCRIPTION
These crates are not intended to be published.