### PR TITLE
Added documentation for iter types and structs

### DIFF
--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -86,12 +86,13 @@ mod unzip;
 mod test;
 
 /// `IntoParallelIterator` implements the conversion to a [`ParallelIterator`].
+///
 /// By implementing `IntoParallelIterator` for a type, you define how it will
 /// transformed into an iterator. This is a parallel version of the standard
-/// library's `std::iter::IntoIterator` trait.
+/// library's [`std::iter::IntoIterator`] trait.
 ///
 /// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`into_par_iter()`]: trait.IntoParallelIterator.html#method.into_par_iter
+/// [`std::iter::IntoIterator`]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
 pub trait IntoParallelIterator {
     type Iter: ParallelIterator<Item = Self::Item>;
     type Item: Send;
@@ -99,12 +100,19 @@ pub trait IntoParallelIterator {
     fn into_par_iter(self) -> Self::Iter;
 }
 
-/// `IntoParallelRefIterator` implements the conversion to a [`ParallelIterator`].
+/// `IntoParallelRefIterator` implements the conversion to a 
+/// [`ParallelIterator`], providing shared references to the data.
+///
 /// This is a parallel version of the `iter()` method 
 /// defined by various collections.
 ///
+/// This trait is automatically implemented 
+/// `for I where &I: IntoParallelIterator`. In most cases, users
+/// will want to implement [`IntoParallelIterator`] rather than implement
+/// this trait directly.
+///
 /// [`ParallelIterator`]: trait.ParallelIterator.html
-/// [`par_iter()`]: trait.IntoParallelRefIterator.html#method.par_iter
+/// [`IntoParallelIterator`]: trait.IntoParallelIterator.html
 pub trait IntoParallelRefIterator<'data> {
     type Iter: ParallelIterator<Item = Self::Item>;
     type Item: Send + 'data;
@@ -124,12 +132,19 @@ impl<'data, I: 'data + ?Sized> IntoParallelRefIterator<'data> for I
 }
 
 
-/// `IntoParallelRefMutIterator` implements the conversion to a [`ParallelIterator`] providing mutable references to the data.
+/// `IntoParallelRefMutIterator` implements the conversion to a
+/// [`ParallelIterator`], providing mutable references to the data.
 ///
 /// This is a parallel version of the `iter_mut()` method 
 /// defined by various collections.
 ///
+/// This trait is automatically implemented 
+/// `for I where &mut I: IntoParallelIterator`. In most cases, users
+/// will want to implement [`IntoParallelIterator`] rather than implement
+/// this trait directly.
+///
 /// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`IntoParallelIterator`]: trait.IntoParallelIterator.html
 pub trait IntoParallelRefMutIterator<'data> {
     type Iter: ParallelIterator<Item = Self::Item>;
     type Item: Send + 'data;

--- a/src/iter/mod.rs
+++ b/src/iter/mod.rs
@@ -85,6 +85,13 @@ mod unzip;
 #[cfg(test)]
 mod test;
 
+/// `IntoParallelIterator` implements the conversion to a [`ParallelIterator`].
+/// By implementing `IntoParallelIterator` for a type, you define how it will
+/// transformed into an iterator. This is a parallel version of the standard
+/// library's `std::iter::IntoIterator` trait.
+///
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`into_par_iter()`]: trait.IntoParallelIterator.html#method.into_par_iter
 pub trait IntoParallelIterator {
     type Iter: ParallelIterator<Item = Self::Item>;
     type Item: Send;
@@ -92,6 +99,12 @@ pub trait IntoParallelIterator {
     fn into_par_iter(self) -> Self::Iter;
 }
 
+/// `IntoParallelRefIterator` implements the conversion to a [`ParallelIterator`].
+/// This is a parallel version of the `iter()` method 
+/// defined by various collections.
+///
+/// [`ParallelIterator`]: trait.ParallelIterator.html
+/// [`par_iter()`]: trait.IntoParallelRefIterator.html#method.par_iter
 pub trait IntoParallelRefIterator<'data> {
     type Iter: ParallelIterator<Item = Self::Item>;
     type Item: Send + 'data;
@@ -110,6 +123,13 @@ impl<'data, I: 'data + ?Sized> IntoParallelRefIterator<'data> for I
     }
 }
 
+
+/// `IntoParallelRefMutIterator` implements the conversion to a [`ParallelIterator`] providing mutable references to the data.
+///
+/// This is a parallel version of the `iter_mut()` method 
+/// defined by various collections.
+///
+/// [`ParallelIterator`]: trait.ParallelIterator.html
 pub trait IntoParallelRefMutIterator<'data> {
     type Iter: ParallelIterator<Item = Self::Item>;
     type Item: Send + 'data;

--- a/src/iter/rev.rs
+++ b/src/iter/rev.rs
@@ -2,6 +2,11 @@ use super::internal::*;
 use super::*;
 use std::iter;
 
+/// `Rev` is an iterator that produces elements in reverse order. This struct
+/// is created by the [`rev()`] method on [`IndexedParallelIterator`]
+///
+/// [`rev()`]: trait.IndexedParallelIterator.html#method.rev
+/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct Rev<I: IndexedParallelIterator> {

--- a/src/iter/zip.rs
+++ b/src/iter/zip.rs
@@ -3,6 +3,12 @@ use super::*;
 use std::cmp;
 use std::iter;
 
+/// `Zip` is an iterator that zips up `a` and `b` into a single iterator
+/// of pairs. This struct is created by the [`zip()`] method on
+/// [`IndexedParallelIterator`]
+///
+/// [`zip()`]: trait.IndexedParallelIterator.html#method.zip
+/// [`IndexedParallelIterator`]: trait.IndexedParallelIterator.html
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct Zip<A: IndexedParallelIterator, B: IndexedParallelIterator> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@
 //! shape of `map` or `for_each` as an example.  This solves [embarrassingly]
 //! parallel tasks that are completely independent of one another.
 //!
-//! [`par_iter`]: iter/trait.IntoParallelRefIterator.html
-//! [`par_iter_mut`]: iter/trait.IntoParallelRefMutIterator.html
+//! [`par_iter`]: iter/trait.IntoParallelRefIterator.html#tymethod.par_iter
+//! [`par_iter_mut`]: iter/trait.IntoParallelRefMutIterator.html#tymethod.par_iter_mut
 //! [`into_par_iter`]: iter/trait.IntoParallelIterator.html#tymethod.into_par_iter
 //! [embarrassingly]: https://en.wikipedia.org/wiki/Embarrassingly_parallel
 //!


### PR DESCRIPTION
Added documentation for all iter traits and structs. Updated links to par_iter and par_iter_mut so they link directly to the methods (previously they linked to the trait page, not the specific method).