### PR TITLE
Tighten Send and Sync requirements

### DIFF
--- a/rayon-core/src/internal/task.rs
+++ b/rayon-core/src/internal/task.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 /// Represents a task that can be scheduled onto the Rayon
 /// thread-pool. Once a task is scheduler, it will execute exactly
 /// once (eventually).
-pub trait Task: Send {
+pub trait Task: Send + Sync {
     fn execute(this: Arc<Self>);
 }
 

--- a/rayon-core/src/scope/internal.rs
+++ b/rayon-core/src/scope/internal.rs
@@ -46,7 +46,7 @@ impl<'scope> Drop for LocalScopeHandle<'scope> {
 unsafe impl<'scope> ScopeHandle<'scope> for LocalScopeHandle<'scope> {
     unsafe fn spawn_task<T: Task + 'scope>(&self, task: Arc<T>) {
         let scope = &*self.scope;
-        (*scope.owner_thread).registry().submit_task(task);
+        scope.registry.submit_task(task);
     }
 
     fn ok(self) {

--- a/rayon-core/src/scope/test.rs
+++ b/rayon-core/src/scope/test.rs
@@ -69,12 +69,12 @@ fn divide_and_conquer_seq(counter: &AtomicUsize, size: usize) {
     }
 }
 
-struct Tree<T> {
+struct Tree<T: Send> {
     value: T,
     children: Vec<Tree<T>>,
 }
 
-impl<T> Tree<T> {
+impl<T: Send> Tree<T> {
     pub fn iter<'s>(&'s self) -> impl Iterator<Item = &'s T> + 's {
         once(&self.value)
             .chain(self.children.iter().flat_map(|c| c.iter()))

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -1,8 +1,6 @@
 use Configuration;
-use latch::LockLatch;
 #[allow(unused_imports)]
 use log::Event::*;
-use job::StackJob;
 use join;
 use {scope, Scope};
 use spawn;
@@ -112,12 +110,7 @@ impl ThreadPool {
         where OP: FnOnce() -> R + Send,
               R: Send
     {
-        unsafe {
-            let job_a = StackJob::new(op, LockLatch::new());
-            self.registry.inject(&[job_a.as_job_ref()]);
-            job_a.latch.wait();
-            job_a.into_result()
-        }
+        self.registry.in_worker(|_| op())
     }
 
     /// Returns the (current) number of threads in the thread pool.

--- a/rayon-core/src/thread_pool/mod.rs
+++ b/rayon-core/src/thread_pool/mod.rs
@@ -109,7 +109,8 @@ impl ThreadPool {
     ///     }
     /// ```
     pub fn install<OP, R>(&self, op: OP) -> R
-        where OP: FnOnce() -> R + Send
+        where OP: FnOnce() -> R + Send,
+              R: Send
     {
         unsafe {
             let job_a = StackJob::new(op, LockLatch::new());

--- a/rayon-core/src/thread_pool/test.rs
+++ b/rayon-core/src/thread_pool/test.rs
@@ -137,3 +137,11 @@ fn panic_thread_name() {
     assert_eq!(5, wait_for_counter(start_count));
     assert_eq!(5, wait_for_counter(exit_count));
 }
+
+#[test]
+fn self_install() {
+    let pool = Configuration::new().num_threads(1).build().unwrap();
+
+    // If the inner `install` blocks, then nothing will actually run it!
+    assert!(pool.install(|| pool.install(|| true)));
+}


### PR DESCRIPTION
This is a **breaking change** to `rayon-core`, necessary for soundness.

- `Scope::spawn` now requires `Send` for the closure.  Fixes #430.

- `ThreadPool::install` now requires `Send` for the return value.

- (unstable) `internal::Task` now requires `Send + Sync` instead of just
`Send`, so its use of `Arc` properly implements `Send` and `Sync` too.