### PR TITLE
Add html_root_url for core and futures, with a reminder in Cargo.toml

### DIFF
--- a/rayon-core/Cargo.toml
+++ b/rayon-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-core"
-version = "1.2.2"
+version = "1.2.2" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Core APIs for Rayon"

--- a/rayon-core/src/lib.rs
+++ b/rayon-core/src/lib.rs
@@ -19,6 +19,7 @@
 //! conflicting requirements will need to be resolved before the build will
 //! succeed.
 
+#![doc(html_root_url = "https://docs.rs/rayon-core/1.2")]
 #![allow(non_camel_case_types)] // I prefer to use ALL_CAPS for type parameters
 #![cfg_attr(test, feature(conservative_impl_trait))]
 

--- a/rayon-futures/Cargo.toml
+++ b/rayon-futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayon-futures"
-version = "0.1.0"
+version = "0.1.0" # reminder to update html_root_url attribute
 authors = ["Niko Matsakis <niko@alum.mit.edu>",
            "Josh Stone <cuviper@gmail.com>"]
 description = "Futures integration into Rayon"

--- a/rayon-futures/src/lib.rs
+++ b/rayon-futures/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! See `README.md` for details.
 
+#![doc(html_root_url = "https://docs.rs/rayon-futures/0")]
+
 extern crate futures;
 extern crate rayon_core;
 

--- a/rayon-futures/src/lib.rs
+++ b/rayon-futures/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! See `README.md` for details.
 
-#![doc(html_root_url = "https://docs.rs/rayon-futures/0")]
+#![doc(html_root_url = "https://docs.rs/rayon-futures/0.1")]
 
 extern crate futures;
 extern crate rayon_core;


### PR DESCRIPTION
Should close #424 - I've used some shorter version links for the docs, but if I should just make these exactly what version is specified in the Cargo.toml I can change it, those versions just don't have any published docs yet and making a PR with links that 404'd didn't feel right (but perhaps this is totally fine)