### PR TITLE
Add a examples to the module docs

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -783,6 +783,8 @@ impl<T: ParallelIterator> IntoParallelIterator for T {
 /// An iterator that supports "random access" to its data, meaning
 /// that you can split it at arbitrary indices and draw data from
 /// those points.
+///
+/// **Note:** Not implemented for `u64` and `i64` ranges
 pub trait IndexedParallelIterator: ParallelIterator {
     /// Collects the results of the iterator into the specified
     /// vector. The vector is always truncated before execution

--- a/src/range.rs
+++ b/src/range.rs
@@ -2,12 +2,42 @@
 //! (`Range<T>`); this is the type for values created by a `a..b`
 //! expression. You will rarely need to interact with it directly
 //! unless you have need to name one of the iterator types.
+//! 
+//! ```
+//! use rayon::prelude::*;
+//! 
+//! let r = (0..100u64).into_par_iter()
+//!                    .sum();
+//! 
+//! // compare result with sequential calculation
+//! assert_eq!((0..100).sum::<u64>(), r);
+//! ```
 
 use iter::*;
 use iter::internal::*;
 use std::ops::Range;
 
-/// Parallel iterator over a range
+/// Parallel iterator over a range, implemented for all integer types.
+///
+/// **Note:** The `zip` operation requires `IndexedParallelIterator`
+/// which is not implemented for `u64` or `i64`.
+///
+/// ```
+/// use rayon::prelude::*;
+///
+/// let p = (0..25usize).into_par_iter()
+///                   .zip(0..25usize)
+///                   .filter(|&(x, y)| x % 5 == 0 || y % 5 == 0)
+///                   .map(|(x, y)| x * y)
+///                   .sum::<usize>();
+///
+/// let s = (0..25usize).zip(0..25)
+///                   .filter(|&(x, y)| x % 5 == 0 || y % 5 == 0)
+///                   .map(|(x, y)| x * y)
+///                   .sum();
+///
+/// assert_eq!(p, s);
+/// ```
 #[derive(Debug)]
 pub struct Iter<T> {
     range: Range<T>,


### PR DESCRIPTION
Hi

I wanted to add examples to the docs. My first example works as I expected.

My second example behaves very strange. It compiles when I use `i32` as the type of the `Range<T>`.
With any other type such as `usize`, `u64` or `i64` it does not compile.
Do you have an idea how to fix it?

Regards

---
Error message:
```
---- src/range.rs - range::Iter (line 23) stdout ----
        error[E0599]: no method named `zip` found for type `rayon::range::Iter<i64>` in the current scope
 --> src/range.rs:6:20
  |
6 |                   .zip(0..25)
  |                    ^^^
  |
  = note: the method `zip` exists but the following trait bounds were not satisfied:
          `&mut rayon::range::Iter<i64> : std::iter::Iterator`
```