### PR TITLE
Raise the min version requirement because of the `?` operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.12.0
+  - 1.13.0
   - stable
   - nightly
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.12.0
   - 1.13.0
   - stable
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ default-features = false
 [dev-dependencies]
 compiletest_rs = "0.2.1"
 docopt = "0.7"
-futures = "0.1.7"
+futures = "=0.1.14"
 rand = "0.3"
 rustc-serialize = "0.3"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ part, adding calls to Rayon should not change how your programs works
 at all, in fact. However, if you operate on mutexes or atomic
 integers, please see the [notes on atomicity](#atomicity).
 
-Rayon currently requires `rustc 1.12.0` or greater.
+Rayon currently requires `rustc 1.13.0` or greater.
 
 ### Using Rayon
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# Release rayon 0.8.3
+
+- `?` operator requires rust 1.13 or greater
+
 # Release rayon 0.8.2
 
 - `ParallelSliceMut` now has six parallel sorting methods with the same

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   RUST_MIN_STACK: 16777216
   matrix:
     - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: 1.12.0
+      CHANNEL: 1.13.0
 
     - TARGET: x86_64-pc-windows-gnu
       CHANNEL: stable
@@ -24,7 +24,7 @@ environment:
 
 
     - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: 1.12.0
+      CHANNEL: 1.13.0
 
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable

--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -18,6 +18,6 @@ libc = "0.2.16"
 lazy_static = "0.2.2"
 
 # only if #[cfg(rayon_unstable)], will be removed eventually
-futures = "0.1.7"
+futures = "=0.1.14"
 
 [dev-dependencies]


### PR DESCRIPTION
I fixed the tests for the latest nightly compiler in #411 but since the `?` operator is in the main code the minimal required version must be raised.

TODO
- [x] Update README
- [x] Update CHANGELOG